### PR TITLE
Adding Metric Presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added
 
 ### Changed
+- Default metrics are RLOC, MCC, MCC. If they do not exist in the current map, the first three metrics are chosen.
 
 ### Removed
 

--- a/visualization/app/codeCharta/core/settings/settingsService.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.js
@@ -19,6 +19,24 @@ class SettingsService {
     constructor(urlService, dataService, $rootScope) {
 
         /**
+         * Preset area metric name
+         * @type {String}
+         */
+        this.presetAreaMetric = "RLOC";
+
+        /**
+         * Preset color metric name
+         * @type {String}
+         */
+        this.presetColorMetric = "MCC";
+
+        /**
+         * Preset height metric name
+         * @type {String}
+         */
+        this.presetHeightMetric = "MCC";
+
+        /**
          * @type {UrlService}
          */
         this.urlService = urlService;
@@ -39,9 +57,9 @@ class SettingsService {
         this.settings = new Settings(
             dataService.data.currentmap,
             new Range(10,20,false),
-            dataService.data.metrics[0],
-            dataService.data.metrics[1],
-            dataService.data.metrics[2],
+            this.getMetricOrDefault(dataService.data.metrics, this.presetAreaMetric, dataService.data.metrics[0]),
+            this.getMetricOrDefault(dataService.data.metrics, this.presetHeightMetric, dataService.data.metrics[1]),
+            this.getMetricOrDefault(dataService.data.metrics, this.presetColorMetric, dataService.data.metrics[2]),
             true,
             false
         );
@@ -52,6 +70,22 @@ class SettingsService {
            ctx.onDataChanged(data);
         });
 
+    }
+
+    /**
+     * Checks if the given metricName is in the metricsArray. If it is in there, we return it, else we return the defaultValue.
+     * @param {String[]} metricsArray an array of metric names
+     * @param {String} metricName a metric name to look for
+     * @param {String} defaultValue a default name in case metricName was not found
+     */
+    getMetricOrDefault(metricsArray, metricName, defaultValue) {
+        var result = defaultValue;
+        metricsArray.forEach((metric) => {
+            if(metric === metricName){
+                result = metric;
+            }
+        });
+        return result;
     }
 
     /**
@@ -67,17 +101,17 @@ class SettingsService {
 
             if(data.metrics.indexOf(this.settings.areaMetric) === -1){
                 //area metric is not set or not in the new metrics and needs to be chosen
-                this.settings.areaMetric = data.metrics[0];
+                this.settings.areaMetric = this.getMetricOrDefault(data.metrics, this.presetAreaMetric, data.metrics[0]);
             }
 
             if(data.metrics.indexOf(this.settings.heightMetric) === -1){
                 //height metric is not set or not in the new metrics and needs to be chosen
-                this.settings.heightMetric = data.metrics[1];
+                this.settings.heightMetric = this.getMetricOrDefault(data.metrics, this.presetHeightMetric, data.metrics[1]);
             }
 
             if(data.metrics.indexOf(this.settings.colorMetric) === -1){
                 //color metric is not set or not in the new metrics and needs to be chosen
-                this.settings.colorMetric = data.metrics[2];
+                this.settings.colorMetric = this.getMetricOrDefault(data.metrics, this.presetColorMetric, data.metrics[2]);
             }
 
         }
@@ -119,7 +153,6 @@ class SettingsService {
         }
 
         //TODO map some special keys like neutralColorRange
-
         this.onSettingsChanged();
 
     }

--- a/visualization/app/codeCharta/core/settings/settingsService.spec.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.spec.js
@@ -16,6 +16,75 @@ describe("app.codeCharta.core.settings.settingsService", function() {
     }));
 
     /**
+     * @test {SettingsService#getMetricOrDefault}
+     */
+    it("should return defaultValue when metric is not in array", angular.mock.inject(function(settingsService, $rootScope){
+
+        var arr = ["a", "b", "c"];
+        var name = "lookingForThis";
+        var defaultValue = "default";
+
+        var result = settingsService.getMetricOrDefault(arr, name, defaultValue);
+
+        expect(result).to.equal(defaultValue);
+
+    }));
+
+    /**
+     * @test {SettingsService#getMetricOrDefault}
+     */
+    it("should return the searched value when metric is in array", angular.mock.inject(function(settingsService, $rootScope){
+
+        var arr = ["a", "b", "lookingForThis"];
+        var name = "lookingForThis";
+        var defaultValue = "default";
+
+        var result = settingsService.getMetricOrDefault(arr, name, defaultValue);
+
+        expect(result).to.equal(name);
+
+    }));
+
+    /**
+     * @test {SettingsService#constructor}
+     */
+    it("should select RLOC,MCC,MCC as default values if available", angular.mock.inject(function(settingsService, $rootScope){
+
+        $rootScope.$broadcast("data-changed", {currentmap: {"name":"some map"}, metrics: ["a","b","c", "RLOC", "MCC"]});
+
+        expect(settingsService.settings.areaMetric).to.equal("RLOC");
+        expect(settingsService.settings.heightMetric).to.equal("MCC");
+        expect(settingsService.settings.colorMetric).to.equal("MCC");
+
+    }));
+
+    /**
+     * @test {SettingsService#constructor}
+     */
+    it("should select metric RLOC, 1 and 2 when only RLOC is available", angular.mock.inject(function(settingsService, $rootScope){
+
+        $rootScope.$broadcast("data-changed", {currentmap: {"name":"some map"}, metrics: ["a","b","c", "RLOC", "!MCC"]});
+
+        expect(settingsService.settings.areaMetric).to.equal("RLOC");
+        expect(settingsService.settings.heightMetric).to.equal("b");
+        expect(settingsService.settings.colorMetric).to.equal("c");
+
+    }));
+
+    /**
+     * @test {SettingsService#constructor}
+     */
+    it("should select first three metrics when RLOC and MCC are not available", angular.mock.inject(function(settingsService, $rootScope){
+
+        $rootScope.$broadcast("data-changed", {currentmap: {"name":"some map"}, metrics: ["a","b","c", "!RLOC", "!MCC"]});
+
+        expect(settingsService.settings.areaMetric).to.equal("a");
+        expect(settingsService.settings.heightMetric).to.equal("b");
+        expect(settingsService.settings.colorMetric).to.equal("c");
+
+    }));
+
+    /**
      * @test {SettingsService#onSettingsChanged}
      * @test {SettingsService#constructor}
      */

--- a/visualization/app/codeCharta/sample.json
+++ b/visualization/app/codeCharta/sample.json
@@ -7,7 +7,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 100, "Functions": 10, "Average Complexity*": 1, "RLOC": 1000, "MCC": 12},
+          "attributes": {"RLOC": 100, "Functions": 10, "MCC": 1},
           "link": "http://www.google.de"
         },
         {
@@ -16,12 +16,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100, "RLOC": 1000, "MCC": 12},
+              "attributes": {"RLOC": 30, "Functions": 100, "MCC": 100},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10, "RLOC": 1120, "MCC": 122},
+              "attributes": {"RLOC": 70, "Functions": 1000, "MCC": 10},
               "children": []
             }
           ]
@@ -35,7 +35,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 90, "Functions": 11, "Average Complexity*": 1, "RLOC": 1000, "MCC": 12},
+          "attributes": {"RLOC": 90, "Functions": 11, "MCC": 1},
           "link": "http://www.google.de"
         },
         {
@@ -44,12 +44,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100, "RLOC": 10300, "MCC": 112},
+              "attributes": {"RLOC": 30, "Functions": 100, "MCC": 100},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10, "RLOC": 100, "MCC": 2},
+              "attributes": {"RLOC": 70, "Functions": 1000, "MCC": 10},
               "children": []
             }
           ]
@@ -62,7 +62,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 102, "MCC": 30},
+          "attributes": {"RLOC": 105, "Functions": 50, "MCC": 4},
           "link": "http://www.google.de"
         },
         {
@@ -71,12 +71,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 2000, "MCC": 42},
+              "attributes": {"RLOC": 40, "Functions": 80, "MCC": 90},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 800, "Average Complexity*": 9, "RLOC": 100, "MCC": 82},
+              "attributes": {"RLOC": 70, "Functions": 800, "MCC": 9},
               "children": []
             }
           ]
@@ -89,7 +89,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 100, "MCC": 12},
+          "attributes": {"RLOC": 105, "Functions": 50, "MCC": 4},
           "link": "http://www.google.de"
         },
         {
@@ -98,7 +98,7 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 10, "Average Complexity*": 90, "RLOC": 100, "MCC": 120},
+              "attributes": {"RLOC": 40, "Functions": 10, "MCC": 90},
               "children": []
             }
           ]
@@ -111,7 +111,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 100, "MCC": 123},
+          "attributes": {"RLOC": 105, "Functions": 50, "MCC": 4},
           "link": "http://www.google.de"
         },
         {
@@ -120,7 +120,7 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 100, "MCC": 129},
+              "attributes": {"RLOC": 40, "Functions": 80, "MCC": 90},
               "children": []
             }
           ]
@@ -131,12 +131,12 @@
           "children": [
             {
               "name": "small leaf 2",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 2000, "MCC": 12},
+              "attributes": {"RLOC": 40, "Functions": 80, "MCC": 90},
               "children": []
             },
             {
               "name": "big leaf2",
-              "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 3000, "MCC": 24},
+              "attributes": {"RLOC": 105, "Functions": 50, "MCC": 4},
               "link": "http://www.google.de"
             }
           ]

--- a/visualization/app/codeCharta/sample.json
+++ b/visualization/app/codeCharta/sample.json
@@ -7,7 +7,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 100, "Functions": 10, "Average Complexity*": 1},
+          "attributes": {"Statements": 100, "Functions": 10, "Average Complexity*": 1, "RLOC": 1000, "MCC": 12},
           "link": "http://www.google.de"
         },
         {
@@ -16,12 +16,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100},
+              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100, "RLOC": 1000, "MCC": 12},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10},
+              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10, "RLOC": 1120, "MCC": 122},
               "children": []
             }
           ]
@@ -35,7 +35,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 90, "Functions": 11, "Average Complexity*": 1},
+          "attributes": {"Statements": 90, "Functions": 11, "Average Complexity*": 1, "RLOC": 1000, "MCC": 12},
           "link": "http://www.google.de"
         },
         {
@@ -44,12 +44,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100},
+              "attributes": {"Statements": 30, "Functions": 100, "Average Complexity*": 100, "RLOC": 10300, "MCC": 112},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10},
+              "attributes": {"Statements": 70, "Functions": 1000, "Average Complexity*": 10, "RLOC": 100, "MCC": 2},
               "children": []
             }
           ]
@@ -62,7 +62,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4},
+          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 102, "MCC": 30},
           "link": "http://www.google.de"
         },
         {
@@ -71,12 +71,12 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90},
+              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 2000, "MCC": 42},
               "children": []
             },
             {
               "name": "other small leaf",
-              "attributes": {"Statements": 70, "Functions": 800, "Average Complexity*": 9},
+              "attributes": {"Statements": 70, "Functions": 800, "Average Complexity*": 9, "RLOC": 100, "MCC": 82},
               "children": []
             }
           ]
@@ -89,7 +89,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4},
+          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 100, "MCC": 12},
           "link": "http://www.google.de"
         },
         {
@@ -98,7 +98,7 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 10, "Average Complexity*": 90},
+              "attributes": {"Statements": 40, "Functions": 10, "Average Complexity*": 90, "RLOC": 100, "MCC": 120},
               "children": []
             }
           ]
@@ -111,7 +111,7 @@
       "children": [
         {
           "name": "big leaf",
-          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4},
+          "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 100, "MCC": 123},
           "link": "http://www.google.de"
         },
         {
@@ -120,7 +120,7 @@
           "children": [
             {
               "name": "small leaf",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90},
+              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 100, "MCC": 129},
               "children": []
             }
           ]
@@ -131,12 +131,12 @@
           "children": [
             {
               "name": "small leaf 2",
-              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90},
+              "attributes": {"Statements": 40, "Functions": 80, "Average Complexity*": 90, "RLOC": 2000, "MCC": 12},
               "children": []
             },
             {
               "name": "big leaf2",
-              "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4},
+              "attributes": {"Statements": 105, "Functions": 50, "Average Complexity*": 4, "RLOC": 3000, "MCC": 24},
               "link": "http://www.google.de"
             }
           ]


### PR DESCRIPTION
This pull request sets RLOC, MCC, MCC as default metrics. If these metrics do not exist in the loaded map then the first three found metrics are used. 
The sample map was adjusted in order to make use of this change.