### PR TITLE
Link to SonarQube Code URL in sonarimporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ## [Unreleased]
 ### Added
 - Adding Labels and UI
+- Support for links to source page of SonarQube in sonarimporter
 
 ### Changed
 

--- a/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinker.java
+++ b/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinker.java
@@ -1,0 +1,28 @@
+package de.maibornwolff.codecharta.importer.sonar;
+
+import de.maibornwolff.codecharta.importer.sonar.model.Component;
+
+import java.net.URL;
+
+public class SonarCodeURLLinker {
+
+    private final String baseCodeUrl;
+
+    public static final SonarCodeURLLinker NULL = new SonarCodeURLLinker() {
+        public String createUrlString(Component c) {
+            return "";
+        }
+    };
+
+    public SonarCodeURLLinker() {
+        baseCodeUrl = "";
+    }
+
+    public SonarCodeURLLinker(URL baseUrlFrom) {
+        baseCodeUrl = baseUrlFrom + "/code?id=";
+    }
+
+    public String createUrlString(Component component) {
+        return baseCodeUrl + component.getKey();
+    }
+}

--- a/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectAdapter.java
+++ b/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectAdapter.java
@@ -14,14 +14,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SonarComponentProjectAdapter extends Project {
+    private final SonarCodeURLLinker sonarCodeURLLinker;
 
-    public SonarComponentProjectAdapter(String name) {
+    public SonarComponentProjectAdapter(String name, SonarCodeURLLinker sonarCodeURLLinker) {
         super(name);
+        this.sonarCodeURLLinker = sonarCodeURLLinker;
         this.getNodes().add(new Node("root", NodeType.Folder));
     }
 
     public void addComponentAsNode(Component component) {
-        Node node = new Node(createNodeName(component), createNodeTypeFromQualifier(component.getQualifier()), createAttributes(component.getMeasures()));
+        Node node = new Node(createNodeName(component), createNodeTypeFromQualifier(component.getQualifier()), createAttributes(component.getMeasures()), createLink(component));
         NodeInserter.insertByPath(this, createParentPath(component), node);
     }
 
@@ -29,6 +31,10 @@ public class SonarComponentProjectAdapter extends Project {
         return measures.stream()
                 .filter(this::isMeasureConvertible)
                 .collect(Collectors.toMap(Measure::getMetric, this::convertMetricValue));
+    }
+
+    private String createLink(Component component) {
+        return sonarCodeURLLinker.createUrlString(component);
     }
 
     private Object convertMetricValue(Measure measure) {

--- a/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarImporter.java
+++ b/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarImporter.java
@@ -2,7 +2,6 @@ package de.maibornwolff.codecharta.importer.sonar;
 
 import com.google.common.collect.ImmutableList;
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMeasuresAPIDatasource;
-import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMetricsAPIDatasource;
 import de.maibornwolff.codecharta.importer.sonar.model.Qualifier;
 import de.maibornwolff.codecharta.model.Project;
 import io.reactivex.Flowable;
@@ -13,17 +12,19 @@ import java.util.List;
 public class SonarImporter {
 
     public static final List STANDARD_SONAR_METRICS = ImmutableList.of(
-            "complexity", "ncloc", "functions", "duplicated_lines", "classes", "blocker_violations", "generated_lines", "bugs", "commented_out_code_lines", "lines", "violations", "comment_lines", "duplicated_blocks");
+            "complexity", "ncloc", "functions", "duplicated_lines", "classes", "coverage", "generated_lines", "bugs", "commented_out_code_lines", "lines", "violations", "comment_lines", "duplicated_blocks");
 
     private SonarMeasuresAPIDatasource measuresDS;
+    private SonarCodeURLLinker sonarCodeURLLinker;
 
-    public SonarImporter(SonarMeasuresAPIDatasource measuresDS) {
+    public SonarImporter(SonarMeasuresAPIDatasource measuresDS, SonarCodeURLLinker sonarCodeURLLinker) {
+        this.sonarCodeURLLinker = sonarCodeURLLinker;
         this.measuresDS = measuresDS;
     }
 
     public Project getProjectFromMeasureAPI(String name, List<String> metrics) throws SonarImporterException {
         List<String> metricsList = getMetricList(metrics);
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter(name);
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter(name, sonarCodeURLLinker);
 
         int noPages = measuresDS.getNumberOfPages(metricsList);
 

--- a/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.java
+++ b/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.java
@@ -78,7 +78,8 @@ public class SonarImporterMain {
 
         String projectKey = callParameter.getFiles().get(1);
         SonarMeasuresAPIDatasource ds = new SonarMeasuresAPIDatasource(callParameter.getUser(), createBaseUrlFrom(callParameter), projectKey);
-        SonarImporter importer = new SonarImporter(ds);
+        SonarCodeURLLinker sonarCodeURLLinker = new SonarCodeURLLinker(createBaseUrlFrom(callParameter));
+        SonarImporter importer = new SonarImporter(ds, sonarCodeURLLinker);
         Project project = importer.getProjectFromMeasureAPI(projectKey, callParameter.getMetrics());
         ProjectSerializer.serializeProject(project, createWriterFrom(callParameter));
     }

--- a/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarResourceToProjectConverter.java
+++ b/analysis/import/SonarImporter/src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarResourceToProjectConverter.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Deprecated
 public class SonarResourceToProjectConverter {
 
     private final List<SonarResource> sonarResources;

--- a/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinkerTest.java
+++ b/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinkerTest.java
@@ -1,0 +1,27 @@
+package de.maibornwolff.codecharta.importer.sonar;
+
+import de.maibornwolff.codecharta.importer.sonar.model.Component;
+import de.maibornwolff.codecharta.importer.sonar.model.Qualifier;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class SonarCodeURLLinkerTest {
+    @Test
+    public void should_createUrlString() throws Exception {
+        // given
+        URL baseUrl = new URL("https://sonarcloud.io");
+        Component component = new Component("","com.adobe%3Aas3corelib%3Asrc%2Fcom%2Fadobe%2Fair%2Fcrypto%2FEncryptionKeyGenerator.as", "","", "",  Qualifier.FIL, Collections.emptyList());
+
+        // when
+        String urlString = new SonarCodeURLLinker(baseUrl).createUrlString(component);
+
+        // then
+        assertThat(urlString, is("https://sonarcloud.io/code?id=com.adobe%3Aas3corelib%3Asrc%2Fcom%2Fadobe%2Fair%2Fcrypto%2FEncryptionKeyGenerator.as"));
+    }
+
+}

--- a/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectAdapterTest.java
+++ b/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectAdapterTest.java
@@ -26,7 +26,7 @@ public class SonarComponentProjectAdapterTest {
         String language = "java";
         Qualifier qualifier = Qualifier.FIL;
         Component component = new Component(id, key, name, path, language, qualifier, ImmutableList.of(measure));
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);
@@ -54,7 +54,7 @@ public class SonarComponentProjectAdapterTest {
         String language = "java";
         Qualifier qualifier = Qualifier.FIL;
         Component component = new Component(id, key, name, path, language, qualifier, ImmutableList.of(measure));
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);
@@ -83,7 +83,7 @@ public class SonarComponentProjectAdapterTest {
         String language = "java";
         Qualifier qualifier = Qualifier.FIL;
         Component component = new Component(id, key, name, path, language, qualifier, ImmutableList.of(measure));
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);
@@ -105,7 +105,7 @@ public class SonarComponentProjectAdapterTest {
         String value = "bla";
         Measure measure = new Measure(metric, value);
         Component component = new Component("id", "key", "name", "path", "java", Qualifier.FIL, ImmutableList.of(measure));
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);
@@ -120,7 +120,7 @@ public class SonarComponentProjectAdapterTest {
     public void should_insert_a_file_node_from_uts_component() {
         // given
         Component component = new Component("id", "key", "name", "path", "java", Qualifier.UTS, ImmutableList.of());
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);
@@ -135,7 +135,7 @@ public class SonarComponentProjectAdapterTest {
     public void should_insert_a_folder_node_from_dir_component() {
         // given
         Component component = new Component("id", "key", "name", "path", "java", Qualifier.DIR, ImmutableList.of());
-        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project");
+        SonarComponentProjectAdapter project = new SonarComponentProjectAdapter("project", SonarCodeURLLinker.NULL);
 
         // when
         project.addComponentAsNode(component);

--- a/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarImporterTest.java
+++ b/analysis/import/SonarImporter/src/test/java/de/maibornwolff/codecharta/importer/sonar/SonarImporterTest.java
@@ -67,7 +67,7 @@ public class SonarImporterTest {
 
         when(measuresDS.getNumberOfPages(metrics)).thenReturn(1);
         when(measuresDS.getMeasures(metrics, 1)).thenReturn(measures);
-        sonar = new SonarImporter(measuresDS);
+        sonar = new SonarImporter(measuresDS, SonarCodeURLLinker.NULL);
 
         // when
         Project project = sonar.getProjectFromMeasureAPI(name, metrics);
@@ -87,7 +87,7 @@ public class SonarImporterTest {
 
         when(measuresDS.getNumberOfPages(metrics)).thenReturn(1);
         when(measuresDS.getMeasures(metrics, 1)).thenReturn(measures);
-        sonar = new SonarImporter(measuresDS);
+        sonar = new SonarImporter(measuresDS, SonarCodeURLLinker.NULL);
 
         //when
         Project project = sonar.getProjectFromMeasureAPI(name, metrics);
@@ -104,7 +104,7 @@ public class SonarImporterTest {
 
         when(measuresDS.getNumberOfPages(metrics)).thenReturn(1);
         when(measuresDS.getMeasures(metrics, 1)).thenReturn(measures);
-        sonar = new SonarImporter(measuresDS);
+        sonar = new SonarImporter(measuresDS, SonarCodeURLLinker.NULL);
 
         //when
         Project project = sonar.getProjectFromMeasureAPI(name, metrics);
@@ -117,7 +117,7 @@ public class SonarImporterTest {
     @Test
     public void shouldGetMetricsWhenMetricsGiven() {
         measuresDS = mock(SonarMeasuresAPIDatasource.class);
-        sonar = new SonarImporter(measuresDS);
+        sonar = new SonarImporter(measuresDS, SonarCodeURLLinker.NULL);
         assertThat(sonar.getMetricList(metrics), hasSize(3));
     }
 
@@ -126,7 +126,7 @@ public class SonarImporterTest {
         // given
         List<String> emptyMetrics = new ArrayList<>();
         measuresDS = mock(SonarMeasuresAPIDatasource.class);
-        sonar = new SonarImporter(measuresDS);
+        sonar = new SonarImporter(measuresDS, SonarCodeURLLinker.NULL);
 
         // when
         List<String> metricList = sonar.getMetricList(emptyMetrics);

--- a/analysis/model/src/main/java/de/maibornwolff/codecharta/model/Node.java
+++ b/analysis/model/src/main/java/de/maibornwolff/codecharta/model/Node.java
@@ -61,6 +61,10 @@ public class Node {
         this(name, type, attributes, "", new ArrayList<>());
     }
 
+    public Node(String name, NodeType type, Map<String, Object> attributes, String link) {
+        this(name, type, attributes, link, new ArrayList<>());
+    }
+
     public String getName() {
         return name;
     }


### PR DESCRIPTION
With this pull request it is possible to fill the link field in the cc.json when importing metrics from SonarQube. Later they can be displayed in the visualization.