### PR TITLE
fixing #18 and correcting variable usage (const, let, var)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed
 
 ### Fixed
+- changing display or color settings resets scaling #18
 
 ## [1.3.1] - 2017-07-05
 ### Added

--- a/visualization/app/codeCharta/codeMap/codeMapService.js
+++ b/visualization/app/codeCharta/codeMap/codeMapService.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import * as THREE from "three";
-import {SpriteText2D, textAlign} from "three-text2d";
 
 /**
  * Main service to manage the state of the rendered code map
@@ -77,14 +76,17 @@ class CodeMapService {
      * @listens {settings-changed}
      */
     applySettings(s) {
-        var area = s.areaMetric;
-        var height = s.heightMetric;
-        var color = s.colorMetric;
-        var map = s.map;
-        var range = s.neutralColorRange;
-        if (area && height && color && map && range) {
-            this.drawFromData(map, area, height, color, s.neutralColorRange, s.amountOfTopLabels);
+
+        //draw
+        if (s.areaMetric && s.heightMetric && s.colorMetric && s.map && s.neutralColorRange) {
+            this.drawFromData(s.map, s.areaMetric, s.heightMetric, s.colorMetric, s.neutralColorRange, s.amountOfTopLabels);
         }
+
+        //scale
+        if(s.scaling && s.scaling.x && s.scaling.y &&s.scaling.z) {
+            this.scaleTo(s.scaling.x, s.scaling.y, s.scaling.z);
+        }
+
     }
 
     /**
@@ -93,7 +95,7 @@ class CodeMapService {
      * @param {string} areaKey
      * @param {string} heightKey
      * @param {string} colorKey
-     * @param {ColorRange} colorConfig
+     * @param {Range} colorConfig
      * @param {number} amountOfTopLabels number of highest buildings with labels
      */
     drawFromData(map, areaKey, heightKey, colorKey, colorConfig, amountOfTopLabels) {
@@ -108,7 +110,7 @@ class CodeMapService {
      * @param {string} areaKey
      * @param {string} heightKey
      * @param {string} colorKey
-     * @param {ColorRange} colorConfig
+     * @param {Range} colorConfig
      * @param {number} amountOfTopLabels number of highest buildings with labels
      */
     drawMap(map, s, p, areaKey, heightKey, colorKey, colorConfig, amountOfTopLabels) {
@@ -169,7 +171,7 @@ class CodeMapService {
     /**
      * Colors the cubes depending on their node data and the given values.
      * @param {string} colorKey
-     * @param {ColorRange} neutralColorRange
+     * @param {Range} neutralColorRange
      */
     colorMap(colorKey, neutralColorRange) {
         this.root.traverse((o)=> {
@@ -194,7 +196,7 @@ class CodeMapService {
      * Colors the 'folders'
      * @param {object} o folder
      * @param {string} colorKey
-     * @param {ColorRange} neutralColorRange
+     * @param {Range} neutralColorRange
      */
     colorBase(o, colorKey, neutralColorRange) {
 
@@ -204,7 +206,7 @@ class CodeMapService {
             return;
         }
 
-        var val = base.node.attributes[colorKey];
+        const val = base.node.attributes[colorKey];
         if (val < neutralColorRange.from) {
             base.originalMaterial = neutralColorRange.flipped ? this.assetService.negative() : this.assetService.positive();
         } else if (val > neutralColorRange.to) {
@@ -358,22 +360,22 @@ class CodeMapService {
 
         if(node.attributes && node.attributes[heightKey]){
 
-            var sprite = this.makeText(node.name + ": " + node.attributes[heightKey], 30);
+            const sprite = this.makeText(node.name + ": " + node.attributes[heightKey], 30);
             sprite.position.set(x+w/2,y+60+h + sprite.heightValue/2,z+l/2);
             this.root.add(sprite);
 
             // Line
-            var material = new THREE.LineBasicMaterial({
+            const material = new THREE.LineBasicMaterial({
                 color: 0x0000ff
             });
 
-            var geometry = new THREE.Geometry();
+            const geometry = new THREE.Geometry();
             geometry.vertices.push(
                 new THREE.Vector3(x + w / 2, y + h, z + l / 2),
                 new THREE.Vector3(x + w / 2, y + h + 60, z + l / 2)
             );
 
-            var line = new THREE.Line(geometry, material);
+            const line = new THREE.Line(geometry, material);
             this.root.add(line);
 
         }
@@ -386,17 +388,16 @@ class CodeMapService {
      * @param {number} fontsize
      * @returns {THREE.Sprite}
      */
-    makeText(message, fontsize) {
-        var ctx, texture, sprite, spriteMaterial,
-            canvas = document.createElement("canvas");
-        ctx = canvas.getContext("2d");
+     makeText(message, fontsize) {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
         ctx.font = fontsize + "px Arial";
 
-        var margin = 10;
+        const margin = 10;
 
         // setting canvas width/height before ctx draw, else canvas is empty
-        var w = ctx.measureText(message).width;
-        var h = fontsize;
+        const w = ctx.measureText(message).width;
+        const h = fontsize;
         canvas.width = w + margin;
         canvas.height = h + margin; // fontsize * 1.5
 
@@ -413,12 +414,12 @@ class CodeMapService {
         ctx.textBaseline = "middle";
         ctx.fillText(message, canvas.width / 2, canvas.height / 2);
 
-        texture = new THREE.Texture(canvas);
+        const texture = new THREE.Texture(canvas);
         texture.minFilter = THREE.LinearFilter; // NearestFilter;
         texture.needsUpdate = true;
 
-        spriteMaterial = new THREE.SpriteMaterial({map : texture});
-        sprite = new THREE.Sprite(spriteMaterial);
+        const spriteMaterial = new THREE.SpriteMaterial({map : texture});
+        const sprite = new THREE.Sprite(spriteMaterial);
         sprite.scale.set(canvas.width,canvas.height,1);
         sprite.heightValue = canvas.height;
         return sprite;
@@ -428,8 +429,8 @@ class CodeMapService {
      * Add scene lighting
      */
     addLightsToScene() {
-        var ambilight = new THREE.AmbientLight(0x707070); // soft white light
-        var light1 = new THREE.DirectionalLight(0xe0e0e0, 1);
+        const ambilight = new THREE.AmbientLight(0x707070); // soft white light
+        const light1 = new THREE.DirectionalLight(0xe0e0e0, 1);
         light1.position.set(50, 10, 8).normalize();
         light1.castShadow = false;
         light1.shadow.camera.right = 5;
@@ -438,7 +439,7 @@ class CodeMapService {
         light1.shadow.camera.bottom = -5;
         light1.shadow.camera.near = 2;
         light1.shadow.camera.far = 100;
-        var light2 = new THREE.DirectionalLight(0xe0e0e0, 1);
+        const light2 = new THREE.DirectionalLight(0xe0e0e0, 1);
         light2.position.set(-50, 10, -8).normalize();
         light2.castShadow = false;
         light2.shadow.camera.right = 5;

--- a/visualization/app/codeCharta/codeMap/codeMapService.spec.js
+++ b/visualization/app/codeCharta/codeMap/codeMapService.spec.js
@@ -5,15 +5,15 @@ require("./codeMap.js");
  */
 describe("app.codeCharta.codeMap.codeMapService", function() {
 
-    var codeMapService, $scope, sandbox, mesh;
+    let codeMapService, $scope, sandbox, mesh;
 
     beforeEach(angular.mock.module("app.codeCharta.codeMap"));
 
     beforeEach(angular.mock.inject((_codeMapService_, _$rootScope_)=>{
         codeMapService = _codeMapService_;
         $scope = _$rootScope_;
-        var geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
-        var material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
+        const geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
+        const material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
         mesh = new THREE.Mesh( geometry, material );
         codeMapService.addRoot();
     }));
@@ -31,7 +31,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
      */
     it("drawMap should showLabels for the highest building", ()=>{
 
-         var data = {
+         const data = {
           "name": "root",
           "attributes": {},
           "children": [
@@ -59,11 +59,9 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
           ]
         };
 
-        var tmp = codeMapService.addNode;
-
-        var smallSpy = sinon.spy();
-        var otherSpy = sinon.spy();
-        var elseSpy = sinon.spy();
+        const smallSpy = sinon.spy();
+        const otherSpy = sinon.spy();
+        const elseSpy = sinon.spy();
 
         codeMapService.addNode = (node, heightKey, showLabel) => {
             if(node.name === "small leaf"){
@@ -205,21 +203,24 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
     /**
      * @test {CodeMapService#applySettings}
      */
-    it("applySettings should call drawFromData when all variables are set", ()=>{
+    it("applySettings should call drawFromData and scaleTo when all variables are set", ()=>{
 
         codeMapService.drawFromData = sandbox.spy();
+        codeMapService.scaleTo = sandbox.spy();
 
-        var s = {
+        const s = {
             areaMetric:1,
             heightMetric:1,
             colorMetric:1,
             map: {},
-            range: {}
+            range: {},
+            scale: {x:1,y:1,z:1}
         };
 
         codeMapService.applySettings(s);
 
         expect(codeMapService.drawFromData.calledOnce);
+        expect(codeMapService.scaleTo.calledOnce);
 
     });
 
@@ -245,7 +246,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
      * @test {CodeMapService#getTransformedMesh}
      */
     it("getTransformedMesh should create correct mesh", ()=>{
-        var mesh = codeMapService.getTransformedMesh(1,1,1,0,0,0,new THREE.MeshLambertMaterial({color: 0x69AE40}), "something");
+        const mesh = codeMapService.getTransformedMesh(1,1,1,0,0,0,new THREE.MeshLambertMaterial({color: 0x69AE40}), "something");
         expect(mesh.node).to.equal("something");
         expect(mesh.scale.x).to.equal(1);
     });
@@ -257,7 +258,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
 
         codeMapService.drawFromData = sandbox.spy();
 
-        var s = {
+        const s = {
             areaMetric:1,
             heightMetric:1,
             colorMetric:1,
@@ -412,7 +413,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
 
         codeMapService.drawFromData = sandbox.spy();
 
-        var min = {
+        const min = {
             areaMetric: "area",
             heightMetric: "height",
             colorMetric: "color",
@@ -433,7 +434,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
 
         codeMapService.drawFromData = sandbox.spy();
 
-        var min = {
+        const min = {
             areaMetric: "area",
             colorMetric: "color",
             map: {},
@@ -486,7 +487,7 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
 
         codeMapService.colorDelta(group);
 
-        var foundDelta = false;
+        let foundDelta = false;
 
         group.children.forEach((c)=>{
             if(c.isDelta && c.originalMaterial && c.selectedMaterial && c.hoveredMaterial){ // a set originalMaterial indicates a colored cube
@@ -502,8 +503,8 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
      * @test {CodeMapService#centerMap}
      */
     it("center map should translate root in xz plane at some point", ()=>{
-        var x = codeMapService.root.translateX = sandbox.spy();
-        var z = codeMapService.root.translateZ = sandbox.spy();
+        const x = codeMapService.root.translateX = sandbox.spy();
+        const z = codeMapService.root.translateZ = sandbox.spy();
         codeMapService.centerMap(0,0);
         expect(x.calledOnce);
         expect(z.calledOnce);

--- a/visualization/app/codeCharta/core/scenario/scenarioService.js
+++ b/visualization/app/codeCharta/core/scenario/scenarioService.js
@@ -2,6 +2,7 @@
 
 import {Scenario} from "./model/scenario.js";
 import {Settings} from "../settings/model/settings.js";
+import {Scale} from "../settings/model/scale.js";
 import {Range} from "../settings/model/range.js";
 
 /**
@@ -52,7 +53,7 @@ class ScenarioService {
      */
     getDefaultScenario() {
         let defaultRange = new Range(20,40,false);
-        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false, false,1);
+        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false, false,1, new Scale(1,1,1));
         return new Scenario("rloc/mcc/mcc(20,40)", defaultSettings);
     }
 

--- a/visualization/app/codeCharta/core/settings/model/scale.js
+++ b/visualization/app/codeCharta/core/settings/model/scale.js
@@ -1,0 +1,34 @@
+/**
+ * Defines the scalings in x, y and z dimension
+ */
+export class Scale {
+
+    /**
+     * @constructor
+     * @param {number} x x scaling
+     * @param {number} y y scaling
+     * @param {number} z z scaling
+     */
+    constructor(x, y, z) {
+
+        /**
+         * x scaling
+         * @type {number}
+         */
+        this.x = x;
+
+        /**
+         * y scaling
+         * @type {number}
+         */
+        this.y = y;
+
+        /**
+         * z scaling
+         * @type {number}
+         */
+        this.z = z;
+
+    }
+
+}

--- a/visualization/app/codeCharta/core/settings/model/settings.js
+++ b/visualization/app/codeCharta/core/settings/model/settings.js
@@ -13,8 +13,9 @@ export class Settings {
      * @param {boolean} deltas
      * @param {boolean} grid
      * @param {Number} amountOfTopLabels
+     * @param {Scale} scaling
      */
-    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, grid, amountOfTopLabels) {
+    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, grid, amountOfTopLabels, scaling) {
 
         /**
          * currently selected map
@@ -58,13 +59,23 @@ export class Settings {
          */
         this.grid = grid;
 
+        /**
+         * number of highest buildings with labels
+         * @type {Number}
+         */
         this.amountOfTopLabels = amountOfTopLabels;
+
+        /**
+         * scaling settings
+         * @type {Scale}
+         */
+        this.scaling = scaling;
 
     }
 
     /**
      * Imports the given settings values without replacing this object with the given one.
-     * @param settings given settings
+     * @param {Settings} settings given settings
      */
     importSettingValues(settings){
         this.map = settings.map;
@@ -75,6 +86,7 @@ export class Settings {
         this.deltas = settings.deltas;
         this.grid = settings.grid;
         this.amountOfTopLabels = settings.amountOfTopLabels;
+        this.scaling = settings.scaling;
     }
 
 }

--- a/visualization/app/codeCharta/core/settings/settingsService.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import {Settings} from "./model/settings";
+import {Scale} from "./model/scale";
 import {Range} from "./model/range";
 
 /**
@@ -44,7 +45,8 @@ class SettingsService {
             dataService.data.metrics[2],
             true,
             false,
-            1
+            1,
+            new Scale(1,1,1)
         );
 
         let ctx = this;
@@ -103,13 +105,13 @@ class SettingsService {
     updateSettingsFromUrl() {
 
         //for every property in settings...
-        for (var property in this.settings) {
+        for (const property in this.settings) {
 
             //...that is not inherited from object...
             if (this.settings.hasOwnProperty(property) && property !== "map") {
 
                 //...get the query param value for the property...
-                var val = this.urlService.getParam(property);
+                const val = this.urlService.getParam(property);
 
                 if (val && val.length > 0) {
 
@@ -139,7 +141,7 @@ class SettingsService {
      * @param {Settings} settings
      */
     correctSettings(settings){
-        var result = settings;
+        const result = settings;
         result.areaMetric = this.getMetricOrDefault(this.dataService.data.metrics, settings.areaMetric,this.dataService.data.metrics[0] );
         result.heightMetric = this.getMetricOrDefault(this.dataService.data.metrics, settings.heightMetric, this.dataService.data.metrics[1]);
         result.colorMetric = this.getMetricOrDefault(this.dataService.data.metrics, settings.colorMetric, this.dataService.data.metrics[2]);
@@ -153,7 +155,7 @@ class SettingsService {
           * @param {String} defaultValue a default name in case metricName was not found
           */
     getMetricOrDefault(metricsArray, metricName, defaultValue) {
-            var result = defaultValue;
+            let result = defaultValue;
             metricsArray.forEach((metric) => {
                     if(metric === metricName){
                             result = metric;

--- a/visualization/app/codeCharta/core/settings/settingsService.spec.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.spec.js
@@ -42,16 +42,17 @@ describe("app.codeCharta.core.settings.settingsService", function() {
         expect(settingsService.onSettingsChanged.calledOnce);
 
     }));
+
     /**
-          * @test {SettingsService#getMetricOrDefault}
-          */
-    it("should return defaultValue when metric is not in array", angular.mock.inject(function(settingsService, $rootScope){
+      * @test {SettingsService#getMetricOrDefault}
+      */
+    it("should return defaultValue when metric is not in array", angular.mock.inject(function(settingsService){
         
-        var arr = ["a", "b", "c"];
-        var name = "lookingForThis";
-        var defaultValue = "default";
+        const arr = ["a", "b", "c"];
+        const name = "lookingForThis";
+        const defaultValue = "default";
         
-        var result = settingsService.getMetricOrDefault(arr, name, defaultValue);
+        const result = settingsService.getMetricOrDefault(arr, name, defaultValue);
         
         expect(result).to.equal(defaultValue);
         
@@ -60,13 +61,13 @@ describe("app.codeCharta.core.settings.settingsService", function() {
     /**
      * @test {SettingsService#getMetricOrDefault}
      */
-    it("should return the searched value when metric is in array", angular.mock.inject(function(settingsService, $rootScope){
+    it("should return the searched value when metric is in array", angular.mock.inject(function(settingsService){
                 
-        var arr = ["a", "b", "lookingForThis"];
-        var name = "lookingForThis";
-        var defaultValue = "default";
+        const arr = ["a", "b", "lookingForThis"];
+        const name = "lookingForThis";
+        const defaultValue = "default";
                 
-        var result = settingsService.getMetricOrDefault(arr, name, defaultValue);
+        const result = settingsService.getMetricOrDefault(arr, name, defaultValue);
                 
         expect(result).to.equal(name);
                 
@@ -74,19 +75,19 @@ describe("app.codeCharta.core.settings.settingsService", function() {
     /**
      * @test {SettingsService#correctSettings}
      */
-    it("should replace metric with default if metric is not available", angular.mock.inject(function(settingsService, dataService, $rootScope){
+    it("should replace metric with default if metric is not available", angular.mock.inject(function(settingsService, dataService){
         dataService.data.metrics = ["a", "f", "g", "h"];
-        var settings = {areaMetric:"a", heightMetric:"b", colorMetric:"c"};
-        var expected = {areaMetric: "a", heightMetric:"f", colorMetric:"g"};
-        var result = settingsService.correctSettings(settings);
+        const settings = {areaMetric:"a", heightMetric:"b", colorMetric:"c"};
+        const expected = {areaMetric: "a", heightMetric:"f", colorMetric:"g"};
+        const result = settingsService.correctSettings(settings);
         expect(result).to.deep.equal(expected);
     }));
     /**
      * @test {SettingsService#correctSettings}
      */
-    it("should return input if metrics are available", angular.mock.inject(function(settingsService, $rootScope){
-        var settings = {areaMetric:"a", heightMetric:"b", colorMetric:"c"};
-        var result = settingsService.correctSettings(settings);
+    it("should return input if metrics are available", angular.mock.inject(function(settingsService){
+        const settings = {areaMetric:"a", heightMetric:"b", colorMetric:"c"};
+        const result = settingsService.correctSettings(settings);
         expect(result).to.deep.equal(settings);
     }));
 });

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
@@ -17,9 +17,9 @@
         </collapsible-element-directive>
 
         <collapsible-element-directive label="Scaling" icon-class="fa-cube">
-            <slider-directive step="0.001"  label="x" min="0.01" max="5" model="ctrl.scaling.x" change="ctrl.scalingChanged()"></slider-directive>
-            <slider-directive step="0.001"  label="y" min="0.01" max="5" model="ctrl.scaling.y" change="ctrl.scalingChanged()"></slider-directive>
-            <slider-directive step="0.001"  label="z" min="0.01" max="5" model="ctrl.scaling.z" change="ctrl.scalingChanged()"></slider-directive>
+            <slider-directive step="0.001"  label="x" min="0.01" max="5" model="ctrl.settings.scaling.x" change="ctrl.notify()"></slider-directive>
+            <slider-directive step="0.001"  label="y" min="0.01" max="5" model="ctrl.settings.scaling.y" change="ctrl.notify()"></slider-directive>
+            <slider-directive step="0.001"  label="z" min="0.01" max="5" model="ctrl.settings.scaling.z" change="ctrl.notify()"></slider-directive>
         </collapsible-element-directive>
 
         <collapsible-element-directive label="Metrics" icon-class="fa-line-chart">

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.js
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.js
@@ -2,14 +2,13 @@
 
 import "../../ui/ui.js";
 import "../../core/core.js";
-import "../../codeMap/codeMap.js";
 
 import {SettingsPanelDirective} from "./settingsPanelDirective.js";
 import {SettingsPanelController} from "./settingsPanelController.js";
 
 angular.module(
     "app.codeCharta.ui.settingsPanel",
-    ["app.codeCharta.ui", "app.codeCharta.core", "app.codeCharta.codeMap"]
+    ["app.codeCharta.ui", "app.codeCharta.core"]
 );
 
 angular.module("app.codeCharta.ui.settingsPanel").directive(

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.js
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.js
@@ -11,10 +11,9 @@ class SettingsPanelController {
      * @constructor
      * @param {SettingsService} settingsService
      * @param {DataService} dataService
-     * @param {CodeMapService} codeMapService
      * @param {Scope} $scope
      */
-    constructor(settingsService, dataService, codeMapService, $scope) {
+    constructor(settingsService, dataService, $scope) {
 
         /**
          *
@@ -34,23 +33,7 @@ class SettingsPanelController {
          */
         this.settingsService = settingsService;
 
-        /**
-         *
-         * @type {CodeMapService}
-         */
-        this.codeMapService = codeMapService;
-
         let ctx = this;
-
-        /**
-         *
-         * @type {{x: number, y: number, z: number}}
-         */
-        this.scaling = {
-            x:1,
-            y:1,
-            z:1
-        };
 
         $scope.$on("data-changed", (e,d)=>{ctx.onDataChanged(d);});
 
@@ -69,13 +52,6 @@ class SettingsPanelController {
      */
     notify(){
         this.settingsService.onSettingsChanged();
-    }
-
-    /**
-     * Tells the codeMapService that scaling changed
-     */
-    scalingChanged(){
-        this.codeMapService.scaleTo(this.scaling.x, this.scaling.y, this.scaling.z);
     }
 
     /**

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.spec.js
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.spec.js
@@ -5,16 +5,15 @@ require("./settingsPanel.js");
  */
 describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
 
-    var settingsPanelController, settingsService, dataService, codeMapService, scope;
+    let settingsPanelController, settingsService, dataService, scope;
 
     beforeEach(angular.mock.module("app.codeCharta.ui.settingsPanel"));
 
-    beforeEach(angular.mock.inject((_settingsService_, _dataService_, _codeMapService_, _$rootScope_, $controller)=>{
+    beforeEach(angular.mock.inject((_settingsService_, _dataService_, _$rootScope_, $controller)=>{
         settingsService = _settingsService_;
         dataService = _dataService_;
-        codeMapService = _codeMapService_;
         scope = _$rootScope_;
-        settingsPanelController = $controller("settingsPanelController", {$scope: scope, settingsService: settingsService, dataService: dataService, codeMapService: codeMapService});
+        settingsPanelController = $controller("settingsPanelController", {$scope: scope, settingsService: settingsService, dataService: dataService});
     }));
 
     /**
@@ -28,7 +27,7 @@ describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
         dataService.data.metrics[1] = "g";
         dataService.data.metrics[2] = "a";
 
-        settingsPanelController = $controller("settingsPanelController", {$scope: scope, settingsService: settingsService, dataService: dataService, codeMapService: codeMapService});
+        settingsPanelController = $controller("settingsPanelController", {$scope: scope, settingsService: settingsService, dataService: dataService});
 
         expect(settingsPanelController.metrics[0]).to.equal("a");
         expect(settingsPanelController.metrics[1]).to.equal("g");
@@ -40,8 +39,8 @@ describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
      * @test {SettingsPanelController#sortStringArrayAlphabetically}
      */
     it("should sort array alphabetically", ()=>{
-        var arr = ["b", "g", "a", "z", "y"];
-        var result = settingsPanelController.sortStringArrayAlphabetically(arr);
+        const arr = ["b", "g", "a", "z", "y"];
+        const result = settingsPanelController.sortStringArrayAlphabetically(arr);
         expect(result).to.eql(["a", "b", "g", "y", "z"]);
     });
 
@@ -56,10 +55,6 @@ describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
         expect(settingsPanelController.settings.map.name).to.equal("specialMap");
         expect(settingsPanelController.metrics[0]).to.equal("specialMetric");
         expect(settingsPanelController.settingsService).to.equal(settingsService);
-        expect(settingsPanelController.codeMapService).to.equal(codeMapService);
-        expect(settingsPanelController.scaling.x).to.equal(1);
-        expect(settingsPanelController.scaling.y).to.equal(1);
-        expect(settingsPanelController.scaling.z).to.equal(1);
 
     });
 
@@ -86,17 +81,6 @@ describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
         settingsService.onSettingsChanged = sinon.spy();
         settingsPanelController.notify();
         expect(settingsService.onSettingsChanged.calledOnce);
-
-    });
-
-    /**
-     * @test {SettingsPanelController#scalingChanged}
-     */
-    it("should call codeMapService#scaleTo when scalingChanged is called", ()=>{
-
-        codeMapService.scaleTo = sinon.spy();
-        settingsPanelController.scalingChanged();
-        expect(codeMapService.scaleTo.calledOnce);
 
     });
 


### PR DESCRIPTION
This suggested fix for #18 adds the scaling to the settings object instead of directly calling the scale method from the controller. 
The settings object survives changes like metric switches. This also means that scaling is a part of a Scenario (but can easily be removed from it by modifying scenarioService#applyScenario or the scenario class itself).