### PR TITLE
Refining URL Parameters and adding a button to generate them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added
 - add slider controls for color thresholds #19
 - Added additional structuring in SonarImporter for multi-module projects
+- button to generate current url parameters
+- camera position is now a setting (e.g. in scenarios or url parameters)
 
 ### Changed
+- better url parameter resolution (nested parameters are handled correctly)
 
 ### Removed
+- obsolete helper grid
 
 ### Fixed
 - changing display or color settings resets scaling #18

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -89,7 +89,24 @@ Use the "Invert Color" option, to declare a high value to be better then a low v
 
 # Further information
 
+## Guides
+
 [Integrating CodeCharte into a Jenkins 2 and Sonarqube pipeline](ci.md)
+
+## URL Parameters used by the web application
+
+The web application allows the usage of query parameters in the URL to set 
+certain settings. Query params are added by appending a `?` to the url, 
+followed by a key value pair `key=value`. Additional parameters can be 
+added by appending `&key2=value2`. E.g. `http://yourdomain.com/pathtocc/index.html?file=something.json&scaling.x=2&areaMetric=myMetric`
+
+* The `file` parameter is a special parameter which accepts a file location. The file must be reachable through XHR.
+* All other parameters are defined by the [Settings class](/visualization/app/codeCharta/core/settings/model/settings.js). 
+`areaMetric=myMetric` therefore sets the value of settings.areaMetric to `myMetric`. Nested properties like `settings.scale.x` can be 
+set by the query parameter `scaling.x=42`
+* The `map` parameter is disabled since it would be too much for the URL bar of your browser.
+* The URL in your browser gets automatically updated when you change settings through the UI. 
+It provides a simple way to customize your links with query parameters.
 
 ## Visualization
 

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -57,6 +57,22 @@ Once you have installed the project, you can use all grunt tasks described in th
 `npm run watch:app` watches the app directory and triggers a quick rebuild.
 `npm run watch:unit` watches the unit test directory and runs tests on change.
 
+## URL Parameters used by the web application
+[[Back To Top]](#jump-to-section)
+
+The web application allows the usage of query parameters in the URL to set 
+certain settings. Query params are added by appending a `?` to the url, 
+followed by a key value pair `key=value`. Additional parameters can be 
+added by appending `&key2=value2`. E.g. `http://yourdomain.com/pathtocc/index.html?file=something.json&scaling.x=2&areaMetric=myMetric`
+
+* The `file` parameter is a special parameter which accepts a file location. The file must be reachable through XHR.
+* All other parameters are defined by the [Settings class](/visualization/app/codeCharta/core/settings/model/settings.js). 
+`areaMetric=myMetric` therefore sets the value of settings.areaMetric to `myMetric`. Nested properties like `settings.scale.x` can be 
+set by the query parameter `scaling.x=42`
+* The `map` parameter is disabled since it would be too much for the URL bar of your browser.
+* The URL in your browser gets automatically updated when you change settings through the UI. 
+It provides a simple way to customize your links with query parameters.
+
 ## JSON structure
 [[Back To Top]](#jump-to-section)
 

--- a/visualization/app/app.js
+++ b/visualization/app/app.js
@@ -1,3 +1,13 @@
+"use strict";
+
 import "./codeCharta/codeCharta.js";
 
 angular.module("app", ["app.codeCharta"]);
+
+angular.module("app").config(["$locationProvider", function($locationProvider) {
+    $locationProvider.hashPrefix("");
+    $locationProvider.html5Mode({
+        enabled: true,
+        requireBase: false
+    });
+}]);

--- a/visualization/app/codeCharta/codeChartaController.js
+++ b/visualization/app/codeCharta/codeChartaController.js
@@ -59,6 +59,7 @@ class CodeChartaController {
                         dataService.setFileData(data).then(
                             () => {
                                 ctx.loadingFinished();
+                                settingsService.updateSettingsFromUrl();
                             },
                             (r) => {ctx.printErrors(r);}
                         );

--- a/visualization/app/codeCharta/codeMap/codeMapService.js
+++ b/visualization/app/codeCharta/codeMap/codeMapService.js
@@ -119,10 +119,6 @@ class CodeMapService {
 
         this.addRoot();
 
-        if (this.settingsService.settings.grid) {
-            this.addGrid(s, 50);
-        }
-
         let nodes = this.treemapService.createTreemapNodes(map, s, s, p, areaKey, heightKey);
 
         let sorted = nodes.sort((a,b)=>{return b.height - a.height;});
@@ -136,35 +132,6 @@ class CodeMapService {
         this.drawScene();
 
         this.colorMap(colorKey, colorConfig);
-
-    }
-
-    /**
-     * Adds a grid to the scene
-     * @param {number} mapSize
-     * @param {number} divisions
-     */
-    addGrid(mapSize, divisions) {
-
-        let xz = new THREE.GridHelper(mapSize, divisions);
-
-        let xy = new THREE.GridHelper(mapSize, divisions);
-        xy.translateY(mapSize);
-        xy.translateX(mapSize);
-        xy.rotation.z = Math.PI / 2;
-
-        let zy = new THREE.GridHelper(mapSize, divisions);
-        zy.translateY(mapSize);
-        zy.translateZ(mapSize);
-        zy.rotation.y = Math.PI / 2;
-        zy.rotation.x = Math.PI / 2;
-
-        let group = new THREE.Object3D();
-        group.add(xz);
-        group.add(xy);
-        group.add(zy);
-
-        this.root.add(group);
 
     }
 

--- a/visualization/app/codeCharta/codeMap/codeMapService.spec.js
+++ b/visualization/app/codeCharta/codeMap/codeMapService.spec.js
@@ -147,23 +147,20 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
     /**
      * @test {CodeMapService#drawMap}
      */
-    it("draw map should clear the scene, add a root, call the treemap service, call addNode for every node, center the map, draw the scene and color the map, grid is deactivated", ()=>{
+    it("draw map should clear the scene, add a root, call the treemap service, call addNode for every node, center the map, draw the scene and color the map", ()=>{
 
         codeMapService.clearScene = sandbox.spy();
         codeMapService.addRoot = sandbox.spy();
-        codeMapService.addGrid = sandbox.spy();
         codeMapService.treemapService.createTreemapNodes = sandbox.stub().returns([{},{},{}]);
         codeMapService.addNode = sandbox.spy();
         codeMapService.centerMap = sandbox.spy();
         codeMapService.drawScene = sandbox.spy();
         codeMapService.colorMap = sandbox.spy();
-        codeMapService.settingsService.settings.grid = false;
 
         codeMapService.drawMap("map", "s", "p", "areaKey", "heightKey", "colorKey", "colorConfig");
 
         expect(codeMapService.clearScene.calledOnce);
         expect(codeMapService.addRoot.calledOnce);
-        expect(!codeMapService.addGrid.called);
         expect(codeMapService.treemapService.createTreemapNodes.calledOnce);
         expect(codeMapService.addNode.calledThrice);
         expect(codeMapService.centerMap.calledOnce);
@@ -175,23 +172,20 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
     /**
      * @test {CodeMapService#drawMap}
      */
-    it("draw map should clear the scene, add a root, call the treemap service, call addNode for every node, center the map, draw the scene and color the map, grid is activated", ()=>{
+    it("draw map should clear the scene, add a root, call the treemap service, call addNode for every node, center the map, draw the scene and color the map", ()=>{
 
         codeMapService.clearScene = sandbox.spy();
         codeMapService.addRoot = sandbox.spy();
-        codeMapService.addGrid = sandbox.spy();
         codeMapService.treemapService.createTreemapNodes = sandbox.stub().returns([{},{},{}]);
         codeMapService.addNode = sandbox.spy();
         codeMapService.centerMap = sandbox.spy();
         codeMapService.drawScene = sandbox.spy();
         codeMapService.colorMap = sandbox.spy();
-        codeMapService.settingsService.settings.grid = true;
 
         codeMapService.drawMap("map", "s", "p", "areaKey", "heightKey", "colorKey", "colorConfig");
 
         expect(codeMapService.clearScene.calledOnce);
         expect(codeMapService.addRoot.calledOnce);
-        expect(codeMapService.addGrid.calledOnce);
         expect(codeMapService.treemapService.createTreemapNodes.calledOnce);
         expect(codeMapService.addNode.calledThrice);
         expect(codeMapService.centerMap.calledOnce);
@@ -444,19 +438,6 @@ describe("app.codeCharta.codeMap.codeMapService", function() {
         codeMapService.applySettings(min);
 
         expect(codeMapService.drawFromData.called).to.equal(false);
-
-    });
-
-    /**
-     * @test {CodeMapService#addGrid}
-     */
-    it("adding a helper grid to the scene should add a group of 3 Meshes to the scene", ()=>{
-
-        codeMapService.root.add = (mesh) => {
-            expect(mesh.children.length).to.equal(3);
-        };
-
-        codeMapService.addGrid(500, 10);
 
     });
 

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
@@ -26,8 +26,11 @@ class ThreeCameraService {
 
     /**
      * Inits the camera with a specific container width and height
-     * @param containerWidth initial width
-     * @param containerHeight initial height
+     * @param {number} containerWidth initial width
+     * @param {number} containerHeight initial height
+     * @param {number} x camera position component x
+     * @param {number} y camera position component y
+     * @param {number} z camera position component z
      */
     init(containerWidth, containerHeight, x, y, z) {
         var VIEW_ANGLE = 45;

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
@@ -23,16 +23,14 @@ class ThreeCameraService {
      * @param containerWidth initial width
      * @param containerHeight initial height
      */
-    init(containerWidth, containerHeight) {
-        var cameraHeight = 300;
-        var cameraDistance = 1000;
+    init(containerWidth, containerHeight, x, y, z) {
         var VIEW_ANGLE = 45;
         var ASPECT = containerWidth / containerHeight;
         var NEAR = 100;
         var FAR = 20000;
 
         this.camera = new THREE.PerspectiveCamera(VIEW_ANGLE, ASPECT, NEAR, FAR);
-        this.camera.position.set(0, cameraHeight, cameraDistance);
+        this.camera.position.set(x,y,z);
     }
 
 }

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.js
@@ -11,11 +11,17 @@ class ThreeCameraService {
      * @constructor
      * @external {PerspectiveCamera} https://threejs.org/docs/#Reference/Cameras/PerspectiveCamera
      */
-    constructor() {
+    constructor($rootScope) {
         /**
          * @type {PerspectiveCamera}
          */
         this.camera = {};
+
+        let ctx = this;
+
+        $rootScope.$on("settings-changed", (event,settings) => {
+            ctx.setPosition(settings.camera.x, settings.camera.y, settings.camera.z);
+        });
     }
 
     /**
@@ -30,6 +36,10 @@ class ThreeCameraService {
         var FAR = 20000;
 
         this.camera = new THREE.PerspectiveCamera(VIEW_ANGLE, ASPECT, NEAR, FAR);
+        this.setPosition(x, y, z);
+    }
+
+    setPosition(x, y, z) {
         this.camera.position.set(x,y,z);
     }
 

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.spec.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeCameraService.spec.js
@@ -30,7 +30,7 @@ describe("app.codeCharta.codeMap.threeViewer.threeCameraService", function() {
     /**
      * @test {ThreeCameraService#init}
      */
-    it("init should set the camera position", angular.mock.inject(function(threeCameraService){
+    it("init should set the camera position", angular.mock.inject(function(threeCameraService, settingsService){
 
         //action
         threeCameraService.init();
@@ -39,6 +39,8 @@ describe("app.codeCharta.codeMap.threeViewer.threeCameraService", function() {
         expect(threeCameraService.camera.position).to.not.equal(undefined);
 
     }));
+
+
 
     /**
      * @test {ThreeCameraService#init}

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeOrbitControlsService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeOrbitControlsService.js
@@ -19,11 +19,12 @@ class ThreeOrbitControlsService {
      * @constructor
      * @param {ThreeCameraService} threeCameraService
      */
-    constructor(threeCameraService) {
+    constructor(threeCameraService, $rootScope) {
         /** @type {ThreeCameraService} **/
         this.cameraService = threeCameraService;
         /** @type {ThreeOrbitControls} **/
         this.controls = {};
+        this.rootScope = $rootScope;
     }
 
     /**
@@ -33,6 +34,14 @@ class ThreeOrbitControlsService {
     init(domElement){
         var ResolvedOrbitControls = Toc.default(THREE);
         this.controls = new ResolvedOrbitControls(this.cameraService.camera, domElement);
+        let ctx= this;
+        this.controls.addEventListener( "change", function () {
+            ctx.onInput(ctx.cameraService.camera);
+        });
+    }
+
+    onInput(camera) {
+        this.rootScope.$broadcast("camera-changed", camera);
     }
 
 }

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeOrbitControlsService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeOrbitControlsService.js
@@ -18,12 +18,14 @@ class ThreeOrbitControlsService {
     /**
      * @constructor
      * @param {ThreeCameraService} threeCameraService
+     * @param {Scope} rootScope
      */
     constructor(threeCameraService, $rootScope) {
         /** @type {ThreeCameraService} **/
         this.cameraService = threeCameraService;
         /** @type {ThreeOrbitControls} **/
         this.controls = {};
+        /** @type {Scope} **/
         this.rootScope = $rootScope;
     }
 
@@ -32,7 +34,7 @@ class ThreeOrbitControlsService {
      * @param domElement Element with the canvas on it
      */
     init(domElement){
-        var ResolvedOrbitControls = Toc.default(THREE);
+        let ResolvedOrbitControls = Toc.default(THREE);
         this.controls = new ResolvedOrbitControls(this.cameraService.camera, domElement);
         let ctx= this;
         this.controls.addEventListener( "change", function () {
@@ -40,6 +42,10 @@ class ThreeOrbitControlsService {
         });
     }
 
+    /**
+     * Called when the orbit controls receive an user input
+     * @param {Camera} camera
+     */
     onInput(camera) {
         this.rootScope.$broadcast("camera-changed", camera);
     }

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeViewer.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeViewer.js
@@ -6,10 +6,11 @@ import {ThreeCameraService} from "./threeCameraService.js";
 import {ThreeOrbitControlsService} from "./threeOrbitControlsService.js";
 import {ThreeRendererService} from "./threeRendererService.js";
 import {ThreeUpdateCycleService} from "./threeUpdateCycleService.js";
+import "../../core/settings/settings.js";
 
 let id = "app.codeCharta.codeMap.threeViewer";
 
-angular.module(id, []);
+angular.module(id, ["app.codeCharta.core.settings"]);
 
 angular.module(id).service(
     "threeViewerService",

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.js
@@ -14,8 +14,9 @@ class ThreeViewerService {
      * @param {ThreeOrbitControlsService} threeOrbitControlsService
      * @param {ThreeRendererService} threeRendererService
      * @param {ThreeUpdateCycleService} threeUpdateCycleService
+     * @param {SettingsService} settingsService
      */
-    constructor(threeSceneService, threeCameraService, threeOrbitControlsService, threeRendererService, threeUpdateCycleService) {
+    constructor(threeSceneService, threeCameraService, threeOrbitControlsService, threeRendererService, threeUpdateCycleService, settingsService) {
         /**
          * @type {ThreeSceneService}
          */
@@ -40,6 +41,11 @@ class ThreeViewerService {
          * @type {ThreeUpdateCycleService}
          */
         this.UpdateCycleService = threeUpdateCycleService;
+
+        /**
+         * @type {SettingsService}
+         */
+        this.settingsService = settingsService;
     }
 
     /**
@@ -47,7 +53,7 @@ class ThreeViewerService {
      * @param {Object} element DOM Element which should be the canvas
      */
     init(element) {
-        this.CameraService.init(window.innerWidth, window.innerHeight);
+        this.CameraService.init(window.innerWidth, window.innerHeight, this.settingsService.settings.camera.x, this.settingsService.settings.camera.y, this.settingsService.settings.camera.z);
 
         this.CameraService.camera.lookAt(this.SceneService.scene.position);
         this.SceneService.scene.add(this.CameraService.camera);
@@ -64,6 +70,8 @@ class ThreeViewerService {
         // handles resizing the renderer when the window is resized
         window.addEventListener("resize", this.onWindowResize.bind(this), false);
     }
+
+    //TODO use camera position and target as camera settings for settings
 
     /**
      * Applies transformations on window resize.

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.js
@@ -71,8 +71,6 @@ class ThreeViewerService {
         window.addEventListener("resize", this.onWindowResize.bind(this), false);
     }
 
-    //TODO use camera position and target as camera settings for settings
-
     /**
      * Applies transformations on window resize.
      */

--- a/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.spec.js
+++ b/visualization/app/codeCharta/codeMap/threeViewer/threeViewerService.spec.js
@@ -5,7 +5,7 @@ require("./threeViewer.js");
  */
 describe("app.codeCharta.codeMap.threeViewer.threeViewerService", function() {
 
-    beforeEach(angular.mock.module("app.codeCharta.codeMap.threeViewer"));
+    beforeEach(angular.mock.module("app.codeCharta"));
 
     it("should retrieve the angular service instance", angular.mock.inject(function(threeViewerService){
         expect(threeViewerService).to.not.equal(undefined);

--- a/visualization/app/codeCharta/core/scenario/scenarioService.js
+++ b/visualization/app/codeCharta/core/scenario/scenarioService.js
@@ -53,7 +53,7 @@ class ScenarioService {
      */
     getDefaultScenario() {
         let defaultRange = new Range(20,40,false);
-        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false,1, new Scale(1,1,1));
+        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false,1, new Scale(1,1,1), new Scale(0,300,1000));
         return new Scenario("rloc/mcc/mcc(20,40)", defaultSettings);
     }
 

--- a/visualization/app/codeCharta/core/scenario/scenarioService.js
+++ b/visualization/app/codeCharta/core/scenario/scenarioService.js
@@ -53,7 +53,7 @@ class ScenarioService {
      */
     getDefaultScenario() {
         let defaultRange = new Range(20,40,false);
-        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false, false,1, new Scale(1,1,1));
+        let defaultSettings = new Settings(this.settingsService.settings.map, defaultRange, "rloc", "mcc", "mcc", false,1, new Scale(1,1,1));
         return new Scenario("rloc/mcc/mcc(20,40)", defaultSettings);
     }
 

--- a/visualization/app/codeCharta/core/settings/model/settings.js
+++ b/visualization/app/codeCharta/core/settings/model/settings.js
@@ -13,8 +13,9 @@ export class Settings {
      * @param {boolean} deltas
      * @param {Number} amountOfTopLabels
      * @param {Scale} scaling
+     * @param {Scale} camera
      */
-    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, amountOfTopLabels, scaling) {
+    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, amountOfTopLabels, scaling, camera) {
 
         /**
          * currently selected map
@@ -64,6 +65,12 @@ export class Settings {
          */
         this.scaling = scaling;
 
+        /**
+         * camera position
+         * @type {Scale}
+         */
+        this.camera = camera;
+
     }
 
     /**
@@ -79,6 +86,7 @@ export class Settings {
         this.deltas = settings.deltas;
         this.amountOfTopLabels = settings.amountOfTopLabels;
         this.scaling = settings.scaling;
+        this.camera = settings.camera;
     }
 
 }

--- a/visualization/app/codeCharta/core/settings/model/settings.js
+++ b/visualization/app/codeCharta/core/settings/model/settings.js
@@ -11,11 +11,10 @@ export class Settings {
      * @param {string} heightMetric
      * @param {string} colorMetric
      * @param {boolean} deltas
-     * @param {boolean} grid
      * @param {Number} amountOfTopLabels
      * @param {Scale} scaling
      */
-    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, grid, amountOfTopLabels, scaling) {
+    constructor(map, neutralColorRange, areaMetric, heightMetric, colorMetric, deltas, amountOfTopLabels, scaling) {
 
         /**
          * currently selected map
@@ -54,12 +53,6 @@ export class Settings {
         this.deltas = deltas;
 
         /**
-         * grid flag
-         * @type {boolean}
-         */
-        this.grid = grid;
-
-        /**
          * number of highest buildings with labels
          * @type {Number}
          */
@@ -84,7 +77,6 @@ export class Settings {
         this.heightMetric = settings.heightMetric;
         this.colorMetric = settings.colorMetric;
         this.deltas = settings.deltas;
-        this.grid = settings.grid;
         this.amountOfTopLabels = settings.amountOfTopLabels;
         this.scaling = settings.scaling;
     }

--- a/visualization/app/codeCharta/core/settings/settingsService.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.js
@@ -34,6 +34,12 @@ class SettingsService {
          */
         this.rootScope = $rootScope;
 
+        /**
+         * A flag which determines if the settings were already updated with url values
+         * @type {boolean} true if the url params were already updated
+         */
+        this.urlUpdateDone = false;
+
         let ctx = this;
 
        /**
@@ -46,12 +52,9 @@ class SettingsService {
             ctx.getMetricByIdOrLast(1, dataService.data.metrics),
             ctx.getMetricByIdOrLast(2, dataService.data.metrics),
             true,
-            false,
             1,
             new Scale(1,1,1)
         );
-
-
 
         $rootScope.$on("data-changed", (event,data) => {
            ctx.onDataChanged(data);
@@ -95,35 +98,91 @@ class SettingsService {
      */
     onSettingsChanged() {
         this.rootScope.$broadcast("settings-changed", this.settings);
-
+        //this should only be called once to prevent overwriting by following setting changes
+        if(this.urlUpdateDone) {
+            console.log(this.getQueryParamStringFromSettings());
+        }
     }
 
     /**
-     * updates the settings object according to url parameters.
+     * updates the settings object according to url parameters. url parameters are named like the accessors of the Settings object. E.g. scale.x or areaMetric
      * @emits {settings-changed} transitively on call
      */
     updateSettingsFromUrl() {
 
-        //for every property in settings...
-        for (const property in this.settings) {
+        let ctx = this;
 
-            //...that is not inherited from object...
-            if (this.settings.hasOwnProperty(property) && property !== "map") {
+        var iterateProperties = function(obj,prefix) {
+            for(var i in obj) {
+                if(obj.hasOwnProperty(i) && i !== "map" && i !== 0 && i){
 
-                //...get the query param value for the property...
-                const val = this.urlService.getParam(property);
+                    console.log(i);
 
-                if (val && val.length > 0) {
+                    if (typeof obj[i] === "string" || obj[i] instanceof String) {
+                        //do not iterate over strings
+                    } else {
+                        iterateProperties(obj[i], i + ".");
+                    }
 
-                    //if it exists, set ist the settings value
-                    this.settings[property] = val;
+                    const res = ctx.urlService.getParam(prefix+i);
+
+                    let val = parseFloat(res);
+
+                    if(isNaN(val)){
+                        val = res;
+                    }
+
+                    if (val) {
+                        console.log(val);
+                        obj[i] = val;
+                    }
+
                 }
             }
-        }
+        };
 
-        //TODO map some special keys like neutralColorRange
+        iterateProperties(this.settings, "");
+
+        this.urlUpdateDone = true;
 
         this.onSettingsChanged();
+
+    }
+
+    /**
+     * Updates query params to current settings
+     */
+    getQueryParamStringFromSettings() {
+
+        var result = "";
+        let ctx = this;
+
+        var iterateProperties = function(obj,prefix) {
+            for(var i in obj) {
+                if(obj.hasOwnProperty(i) && i !== "map" && i !== 0 && i){
+
+                    if (typeof obj[i] === "string" || obj[i] instanceof String) {
+                        //do not iterate over strings
+                    } else {
+                        iterateProperties(obj[i], i + ".");
+                    }
+
+                    if(typeof obj[i] === "object" || obj[i] instanceof Object) {
+                        //do not print objects in string
+                    } else {
+                        result += "&" + prefix+ i + "=" + obj[i];
+                        ctx.urlService.setUrlParam(prefix+i, obj[i]);
+                    }
+
+                }
+
+            }
+
+        };
+
+        iterateProperties(this.settings, "");
+
+        return result;
 
     }
 

--- a/visualization/app/codeCharta/core/settings/settingsService.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.js
@@ -100,7 +100,7 @@ class SettingsService {
         this.rootScope.$broadcast("settings-changed", this.settings);
         //this should only be called once to prevent overwriting by following setting changes
         if(this.urlUpdateDone) {
-            console.log(this.getQueryParamStringFromSettings());
+            this.getQueryParamStringFromSettings();
         }
     }
 
@@ -116,8 +116,6 @@ class SettingsService {
             for(var i in obj) {
                 if(obj.hasOwnProperty(i) && i !== "map" && i !== 0 && i){
 
-                    console.log(i);
-
                     if (typeof obj[i] === "string" || obj[i] instanceof String) {
                         //do not iterate over strings
                     } else {
@@ -132,8 +130,7 @@ class SettingsService {
                         val = res;
                     }
 
-                    if (val) {
-                        console.log(val);
+                    if (val === 0 || val) {
                         obj[i] = val;
                     }
 
@@ -154,7 +151,6 @@ class SettingsService {
      */
     getQueryParamStringFromSettings() {
 
-        var result = "";
         let ctx = this;
 
         var iterateProperties = function(obj,prefix) {
@@ -170,7 +166,6 @@ class SettingsService {
                     if(typeof obj[i] === "object" || obj[i] instanceof Object) {
                         //do not print objects in string
                     } else {
-                        result += "&" + prefix+ i + "=" + obj[i];
                         ctx.urlService.setUrlParam(prefix+i, obj[i]);
                     }
 
@@ -182,7 +177,6 @@ class SettingsService {
 
         iterateProperties(this.settings, "");
 
-        return result;
 
     }
 

--- a/visualization/app/codeCharta/core/settings/settingsService.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.js
@@ -53,7 +53,8 @@ class SettingsService {
             ctx.getMetricByIdOrLast(2, dataService.data.metrics),
             true,
             1,
-            new Scale(1,1,1)
+            new Scale(1,1,1),
+            new Scale(0,300,1000)
         );
 
         $rootScope.$on("data-changed", (event,data) => {

--- a/visualization/app/codeCharta/core/settings/settingsService.spec.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.spec.js
@@ -16,6 +16,17 @@ describe("app.codeCharta.core.settings.settingsService", function() {
     }));
 
     /**
+     * @test {SettingsService#getQueryParamString}
+     */
+    it("should retrieve the correct query param strings", angular.mock.inject(function(settingsService){
+        settingsService.settings.areaMetric = "areaStuff";
+        settingsService.settings.camera.x = "2";
+        expect(settingsService.getQueryParamString()).to.include("areaMetric=areaStuff");
+        expect(settingsService.getQueryParamString()).to.include("camera.x=2");
+        expect(settingsService.getQueryParamString()).to.include("neutralColorRange.from=10");
+    }));
+
+    /**
      * @test {SettingsService#updateSettingsFromUrl}
      */
     it("should update settings from url", angular.mock.inject(function(settingsService, $location){
@@ -61,6 +72,31 @@ describe("app.codeCharta.core.settings.settingsService", function() {
         expect(settingsService.onSettingsChanged.calledTwice);
 
     }));
+
+    /**
+     * @test {SettingsService#onCameraChanged}
+     * @test {SettingsService#constructor}
+     */
+    it("should react to camera-changed events", angular.mock.inject(function(settingsService, $rootScope){
+
+        settingsService.onCameraChanged = sinon.spy();
+
+        $rootScope.$broadcast("camera-changed", {});
+
+        expect(settingsService.onCameraChanged.calledOnce);
+
+    }));
+
+    /**
+     * @test {SettingsService#onCameraChanged}
+     */
+    it("onCameraChanged should update settings object but not call onSettingsChanged to ensure performance", angular.mock.inject(function(settingsService){
+        settingsService.onSettingsChanged = sinon.spy();
+        settingsService.onCameraChanged({position: {x:0, y:0, z: 42}});
+        expect(!settingsService.onSettingsChanged.called);
+        expect(settingsService.settings.camera.z).to.equal(42);
+    }));
+
 
     /**
      * @test {SettingsService#onSettingsChanged}

--- a/visualization/app/codeCharta/core/settings/settingsService.spec.js
+++ b/visualization/app/codeCharta/core/settings/settingsService.spec.js
@@ -16,6 +16,27 @@ describe("app.codeCharta.core.settings.settingsService", function() {
     }));
 
     /**
+     * @test {SettingsService#updateSettingsFromUrl}
+     */
+    it("should update settings from url", angular.mock.inject(function(settingsService, $location){
+        $location.url("http://something.de?scaling.x=42&areaMetric=myMetric&scaling.y=0.32");
+        settingsService.updateSettingsFromUrl();
+        expect(settingsService.settings.scaling.x).to.equal(42);
+        expect(settingsService.settings.scaling.y).to.equal(0.32);
+        expect(settingsService.settings.areaMetric).to.equal("myMetric");
+    }));
+
+    /**
+     * @test {SettingsService#updateSettingsFromUrl}
+     */
+    it("should not update settings.map from url", angular.mock.inject(function(settingsService, $location){
+        $location.url("http://something.de?map=aHugeMap");
+        settingsService.settings.map="correctMap";
+        settingsService.updateSettingsFromUrl();
+        expect(settingsService.settings.map).to.equal("correctMap");
+    }));
+
+    /**
      * @test {SettingsService#onSettingsChanged}
      * @test {SettingsService#constructor}
      */

--- a/visualization/app/codeCharta/core/url/urlService.js
+++ b/visualization/app/codeCharta/core/url/urlService.js
@@ -61,6 +61,15 @@ class UrlService {
     }
 
     /**
+     * Sets a query param key to a specified value
+     * @param key
+     * @param value
+     */
+    setUrlParam(key, value){
+        this.location.search(key, value);
+    }
+
+    /**
      * returns the files content specified in the 'file' url parameter
      * @returns {Promise} which returns the files content on resolution
      */

--- a/visualization/app/codeCharta/core/url/urlService.js
+++ b/visualization/app/codeCharta/core/url/urlService.js
@@ -12,13 +12,15 @@ class UrlService {
      * @param {$location} $location
      * @param {$http} $http
      */
-    constructor($location, $http) {
+    constructor($location, $http, $timeout) {
 
         /** @type {$location} */
         this.location = $location;
 
         /** @type {$http} */
         this.http = $http;
+
+        this.$timeout = $timeout;
     }
 
     /**
@@ -58,15 +60,6 @@ class UrlService {
      */
     getUrl() {
         return this.location.absUrl();
-    }
-
-    /**
-     * Sets a query param key to a specified value
-     * @param key
-     * @param value
-     */
-    setUrlParam(key, value){
-        this.location.search(key, value);
     }
 
     /**

--- a/visualization/app/codeCharta/core/url/urlService.js
+++ b/visualization/app/codeCharta/core/url/urlService.js
@@ -12,7 +12,7 @@ class UrlService {
      * @param {$location} $location
      * @param {$http} $http
      */
-    constructor($location, $http, $timeout) {
+    constructor($location, $http) {
 
         /** @type {$location} */
         this.location = $location;
@@ -20,7 +20,6 @@ class UrlService {
         /** @type {$http} */
         this.http = $http;
 
-        this.$timeout = $timeout;
     }
 
     /**

--- a/visualization/app/codeCharta/core/url/urlService.spec.js
+++ b/visualization/app/codeCharta/core/url/urlService.spec.js
@@ -23,6 +23,17 @@ describe("app.codeCharta.core.url.urlService", function() {
     });
 
     /**
+     * @test {UrlService#setUrlParamString}
+     */
+    it("url params should be placed correctly", ()=>{
+        $location.url("somePath.html?someParam=0");
+        urlService.setUrlParam("test", 0);
+        expect(urlService.getUrl()).to.equal("http://server/#!/somePath.html?someParam=0&test=0");
+        urlService.setUrlParam("someParam", 1);
+        expect(urlService.getUrl()).to.equal("http://server/#!/somePath.html?someParam=1&test=0");
+    });
+
+    /**
      * @test {UrlService#getParameterByName}
      */
     it("query parameter(s) should be recognized from static url and location mock", () => {

--- a/visualization/app/codeCharta/core/url/urlService.spec.js
+++ b/visualization/app/codeCharta/core/url/urlService.spec.js
@@ -23,17 +23,6 @@ describe("app.codeCharta.core.url.urlService", function() {
     });
 
     /**
-     * @test {UrlService#setUrlParamString}
-     */
-    it("url params should be placed correctly", ()=>{
-        $location.url("somePath.html?someParam=0");
-        urlService.setUrlParam("test", 0);
-        expect(urlService.getUrl()).to.equal("http://server/#!/somePath.html?someParam=0&test=0");
-        urlService.setUrlParam("someParam", 1);
-        expect(urlService.getUrl()).to.equal("http://server/#!/somePath.html?someParam=1&test=0");
-    });
-
-    /**
      * @test {UrlService#getParameterByName}
      */
     it("query parameter(s) should be recognized from static url and location mock", () => {

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.css
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.css
@@ -1,0 +1,5 @@
+.settings-panel-btn {
+    margin: 0 auto;
+    display: block;
+    width: 70%;
+}

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
@@ -33,4 +33,6 @@
 
     </collapsible-directive>
 
+    <a class="waves-effect waves-light btn settings-panel-btn" title="Show Url Parameters" ng-click="ctrl.showUrlParams()">Show Url Parameters</a>
+
 </div>

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.html
@@ -13,7 +13,6 @@
         <collapsible-element-directive label="Display" icon-class="fa-television">
             <number-field-directive label="Amount of labeled buildings" min="0" model="ctrl.settings.amountOfTopLabels" change="ctrl.notify()"></number-field-directive>
             <checkbox-directive model="ctrl.settings.deltas" label="Delta cubes" change="ctrl.notify()"></checkbox-directive>
-            <!--<checkbox-directive model="ctrl.settings.grid" label="Helper grid" change="ctrl.notify()"></checkbox-directive>-->
         </collapsible-element-directive>
 
         <collapsible-element-directive label="Scaling" icon-class="fa-cube">

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.js
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.js
@@ -39,6 +39,10 @@ class SettingsPanelController {
 
     }
 
+    showUrlParams() {
+        window.prompt("Copy to clipboard: Ctrl+C", this.settingsService.getQueryParamString());
+    }
+
     /**
      * called on data change.
      * @param {DataModel} data

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.spec.js
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanelController.spec.js
@@ -84,4 +84,17 @@ describe("app.codeCharta.ui.settingsPanel.settingsPanelController", function() {
 
     });
 
+    /**
+     * @test {SettingsPanelController#showUrlParams}
+     */
+    it("should prompt the user when showUrlParams() is called", ()=>{
+
+        const tmp = window.prompt;
+        window.prompt = sinon.spy();
+        settingsPanelController.showUrlParams();
+        expect(window.prompt.calledOnce);
+        window.prompt = tmp;
+
+    });
+
 });


### PR DESCRIPTION
The update on this branch refines the resolution of url parameters. Possible parameters are direct and nested properties of the Settings object. All possibilities are documented in the visualization/readme and the github pages.
Camera position is now a setting so specific views can be defined on project startup. 
To make query parameter definition easier, a button was added to generate the current query parameter string. 
Removed the old (defective and disabled) helper grid functionality.