### PR TITLE
Merging map nodes in delta maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 ### Added
+- the file origin of a node is displayed in the details now
 
 ### Changed
+- two selected delta maps now merge their nodes correctly. The map where 
+a node was missing get's a copy of this node with metrics=0. 
+File additions/deletions are therefore only visible when areaMetric is 
+unary and deltas are activated.
 
 ### Removed
 
 ### Fixed
+- delta display bug for heights
+- going back from delta view now correctly removes deltas from node data
 
 ## [1.5.2] - 2018-01-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ unary and deltas are activated.
 ### Fixed
 - delta display bug for heights
 - going back from delta view now correctly removes deltas from node data
+- Delta shown although not in delta mode #60
 
 ## [1.5.2] - 2018-01-04
 ### Added

--- a/visualization/app/codeCharta/codeMap/codeMapService.ts
+++ b/visualization/app/codeCharta/codeMap/codeMapService.ts
@@ -4,6 +4,7 @@ import {CodeMapMesh} from "./rendering/codeMapMesh";
 import {renderSettings} from "./rendering/renderSettings"
 import {LabelManager} from "./rendering/labelManager"
 import {SettingsServiceSubscriber, Settings, SettingsService} from "../core/settings/settings.service";
+import {node} from "./rendering/node";
 
 const mapSize = 500.0;
 
@@ -47,8 +48,7 @@ export class CodeMapService implements SettingsServiceSubscriber{
 
     updateMapGeometry(s) {
         let nodes = this.treeMapService.createTreemapNodes(s.map.root, mapSize, mapSize, s.margin, s.areaMetric, s.heightMetric);
-        let sorted = nodes.sort((a,b)=>{return b.height - a.height;});
-        console.log(sorted);
+        let sorted: node[] = nodes.sort((a,b)=>{return b.height - a.height;});
         let renderSettings: renderSettings  =  {
             heightKey : s.heightMetric,
             colorKey : s.colorMetric,

--- a/visualization/app/codeCharta/codeMap/codeMapService.ts
+++ b/visualization/app/codeCharta/codeMap/codeMapService.ts
@@ -48,7 +48,7 @@ export class CodeMapService implements SettingsServiceSubscriber{
     updateMapGeometry(s) {
         let nodes = this.treeMapService.createTreemapNodes(s.map.root, mapSize, mapSize, s.margin, s.areaMetric, s.heightMetric);
         let sorted = nodes.sort((a,b)=>{return b.height - a.height;});
-
+        console.log(sorted);
         let renderSettings: renderSettings  =  {
             heightKey : s.heightMetric,
             colorKey : s.colorMetric,

--- a/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
@@ -58,9 +58,15 @@ export class geometryGenerator {
             y : n.z0,
             z : n.y0,
             width : n.width,
-            height : Math.max(n.height, 5.0),
+            height : this.ensureMinHeightIfDeltaNotNegative(n.height, n.heightDelta),
             depth : n.length
         };
+    }
+
+    private ensureMinHeightIfDeltaNotNegative(x: number, d: number): number {
+        if(d >= 0) {
+            return Math.max(x, 5.0);
+        } else return x;
     }
 
     private addFloor(data : intermediateVertexData, n : node, idx : number, desc : codeMapGeometricDescription)
@@ -100,14 +106,14 @@ export class geometryGenerator {
         let measures : boxMeasures = this.mapNodeToLocalBox(n);
         let color : number = this.estimateColorForBuilding(n, settings.colorKey, settings.colorRange, settings.renderDeltas);
 
-        let deltaValue : number = 0.0;
+        let renderDelta: number = 0.0;
 
-        if (settings.renderDeltas && this.nodeHasSuitableDeltas(n, settings.heightKey))
+        if (settings.renderDeltas && this.nodeHasSuitableDeltas(n, settings.heightKey) && n.heightDelta)
         {
-            deltaValue = n.deltas[settings.heightKey];
+            renderDelta = n.heightDelta; //set the transformed render delta
 
-            if(deltaValue < 0) {
-                measures.height += Math.abs(deltaValue);
+            if(renderDelta < 0) {
+                measures.height += Math.abs(renderDelta);
             }
 
         }
@@ -124,7 +130,7 @@ export class geometryGenerator {
             )
         );
 
-        boxGeometryGenerationHelper.addBoxToVertexData(data, measures, color, idx, deltaValue);
+        boxGeometryGenerationHelper.addBoxToVertexData(data, measures, color, idx, renderDelta);
     }
 
     private estimateColorForBuilding(n : node, colorKey : string, range : colorRange, deltasEnabled : boolean) : number

--- a/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
@@ -24,6 +24,9 @@ export interface buildResult {
 }
 
 export class geometryGenerator {
+
+    private static MINIMAL_BUILDING_HEIGHT = 5.0;
+
     constructor() {};
 
     public build(nodes : node[], material : THREE.Material, settings : renderSettings) : buildResult
@@ -65,7 +68,7 @@ export class geometryGenerator {
 
     private ensureMinHeightIfDeltaNotNegative(x: number, d: number): number {
         if(d >= 0) {
-            return Math.max(x, 5.0);
+            return Math.max(x, geometryGenerator.MINIMAL_BUILDING_HEIGHT);
         } else return x;
     }
 

--- a/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
@@ -106,8 +106,10 @@ export class geometryGenerator {
         {
             deltaValue = n.deltas[settings.heightKey];
 
+            if(deltaValue < 0) {
+                measures.height += Math.abs(deltaValue);
+            }
 
-            measures.height += Math.abs(deltaValue);
         }
 
         desc.add(

--- a/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/geometryGenerator.ts
@@ -106,10 +106,8 @@ export class geometryGenerator {
         {
             deltaValue = n.deltas[settings.heightKey];
 
-            if (deltaValue > 0.0)
-            {
-                measures.height += deltaValue;
-            }
+
+            measures.height += Math.abs(deltaValue);
         }
 
         desc.add(

--- a/visualization/app/codeCharta/codeMap/rendering/labelManager.spec.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/labelManager.spec.ts
@@ -89,28 +89,6 @@ describe("LabelManager", () => {
         expect(labelManager.labels.length).toBe(0);
     });
 
-    it("addLabel should add delta to height when it exists", ()=>{
-
-        const DELTA = 2;
-
-        //no delta base value
-        sampleRenderSettings.renderDeltas = false;
-        labelManager.addLabel(sampleLeaf, sampleRenderSettings);
-        let positionWithoutDelta: Vector3 = labelManager.labels[0].sprite.position;
-
-        //delta position value
-        labelManager.labels = [];
-        sampleRenderSettings.renderDeltas = true;
-        sampleRenderSettings.heightKey = "deltaKey";
-        sampleLeaf.attributes = {"deltaKey": 10};
-        sampleLeaf.deltas = {"deltaKey": DELTA};
-        labelManager.addLabel(sampleLeaf, sampleRenderSettings);
-        let positionWithDelta: Vector3 = labelManager.labels[0].sprite.position;
-
-        expect(positionWithDelta.y - positionWithoutDelta.y).toBe(DELTA);
-
-    });
-
     it("addLabel should calculate correct height without delta", ()=>{
         labelManager.addLabel(sampleLeaf, sampleRenderSettings);
         let positionWithoutDelta: Vector3 = labelManager.labels[0].sprite.position;

--- a/visualization/app/codeCharta/codeMap/rendering/labelManager.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/labelManager.ts
@@ -28,12 +28,6 @@ export class LabelManager {
             let h : number = node.height;
             let l : number = node.length;
 
-            //if (settings.renderDeltas && node.heightDelta > 0.0)
-            //{
-            //    h += node.heightDelta;
-            //    console.log(h, node.heightDelta);
-            //}
-
             let label : internalLabel = this.makeText(node.name + ": " + node.attributes[settings.heightKey], 30);
             label.sprite.position.set(x+w/2,y+60+h + label.heightValue/2,z+l/2);
 

--- a/visualization/app/codeCharta/codeMap/rendering/labelManager.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/labelManager.ts
@@ -28,10 +28,11 @@ export class LabelManager {
             let h : number = node.height;
             let l : number = node.length;
 
-            if (settings.renderDeltas && node.deltas[settings.heightKey] > 0.0)
-            {
-                h += node.deltas[settings.heightKey];
-            }
+            //if (settings.renderDeltas && node.heightDelta > 0.0)
+            //{
+            //    h += node.heightDelta;
+            //    console.log(h, node.heightDelta);
+            //}
 
             let label : internalLabel = this.makeText(node.name + ": " + node.attributes[settings.heightKey], 30);
             label.sprite.position.set(x+w/2,y+60+h + label.heightValue/2,z+l/2);

--- a/visualization/app/codeCharta/codeMap/rendering/node.ts
+++ b/visualization/app/codeCharta/codeMap/rendering/node.ts
@@ -16,4 +16,5 @@ export interface node {
     readonly attributes : nodeAttributes;
     readonly children : node[];
     readonly isDelta : boolean;
+    readonly heightDelta : number;
 }

--- a/visualization/app/codeCharta/core/data/data.decorator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.decorator.service.ts
@@ -32,4 +32,16 @@ export class DataDecoratorService {
         }
     }
 
+    public decorateMapWithOriginAttribute(map: CodeMap) {
+
+        if(map && map.root) {
+
+            let root = d3.hierarchy<CodeMapNode>(map.root);
+            root.each((node)=>{
+                node.data.origin = map.fileName;
+            });
+
+        }
+    }
+
 }

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
@@ -4,6 +4,7 @@ import DoneCallback = jest.DoneCallback;
 import {CodeMap} from "./model/CodeMap";
 import {TEST_FILE_DATA, TEST_DELTA_MAP_A, TEST_DELTA_MAP_B} from "./data.mocks";
 import {DeltaCalculatorService} from "./data.deltaCalculator.service";
+import {DataDecoratorService} from "./data.decorator.service";
 
 /**
  * @test {DataService}
@@ -21,6 +22,26 @@ describe("app.codeCharta.core.data.dataService", function() {
     beforeEach(function() {
         a = TEST_DELTA_MAP_A;
         b = TEST_DELTA_MAP_B;
+    });
+
+    it("additionalLeaf from map b should exist in a after calling fillMapsWithNonExistingNodesFromOtherMap", ()=>{
+
+        let dds = new DataDecoratorService();
+        dds.decorateMapWithOriginAttribute(a);
+        dds.decorateMapWithOriginAttribute(b);
+
+        a.root.children[0].origin = "blas";
+
+        let result = deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
+        let da = result.leftMap;
+        let db = result.rightMap;
+
+        expect(da.root.children[2].name).toBe("additional leaf");
+        expect(db.root.children[1].name).toBe("additional leaf");
+
+        expect(da.root.children[2].attributes.rloc).toBe(10);
+        expect(db.root.children[1].attributes.rloc).toBe(10);
+
     });
 
     it("should result in expected delta maps", ()=>{

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
@@ -24,13 +24,13 @@ describe("app.codeCharta.core.data.dataService", function() {
         b = TEST_DELTA_MAP_B;
     });
 
-    it("additionalLeaf from map b should exist in a after calling fillMapsWithNonExistingNodesFromOtherMap", ()=>{
+    it("additionalLeaf from map b should exist in a after calling fillMapsWithNonExistingNodesFromOtherMap, metrics should be 0", ()=>{
 
         let dds = new DataDecoratorService();
         dds.decorateMapWithOriginAttribute(a);
         dds.decorateMapWithOriginAttribute(b);
 
-        a.root.children[0].origin = "blas";
+        a.root.children[0].origin = "hallo";
 
         let result = deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
         let da = result.leftMap;
@@ -39,7 +39,7 @@ describe("app.codeCharta.core.data.dataService", function() {
         expect(da.root.children[2].name).toBe("additional leaf");
         expect(db.root.children[1].name).toBe("additional leaf");
 
-        expect(da.root.children[2].attributes.rloc).toBe(10);
+        expect(da.root.children[2].attributes.rloc).toBe(0);
         expect(db.root.children[1].attributes.rloc).toBe(10);
 
     });

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -3,6 +3,7 @@
 import * as d3 from "d3";
 import {CodeMap, CodeMapNode} from "./model/CodeMap";
 import {HierarchyNode} from "d3-hierarchy";
+import * as deepcopy from "deepcopy";
 
 interface KVObject {
     [key: string]: number
@@ -14,13 +15,13 @@ interface KVObject {
 export class DeltaCalculatorService {
 
     /* @ngInject */
-    constructor(){
+    constructor() {
 
     }
 
     public decorateMapsWithDeltas(firstMap: CodeMap, secondMap: CodeMap) {
 
-        if(firstMap && secondMap && firstMap.root && secondMap.root) {
+        if (firstMap && secondMap && firstMap.root && secondMap.root) {
             let firstRoot = d3.hierarchy<CodeMapNode>(firstMap.root);
             let firstLeaves: HierarchyNode<CodeMapNode>[] = firstRoot.leaves();
             let secondRoot = d3.hierarchy(secondMap.root);
@@ -48,10 +49,124 @@ export class DeltaCalculatorService {
 
     }
 
-    calculateAttributeListDelta(first: KVObject, second: KVObject){
+    /**
+     * Unifies both maps and inserts unique nodes into the other map. The inserted nodes have all metrics set to zero.
+     * This will calculate deltas correctly between versions and add "empty" buildings to ensure all revisions have an
+     * equal building pool. These empty buildings should be viewed with the unary metric as area
+     * @param {CodeMap} leftMap
+     * @param {CodeMap} rightMap
+     * @returns {{leftMap: CodeMap; rightMap: CodeMap}}
+     */
+    public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap): { leftMap: CodeMap; rightMap: CodeMap; } {
+        if (leftMap && rightMap && leftMap.root && rightMap.root) {
+
+            let leftMapCopy: CodeMap = deepcopy.default(leftMap);
+            let rightMapCopy: CodeMap = deepcopy.default(rightMap);
+
+            //clean up maps
+            leftMapCopy = this.removeUpCrossOriginNodes(leftMapCopy);
+            rightMapCopy = this.removeUpCrossOriginNodes(rightMapCopy);
+
+            let leftRoot = d3.hierarchy<CodeMapNode>(leftMapCopy.root);
+            let rightRoot = d3.hierarchy<CodeMapNode>(rightMapCopy.root);
+
+            this.insertLeftIntoRightWithZeroMetrics(leftRoot, rightRoot);
+            this.insertLeftIntoRightWithZeroMetrics(rightRoot, leftRoot);
+            return {leftMap: leftMapCopy, rightMap: rightMapCopy};
+
+        } else {
+            return {leftMap: leftMap, rightMap: rightMap};
+        }
+    }
+
+    public removeUpCrossOriginNodes(map: CodeMap): CodeMap {
+        if (map && map.root) {
+
+            let mapCopy: CodeMap = deepcopy.default(map);
+
+            let mapRoot = d3.hierarchy<CodeMapNode>(mapCopy.root);
+
+            mapRoot.each((node)=>{
+                if(node.data.children) {
+                    node.data.children = node.data.children.filter(x => x.origin === mapCopy.fileName);
+                }
+            });
+
+            return mapCopy;
+
+        } else {
+            return map;
+        }
+    }
+
+    private insertLeftIntoRightWithZeroMetrics(left: HierarchyNode<CodeMapNode>, right: HierarchyNode<CodeMapNode>) {
+
+        // are these nodes mergable (same name and have children)?
+        if (left.data.name === right.data.name && left.children != undefined && right.children != undefined && left.children.length > 0 && right.children.length > 0) {
+
+            left.children.forEach((leftChild) => {
+
+                //Is the leftChild existant in the right node's children ?
+                let leftChildExistsInRight = false;
+                right.children.forEach((rightChild) => {
+                    if (leftChild.data.name === rightChild.data.name) {
+                        leftChildExistsInRight = true;
+                    }
+                });
+
+
+                //if left child does not exist in the right node's children, insert it as a new valueless node into rights children
+                if (!leftChildExistsInRight) {
+                    let copy = this.deepcopy(leftChild);
+                    right.data.children.push(copy.data);
+                } else {
+                    // if left child exists in right nodes children, skip, since we only look for direct children
+                    right.children.forEach((rightChildInner) => {
+                        left.children.forEach((leftChildInner) => {
+                            //step in with pre-filtering
+                            if (leftChildInner.data.name !== leftChild.data.name) {
+                                if (leftChildInner.data.name === rightChildInner.data.name && leftChildInner.children != undefined && rightChildInner.children != undefined && leftChildInner.children.length > 0 && rightChildInner.children.length > 0) {
+                                    this.insertLeftIntoRightWithZeroMetrics(leftChildInner, rightChildInner);
+                                }
+                            }
+                        });
+                    });
+                }
+
+            });
+
+        }
+    }
+
+    private deepcopy(nodes: HierarchyNode<CodeMapNode>): HierarchyNode<CodeMapNode> {
+
+        //deepcopy
+        let copy: HierarchyNode<CodeMapNode> = deepcopy.default(nodes.copy()); //Hm this seems to be doing the right thing. First shallow copy then a deep copy ?!
+
+        //make own attributes 0
+        //for (let property in copy.data.attributes) {
+        //    if (copy.data.attributes.hasOwnProperty(property)) {
+        //        //TODO copy.data.attributes[property] = 0;
+        //    }
+        //}
+//
+        ////make all ancestors attributes 0
+        //copy.each((node) => {
+        //    for (var property in node.data.attributes) {
+        //        if (node.data.attributes.hasOwnProperty(property)) {
+        //            //TODO node.data.attributes[property] = 0;
+        //        }
+        //    }
+        //});
+
+        return copy;
+
+    }
+
+    calculateAttributeListDelta(first: KVObject, second: KVObject) {
         let deltas = {};
         for (var key in second) {
-            if(key) {
+            if (key) {
                 let firstValue = first[key] ? first[key] : 0; //assume zero if no value in first
                 let secondValue = second[key];
                 let delta = secondValue - firstValue;

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -102,14 +102,7 @@ export class DeltaCalculatorService {
 
             left.children.forEach((leftChild) => {
 
-                //Is the leftChild existant in the right node's children ?
-                let leftChildExistsInRight = false;
-                right.children.forEach((rightChild) => {
-                    if (leftChild.data.name === rightChild.data.name) {
-                        leftChildExistsInRight = true;
-                    }
-                });
-
+                let leftChildExistsInRight = this.childExistsInHierarchy(right, leftChild);
 
                 //if left child does not exist in the right node's children, insert it as a new valueless node into rights children
                 if (!leftChildExistsInRight) {
@@ -132,6 +125,16 @@ export class DeltaCalculatorService {
             });
 
         }
+    }
+
+    private childExistsInHierarchy(hierarchy: HierarchyNode<CodeMapNode>, child: HierarchyNode<CodeMapNode>): boolean {
+        let tmp = false;
+        hierarchy.children.forEach((rightChild) => {
+            if (child.data.name === rightChild.data.name) {
+                tmp = true;
+            }
+        });
+        return tmp;
     }
 
     private deepcopy(nodes: HierarchyNode<CodeMapNode>): HierarchyNode<CodeMapNode> {

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -141,20 +141,20 @@ export class DeltaCalculatorService {
         let copy: HierarchyNode<CodeMapNode> = deepcopy.default(nodes.copy()); //Hm this seems to be doing the right thing. First shallow copy then a deep copy ?!
 
         //make own attributes 0
-        //for (let property in copy.data.attributes) {
-        //    if (copy.data.attributes.hasOwnProperty(property)) {
-        //        //TODO copy.data.attributes[property] = 0;
-        //    }
-        //}
-//
+        for (let property in copy.data.attributes) {
+            if (copy.data.attributes.hasOwnProperty(property)) {
+                copy.data.attributes[property] = 0;
+            }
+        }
+
         ////make all ancestors attributes 0
-        //copy.each((node) => {
-        //    for (var property in node.data.attributes) {
-        //        if (node.data.attributes.hasOwnProperty(property)) {
-        //            //TODO node.data.attributes[property] = 0;
-        //        }
-        //    }
-        //});
+        copy.each((node) => {
+            for (var property in node.data.attributes) {
+                if (node.data.attributes.hasOwnProperty(property)) {
+                    node.data.attributes[property] = 0;
+                }
+            }
+        });
 
         return copy;
 

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -115,7 +115,6 @@ export class DeltaCalculatorService {
                 if (!leftChildExistsInRight) {
                     let copy = this.deepcopy(leftChild);
                     right.data.children.push(copy.data);
-                    console.log("INSERT");
                 } else {
                     // if left child exists in right nodes children, skip, since we only look for direct children
                     right.children.forEach((rightChildInner) => {

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -76,7 +76,7 @@ export class DeltaCalculatorService {
         }
     }
 
-    public removeUpCrossOriginNodes(map: CodeMap): CodeMap {
+    public removeCrossOriginNodes(map: CodeMap): CodeMap {
         if (map && map.root) {
 
             let mapCopy: CodeMap = deepcopy.default(map);

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -68,6 +68,7 @@ export class DeltaCalculatorService {
 
             this.insertLeftIntoRightWithZeroMetrics(leftRoot, rightRoot);
             this.insertLeftIntoRightWithZeroMetrics(rightRoot, leftRoot);
+
             return {leftMap: leftMapCopy, rightMap: rightMapCopy};
 
         } else {
@@ -114,6 +115,7 @@ export class DeltaCalculatorService {
                 if (!leftChildExistsInRight) {
                     let copy = this.deepcopy(leftChild);
                     right.data.children.push(copy.data);
+                    console.log("INSERT");
                 } else {
                     // if left child exists in right nodes children, skip, since we only look for direct children
                     right.children.forEach((rightChildInner) => {

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -63,10 +63,6 @@ export class DeltaCalculatorService {
             let leftMapCopy: CodeMap = deepcopy.default(leftMap);
             let rightMapCopy: CodeMap = deepcopy.default(rightMap);
 
-            //clean up maps
-            leftMapCopy = this.removeUpCrossOriginNodes(leftMapCopy);
-            rightMapCopy = this.removeUpCrossOriginNodes(rightMapCopy);
-
             let leftRoot = d3.hierarchy<CodeMapNode>(leftMapCopy.root);
             let rightRoot = d3.hierarchy<CodeMapNode>(rightMapCopy.root);
 
@@ -85,10 +81,9 @@ export class DeltaCalculatorService {
             let mapCopy: CodeMap = deepcopy.default(map);
 
             let mapRoot = d3.hierarchy<CodeMapNode>(mapCopy.root);
-
             mapRoot.each((node)=>{
                 if(node.data.children) {
-                    node.data.children = node.data.children.filter(x => x.origin === mapCopy.fileName);
+                    node.data.children = node.data.children.filter(x => (x.origin === mapCopy.fileName));
                 }
             });
 

--- a/visualization/app/codeCharta/core/data/data.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.service.spec.ts
@@ -38,7 +38,7 @@ describe("app.codeCharta.core.data.dataService", function() {
     it("should find all metrics, even in child nodes", () => {
         let sut = dataService;
         sut.setMap(data, 0);
-        expect(sut.data.metrics.length).toBe(3);
+        expect(sut.data.metrics.length).toBe(4);
     });
 
     it("should retrieve instance", ()=>{

--- a/visualization/app/codeCharta/core/data/data.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.service.spec.ts
@@ -45,6 +45,30 @@ describe("app.codeCharta.core.data.dataService", function() {
         expect(dataService).not.toBe(undefined);
     });
 
+    it("resetting map should clear everything", ()=>{
+        dataService.setMap(data, 0);
+        dataService.setMap(data, 1);
+        dataService.resetMaps();
+        expect(dataService.data.renderMap).toBe(null);
+        expect(dataService.data.metrics).toEqual([]);
+    });
+
+    it("setting a map should set it as render map and add the origin attribute", ()=>{
+        dataService.setMap(data, 0);
+        expect(dataService.data.renderMap.root.origin).toBe(dataService.data.renderMap.fileName);
+    });
+
+    it("setting a comparison map should do nothing if map at index does not exist", ()=>{
+        dataService.setMap(data, 0);
+        dataService.setComparisonMap(1);
+        expect(dataService.data.renderMap.fileName).toBe(data.fileName);
+    });
+
+    it("setting a reference map should do nothing if map at index does not exist", ()=>{
+        dataService.setMap(data, 0);
+        dataService.setReferenceMap(1);
+        expect(dataService.data.renderMap.fileName).toBe(data.fileName);
+    });
 
 });
 

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -106,7 +106,15 @@ export class DataService {
             this._data.comparisonMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
+            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.comparisonMap);
+            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.referenceMap);
             this.deltaCalculatorService.decorateMapsWithDeltas(this._data.comparisonMap, this._data.referenceMap);
+
+            //TODO display node origin
+            //TODO make this toggleable since two huge different maps result in two even bigger maps (performance)
+            //let nodeMerge = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.comparisonMap, this._data.referenceMap);
+            //this._data.referenceMap = nodeMerge.rightMap;
+            //this._data.comparisonMap = nodeMerge.leftMap;
             this.notify();
         }
     }
@@ -121,7 +129,15 @@ export class DataService {
             this._data.referenceMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
+            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.comparisonMap);
+            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.referenceMap);
             this.deltaCalculatorService.decorateMapsWithDeltas(this._data.comparisonMap, this._data.referenceMap);
+
+            //TODO display node origin
+            //TODO make this toggleable since two huge different maps result in two even bigger maps (performance)
+            //let nodeMerge = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.comparisonMap, this._data.referenceMap);
+            //this._data.referenceMap = nodeMerge.rightMap;
+            //this._data.comparisonMap = nodeMerge.leftMap;
             this.notify();
         }
     }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -62,6 +62,7 @@ export class DataService {
      */
     public setMap(map: CodeMap, revision: number) {
         this._data.revisions[revision] = map;
+        this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.revisions[revision]);
         this.setComparisonMap(revision);
     }
 
@@ -102,19 +103,12 @@ export class DataService {
      */
     public setComparisonMap(index: number) {
         if (this._data.revisions[index] !== null) {
-            this.setMetrics(index);
+
             this._data.comparisonMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
-            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.comparisonMap);
-            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.referenceMap);
             this.deltaCalculatorService.decorateMapsWithDeltas(this._data.comparisonMap, this._data.referenceMap);
-
-            //TODO display node origin
-            //TODO make this toggleable since two huge different maps result in two even bigger maps (performance)
-            //let nodeMerge = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.comparisonMap, this._data.referenceMap);
-            //this._data.referenceMap = nodeMerge.rightMap;
-            //this._data.comparisonMap = nodeMerge.leftMap;
+            this.setMetrics(index);
             this.notify();
         }
     }
@@ -125,21 +119,13 @@ export class DataService {
      */
     public setReferenceMap(index: number) {
         if (this._data.revisions[index] !== null) {
-            this.setMetrics(index);
+
             this._data.referenceMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
-            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.comparisonMap);
-            this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.referenceMap);
             this.deltaCalculatorService.decorateMapsWithDeltas(this._data.comparisonMap, this._data.referenceMap);
-
-            //TODO display node origin
-            //TODO make this toggleable since two huge different maps result in two even bigger maps (performance)
-            //let nodeMerge = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.comparisonMap, this._data.referenceMap);
-            //this._data.referenceMap = nodeMerge.rightMap;
-            //this._data.comparisonMap = nodeMerge.leftMap;
+            this.setMetrics(index);
             this.notify();
         }
     }
-
 }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -6,6 +6,7 @@ import {IRootScopeService, IAngularEvent} from "angular";
 import {DeltaCalculatorService} from "./data.deltaCalculator.service";
 import {DataDecoratorService} from "./data.decorator.service";
 import {HierarchyNode} from "d3-hierarchy";
+import {SettingsService} from "../settings/settings.service";
 
 export interface DataModel {
 
@@ -26,6 +27,7 @@ export interface DataServiceSubscriber {
 export class DataService {
 
     private _data: DataModel;
+    private _lastReferenceIndex = 0;
 
     /* @ngInject */
     constructor(private $rootScope: IRootScopeService,
@@ -51,7 +53,7 @@ export class DataService {
         });
     }
 
-    private notify() {
+    public notify() {
         this.$rootScope.$broadcast("data-changed", this._data);
     }
 
@@ -63,7 +65,7 @@ export class DataService {
     public setMap(map: CodeMap, revision: number) {
         this._data.revisions[revision] = map;
         this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.revisions[revision]);
-        this.setComparisonMap(revision);
+        this.setReferenceMap(revision);
     }
 
     /**
@@ -98,12 +100,11 @@ export class DataService {
     }
 
     /**
-     * Selects and sets the first map to compare.
+     * Selects and sets the first map to compare.  this is the map which is substracted from the main map
      * @param {number} index the maps index in the revisions array
      */
     public setComparisonMap(index: number) {
         if (this._data.revisions[index] !== null) {
-
             this._data.comparisonMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
@@ -114,12 +115,12 @@ export class DataService {
     }
 
     /**
-     * Selects and sets the second map to compare.
+     * Selects and sets the second map to compare. this is the main visible map
      * @param {number} index the maps index in the revisions array
      */
-    public setReferenceMap(index: number) {
+    public setReferenceMap(index: number = this._lastReferenceIndex) {
         if (this._data.revisions[index] !== null) {
-
+            this._lastReferenceIndex = index;
             this._data.referenceMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.referenceMap);
@@ -128,4 +129,5 @@ export class DataService {
             this.notify();
         }
     }
+
 }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -130,4 +130,23 @@ export class DataService {
         }
     }
 
+    public applyNodeMerging(): CodeMap {
+        //TODO this is data manipulation which should be delegated to data service itself
+        let result = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(
+            this.deltaCalculatorService.removeUpCrossOriginNodes(this.data.referenceMap),
+            this.deltaCalculatorService.removeUpCrossOriginNodes(this.data.comparisonMap));
+
+        this.dataDecoratorService.decorateMapWithUnaryMetric(result.leftMap);
+
+        //recalculate deltas on maps
+        this.deltaCalculatorService.decorateMapsWithDeltas(result.leftMap, this.data.comparisonMap);
+
+        //The left map is the map to be rendered
+
+        //we should write back map changes to dataService, no need to call notify and make an infinite loop
+        this.data.referenceMap = result.leftMap;
+
+        return this.data.referenceMap
+    }
+
 }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -103,7 +103,7 @@ export class DataService {
      * Selects and sets the first map to compare.  this is the map which is substracted from the main map
      * @param {number} index the maps index in the revisions array
      */
-    public setComparisonMap(index: number) {
+    public setComparisonMap(index: number = this._lastReferenceIndex) { //this allows to reset delta values when switching back from delta view
         if (this._data.revisions[index] !== null) {
             this._data.comparisonMap = this._data.revisions[index];
             this.dataDecoratorService.decorateMapWithUnaryMetric(this._data.comparisonMap);

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -112,7 +112,7 @@ export class DataService {
      * @param {number} index the maps index in the revisions array
      */
     public setComparisonMap(index: number) { //this allows to reset delta values when switching back from delta view
-        if (this._data.revisions[index] !== null) {
+        if (this._data.revisions[index] != null) {
             this._lastComparisonMap = this._data.revisions[index];
             if (this._deltasEnabled) {
                 this.applyNodeMerging();
@@ -132,7 +132,7 @@ export class DataService {
      * @param {number} index the maps index in the revisions array
      */
     public setReferenceMap(index: number) {
-        if (this._data.revisions[index] !== null) {
+        if (this._data.revisions[index] != null) {
             this._lastReferenceIndex = index;
             this._data.renderMap = this._data.revisions[index];
             if (this._deltasEnabled) {
@@ -167,8 +167,8 @@ export class DataService {
 
     public applyNodeMerging() {
         let result = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(
-            this.deltaCalculatorService.removeUpCrossOriginNodes(this._data.renderMap),
-            this.deltaCalculatorService.removeUpCrossOriginNodes(this._lastComparisonMap));
+            this.deltaCalculatorService.removeCrossOriginNodes(this._data.renderMap),
+            this.deltaCalculatorService.removeCrossOriginNodes(this._lastComparisonMap));
 
         this.dataDecoratorService.decorateMapWithUnaryMetric(result.leftMap);
         this.dataDecoratorService.decorateMapWithUnaryMetric(result.rightMap);

--- a/visualization/app/codeCharta/core/data/model/CodeMap.ts
+++ b/visualization/app/codeCharta/core/data/model/CodeMap.ts
@@ -7,7 +7,8 @@ export interface CodeMapNode {
     deltas?: {
         [key: string]: number
     },
-    link?: string
+    link?: string,
+    origin?: string
 }
 
 export interface CodeMap {

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -94,16 +94,11 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
     }
 
     private onActivateDeltas() {
-        this._settings.map = this.dataService.applyNodeMerging();
+        this.dataService.onActivateDeltas();
     }
 
     private onDeactivateDeltas() {
-        this.deactivateNodeMerging();
-    }
-
-    private deactivateNodeMerging() {
-        this.dataService.setComparisonMap();
-        this.dataService.setReferenceMap();
+        this.dataService.onDeactivateDeltas();
     }
 
     /**
@@ -114,10 +109,10 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
      */
     public onDataChanged(data: DataModel) {
 
-        this._settings.map = data.referenceMap;
+        this._settings.map = data.referenceMap; // reference map is always the map which should be drawn
 
         if(this._settings.deltas){
-            this.onActivateDeltas();
+            //this.onActivateDeltas();
         }
 
         if (data.metrics.indexOf(this._settings.areaMetric) === -1) {

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -9,6 +9,7 @@ import {PerspectiveCamera} from "three";
 import {STATISTIC_OPS} from "../statistic/statistic.service";
 import {DeltaCalculatorService} from "../data/data.deltaCalculator.service";
 import * as d3 from "d3";
+import {DataDecoratorService} from "../data/data.decorator.service";
 
 export interface Settings {
 
@@ -40,7 +41,8 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
 
     /* ngInject */
     constructor(private urlService, private dataService: DataService, private $rootScope,
-                private threeOrbitControlsService: ThreeOrbitControlsService, private statisticMapService, private deltaCalculatorService: DeltaCalculatorService) {
+                private threeOrbitControlsService: ThreeOrbitControlsService, private statisticMapService, private deltaCalculatorService: DeltaCalculatorService,
+                private dataDecoratorService: DataDecoratorService) {
 
         let ctx = this;
 
@@ -101,8 +103,10 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
             this.deltaCalculatorService.removeUpCrossOriginNodes(this.dataService.data.referenceMap),
             this.deltaCalculatorService.removeUpCrossOriginNodes(this.dataService.data.comparisonMap));
 
+        this.dataDecoratorService.decorateMapWithUnaryMetric(result.leftMap);
+
         //recalculate deltas on maps
-        this.deltaCalculatorService.decorateMapsWithDeltas(result.leftMap, result.rightMap);
+        this.deltaCalculatorService.decorateMapsWithDeltas(result.leftMap, this.dataService.data.comparisonMap);
 
         //The left map is the map to be rendered
         this._settings.map = result.leftMap;

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -46,7 +46,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
 
         let ctx = this;
 
-        this._settings = this.getInitialSettings(dataService.data.referenceMap, dataService.data.metrics);
+        this._settings = this.getInitialSettings(dataService.data.renderMap, dataService.data.metrics);
 
         dataService.subscribe(this);
         threeOrbitControlsService.subscribe(this);
@@ -59,7 +59,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
         });
     }
 
-    private getInitialSettings(referenceMap: any, metrics: string[]): Settings {
+    private getInitialSettings(renderMap: any, metrics: string[]): Settings {
 
         let r: Range = {
             from: 10,
@@ -78,7 +78,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
         this._lastDeltaState = false;
 
         return {
-            map: referenceMap,
+            map: renderMap,
             neutralColorRange: r,
             areaMetric: this.getMetricByIdOrLast(0, metrics),
             heightMetric: this.getMetricByIdOrLast(1, metrics),
@@ -109,11 +109,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
      */
     public onDataChanged(data: DataModel) {
 
-        this._settings.map = data.referenceMap; // reference map is always the map which should be drawn
-
-        if(this._settings.deltas){
-            //this.onActivateDeltas();
-        }
+        this._settings.map = data.renderMap; // reference map is always the map which should be drawn
 
         if (data.metrics.indexOf(this._settings.areaMetric) === -1) {
             //area metric is not set or not in the new metrics and needs to be chosen

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -120,6 +120,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
     }
 
     private deactivateNodeMerging() {
+        this.dataService.setComparisonMap();
         this.dataService.setReferenceMap();
     }
 

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -94,25 +94,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
     }
 
     private onActivateDeltas() {
-        this.applyNodeMerging();
-    }
-
-    private applyNodeMerging() {
-        //TODO this is data manipulation which should be delegated to data service itself
-        let result = this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(
-            this.deltaCalculatorService.removeUpCrossOriginNodes(this.dataService.data.referenceMap),
-            this.deltaCalculatorService.removeUpCrossOriginNodes(this.dataService.data.comparisonMap));
-
-        this.dataDecoratorService.decorateMapWithUnaryMetric(result.leftMap);
-
-        //recalculate deltas on maps
-        this.deltaCalculatorService.decorateMapsWithDeltas(result.leftMap, this.dataService.data.comparisonMap);
-
-        //The left map is the map to be rendered
-        this._settings.map = result.leftMap;
-
-        //we should write back map changes to dataService, no need to call notify and make an infinite loop
-        this.dataService.data.referenceMap = this._settings.map;
+        this._settings.map = this.dataService.applyNodeMerging();
     }
 
     private onDeactivateDeltas() {
@@ -135,7 +117,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
         this._settings.map = data.referenceMap;
 
         if(this._settings.deltas){
-            this.applyNodeMerging();
+            this.onActivateDeltas();
         }
 
         if (data.metrics.indexOf(this._settings.areaMetric) === -1) {

--- a/visualization/app/codeCharta/core/statistic/statistic.service.spec.ts
+++ b/visualization/app/codeCharta/core/statistic/statistic.service.spec.ts
@@ -217,7 +217,7 @@ describe("app.codeCharta.core.statistic", function() {
     beforeEach(() =>{
         data = {} as DataModel;
         settings = {} as Settings;
-        data.referenceMap = file1;
+        data.renderMap = file1;
     });
 
     /**

--- a/visualization/app/codeCharta/core/statistic/statistic.service.ts
+++ b/visualization/app/codeCharta/core/statistic/statistic.service.ts
@@ -29,7 +29,7 @@ export class StatisticMapService {
     unifyMaps(data: DataModel, settings: Settings): CodeMap {
         let operation = settings.operation || STATISTIC_OPS.NOTHING;
         if(operation == STATISTIC_OPS.NOTHING){
-            return data.referenceMap;
+            return data.renderMap;
         }
         var maps: CodeMap[] = data.revisions;
         if(maps.length === 1){

--- a/visualization/app/codeCharta/core/statistic/statisticMapService.spec.js
+++ b/visualization/app/codeCharta/core/statistic/statisticMapService.spec.js
@@ -213,7 +213,7 @@ xdescribe("app.codeCharta.core.statistic", function() {
     beforeEach(angular.mock.module("app.codeCharta.core.statistic"));
     beforeEach(() =>{
         data = new DataModel();
-        data.referenceMap = file1;
+        data.renderMap = file1;
         settings = new Settings();
     });
 

--- a/visualization/app/codeCharta/core/treemap/treemap.service.ts
+++ b/visualization/app/codeCharta/core/treemap/treemap.service.ts
@@ -56,9 +56,7 @@ class TreeMapService {
             this.transformNode(node, heightKey, heightScale, 2);
         });
 
-        return nodes.filter(function (el: any) {
-            return el.value > 0 && el.width > 0 && el.height > 0 && el.length > 0;
-        }); //dont draw invisble nodes (for the current metrics)
+        return nodes;
     }
 
     /**

--- a/visualization/app/codeCharta/core/treemap/treemap.service.ts
+++ b/visualization/app/codeCharta/core/treemap/treemap.service.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 import {DataService} from "../data/data.service";
 import {CodeMap, CodeMapNode} from "../data/model/CodeMap";
 import {HierarchyNode} from "d3-hierarchy";
+import {node} from "../../codeMap/rendering/node";
 
 /**
  * This service transforms valid file data to a custom treemap. Our custom treemap has a 3rd axis added to the nodes.
@@ -71,7 +72,7 @@ class TreeMapService {
      * @param {number} heightScale scaling factor
      * @param {number} folderHeight height of folder
      */
-    transformNode(node, heightKey, heightScale, folderHeight) {
+    private transformNode(node, heightKey, heightScale, folderHeight) {
 
         node.width = Math.max(node.x1 - node.x0, 1);
         node.length = Math.max(node.y1 - node.y0, 1);
@@ -82,6 +83,9 @@ class TreeMapService {
         node.name = node.data.name;
         if (node.data.deltas) {
             node.deltas = node.data.deltas;
+            if(node.deltas[heightKey]) {
+                node.heightDelta = heightScale * node.data.deltas[heightKey];
+            }
         }
         node.link = node.data.link;
         node.origin = node.data.origin;

--- a/visualization/app/codeCharta/core/treemap/treemap.service.ts
+++ b/visualization/app/codeCharta/core/treemap/treemap.service.ts
@@ -86,6 +86,7 @@ class TreeMapService {
             node.deltas = node.data.deltas;
         }
         node.link = node.data.link;
+        node.origin = node.data.origin;
 
         node.data = {};
         delete node.data;

--- a/visualization/app/codeCharta/sample1.json
+++ b/visualization/app/codeCharta/sample1.json
@@ -5,6 +5,11 @@
     "attributes": {},
     "children": [
       {
+        "name": "sample1 only leaf",
+        "attributes": {"rloc": 400, "functions": 10, "mcc": 100},
+        "link": "http://www.google.de"
+      },
+      {
         "name": "big leaf",
         "attributes": {"rloc": 100, "functions": 10, "mcc": 1},
         "link": "http://www.google.de"

--- a/visualization/app/codeCharta/sample2.json
+++ b/visualization/app/codeCharta/sample2.json
@@ -26,6 +26,11 @@
             "name": "other small leaf",
             "id":3,
             "attributes": {"rloc": 70, "functions": 10, "mcc": 100}
+          },
+          {
+            "name": "sample2 leaf merged in",
+            "attributes": {"rloc": 600, "functions": 10, "mcc": 1},
+            "link": "http://www.google.de"
           }
         ]
       }

--- a/visualization/app/codeCharta/ui/detailPanel/detailPanel.html
+++ b/visualization/app/codeCharta/ui/detailPanel/detailPanel.html
@@ -31,6 +31,11 @@
                           <td ng-hide="!$ctrl.isHovered()">{{$ctrl.details.hovered.color}} <span ng-hide="!$ctrl.details.hovered.colorDelta">(&Delta;{{$ctrl.details.hovered.colorDelta}})</span></td>
                           <td ng-hide="!$ctrl.isSelected()">{{$ctrl.details.selected.color}} <span ng-hide="!$ctrl.details.selected.colorDelta">(&Delta;{{$ctrl.details.selected.colorDelta}})</span></td>
                       </tr>
+                      <tr>
+                          <td>Origin</td>
+                          <td ng-hide="!$ctrl.isHovered()">{{$ctrl.details.hovered.origin}}</td>
+                          <td ng-hide="!$ctrl.isSelected()">{{$ctrl.details.selected.origin}}</td>
+                      </tr>
                   </tbody>
               </table>
 

--- a/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
@@ -19,7 +19,8 @@ interface SpecificDetails {
     heightDelta: number | null,
     areaDelta: number | null,
     colorDelta: number | null,
-    link: string | null
+    link: string | null,
+    origin: string | null
 }
 
 interface Details {
@@ -52,7 +53,8 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
                 heightDelta: null,
                 areaDelta: null,
                 colorDelta: null,
-                link: null
+                link: null,
+                origin: null
             },
             selected: {
                 name: null,
@@ -62,7 +64,8 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
                 heightDelta: null,
                 areaDelta: null,
                 colorDelta: null,
-                link: null
+                link: null,
+                origin: null
             }
         };
 
@@ -152,6 +155,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
             this.details.hovered.areaDelta = hovered.deltas ? hovered.deltas[this.details.common.areaAttributeName] : null;
             this.details.hovered.colorDelta = hovered.deltas ? hovered.deltas[this.details.common.colorAttributeName] : null;
             this.details.hovered.link = hovered.link;
+            this.details.hovered.origin = hovered.origin;
         }.bind(this));
     }
 
@@ -169,6 +173,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
             this.details.selected.areaDelta = selected.deltas ? selected.deltas[this.details.common.areaAttributeName] : null;
             this.details.selected.colorDelta = selected.deltas ? selected.deltas[this.details.common.colorAttributeName] : null;
             this.details.selected.link = selected.link;
+            this.details.selected.origin = selected.origin;
         }.bind(this));
     }
 
@@ -185,6 +190,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
             this.details.hovered.areaDelta = null;
             this.details.hovered.colorDelta = null;
             this.details.hovered.link = null;
+            this.details.hovered.origin = null;
         }.bind(this));
     }
 
@@ -201,6 +207,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
             this.details.selected.areaDelta = null;
             this.details.selected.colorDelta = null;
             this.details.selected.link = null;
+            this.details.selected.origin = null;
         }.bind(this));
     }
 

--- a/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
@@ -148,12 +148,16 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
     setHoveredDetails(hovered) {
         this.$timeout(function () {
             this.details.hovered.name = hovered.name;
-            this.details.hovered.area = hovered.attributes ? hovered.attributes[this.details.common.areaAttributeName] : null;
-            this.details.hovered.height = hovered.attributes ? hovered.attributes[this.details.common.heightAttributeName] : null;
-            this.details.hovered.color = hovered.attributes ? hovered.attributes[this.details.common.colorAttributeName] : null;
-            this.details.hovered.heightDelta = hovered.deltas && hovered.deltas.length ? hovered.deltas[this.details.common.heightAttributeName] : null;
-            this.details.hovered.areaDelta = hovered.deltas ? hovered.deltas[this.details.common.areaAttributeName] : null;
-            this.details.hovered.colorDelta = hovered.deltas ? hovered.deltas[this.details.common.colorAttributeName] : null;
+            if(hovered.deltas != undefined){
+                this.details.hovered.heightDelta = hovered.deltas ? hovered.deltas[this.details.common.heightAttributeName] : null;
+                this.details.hovered.areaDelta = hovered.deltas ? hovered.deltas[this.details.common.areaAttributeName] : null;
+                this.details.hovered.colorDelta = hovered.deltas ? hovered.deltas[this.details.common.colorAttributeName] : null;
+            }
+            if(hovered.attributes != undefined) {
+                this.details.hovered.area = hovered.attributes ? hovered.attributes[this.details.common.areaAttributeName] : null;
+                this.details.hovered.height = hovered.attributes ? hovered.attributes[this.details.common.heightAttributeName] : null;
+                this.details.hovered.color = hovered.attributes ? hovered.attributes[this.details.common.colorAttributeName] : null;
+            }
             this.details.hovered.link = hovered.link;
             this.details.hovered.origin = hovered.origin;
         }.bind(this));
@@ -166,12 +170,16 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
     setSelectedDetails(selected) {
         this.$timeout(function () {
             this.details.selected.name = selected.name;
-            this.details.selected.area = selected.attributes ? selected.attributes[this.details.common.areaAttributeName] : null;
-            this.details.selected.height = selected.attributes ? selected.attributes[this.details.common.heightAttributeName] : null;
-            this.details.selected.color = selected.attributes ? selected.attributes[this.details.common.colorAttributeName] : null;
-            this.details.selected.heightDelta = selected.deltas ? selected.deltas[this.details.common.heightAttributeName] : null;
-            this.details.selected.areaDelta = selected.deltas ? selected.deltas[this.details.common.areaAttributeName] : null;
-            this.details.selected.colorDelta = selected.deltas ? selected.deltas[this.details.common.colorAttributeName] : null;
+            if(selected.attributes != undefined) {
+                this.details.selected.area = selected.attributes ? selected.attributes[this.details.common.areaAttributeName] : null;
+                this.details.selected.height = selected.attributes ? selected.attributes[this.details.common.heightAttributeName] : null;
+                this.details.selected.color = selected.attributes ? selected.attributes[this.details.common.colorAttributeName] : null;
+            }
+            if(selected.deltas != undefined) {
+                this.details.selected.heightDelta = selected.deltas ? selected.deltas[this.details.common.heightAttributeName] : null;
+                this.details.selected.areaDelta = selected.deltas ? selected.deltas[this.details.common.areaAttributeName] : null;
+                this.details.selected.colorDelta = selected.deltas ? selected.deltas[this.details.common.colorAttributeName] : null;
+            }
             this.details.selected.link = selected.link;
             this.details.selected.origin = selected.origin;
         }.bind(this));

--- a/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/detailPanel/detailPanelComponent.ts
@@ -148,7 +148,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
     setHoveredDetails(hovered) {
         this.$timeout(function () {
             this.details.hovered.name = hovered.name;
-            if(hovered.deltas != undefined){
+            if(hovered.deltas != undefined && this.settings.deltas){
                 this.details.hovered.heightDelta = hovered.deltas ? hovered.deltas[this.details.common.heightAttributeName] : null;
                 this.details.hovered.areaDelta = hovered.deltas ? hovered.deltas[this.details.common.areaAttributeName] : null;
                 this.details.hovered.colorDelta = hovered.deltas ? hovered.deltas[this.details.common.colorAttributeName] : null;
@@ -175,7 +175,7 @@ export class DetailPanelController implements SettingsServiceSubscriber, CodeMap
                 this.details.selected.height = selected.attributes ? selected.attributes[this.details.common.heightAttributeName] : null;
                 this.details.selected.color = selected.attributes ? selected.attributes[this.details.common.colorAttributeName] : null;
             }
-            if(selected.deltas != undefined) {
+            if(selected.deltas != undefined && this.settings.deltas) {
                 this.details.selected.heightDelta = selected.deltas ? selected.deltas[this.details.common.heightAttributeName] : null;
                 this.details.selected.areaDelta = selected.deltas ? selected.deltas[this.details.common.areaAttributeName] : null;
                 this.details.selected.colorDelta = selected.deltas ? selected.deltas[this.details.common.colorAttributeName] : null;

--- a/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.html
+++ b/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.html
@@ -17,7 +17,7 @@
     <br><br>
 
     <span ng-if="$ctrl.settingsService.settings.deltas">
-        Current Comparison Map: {{$ctrl.dataService.data.comparisonMap.fileName}}<br/>
+        Current Comparison Map: {{$ctrl.dataService.getComparisonMapName()}}<br/>
         Select Comparison Map:
         <span ng-repeat="(key, value) in $ctrl.revisions">
             <a href="#" ng-click="$ctrl.loadComparisonMap(key)">{{value.fileName}} - </a>

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "CodeCharta",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3083,6 +3083,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepcopy": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-0.6.3.tgz",
+      "integrity": "sha1-Y0eA8vhlardxr4+oQx7RzO5Vx7A=",
       "dev": true
     },
     "default-require-extensions": {

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -115,6 +115,7 @@
     "browser-sync-webpack-plugin": "^1.2.0",
     "chai": "^3.5.0",
     "css-loader": "^0.28.5",
+    "deepcopy": "^0.6.3",
     "es6-shim": "^0.35.3",
     "esdoc": "^0.5.2",
     "file-loader": "^0.11.2",


### PR DESCRIPTION
The delta view between maps now correctly displays nodes as "added" (fully green, delta = height) and "removed" (fully red, delta = height). Map 1 gets all missing nodes from Map 2 and vice versa. The newly added nodes have metrics of 0. Only the unary metric stays 1, therefore it is necessary to choose it as the area metric to see them. 
Also added origin name in node details.  