### PR TITLE
Refactoring delta methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 - Delta View shows Deltas of itself as non-trivial if nodes have same name #89: Compare deltas by path not name
+- Delta calculation performance boost #91
+- Problems when intermediate nodes missed metrics #92
+- removed unnecessary calculations
 
 ## [1.9.3] - 2018-02-23
 ### Added

--- a/visualization/app/codeCharta/core/data/data.decorator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.decorator.service.spec.ts
@@ -22,19 +22,55 @@ describe("app.codeCharta.core.data.dataService", () => {
         dataDecoratorService = new DataDecoratorService();
     });
 
-    describe("decorateEmptyAttributeLists",() => {
+    describe("decorateLeavesWithMissingMetrics", () => {
 
-        it("all nodes should have an attribute list", ()=>{
-            a.root.children[0].attributes = undefined
-            dataDecoratorService.decorateEmptyAttributeLists(a, ["some", "metrics"]);
+        it("leaves should have all metrics", ()=>{
+            dataDecoratorService.decorateLeavesWithMissingMetrics([a, b],["some", "metrics", "rloc", "functions", "mcc"]);
+            let h = d3.hierarchy(a.root);
+            h.leaves().forEach((node)=>{
+                expect(node.data.attributes).toBeDefined();
+                expect(node.data.attributes.some).toBe(0);
+                expect(node.data.attributes.metrics).toBe(0);
+                expect(node.data.attributes.rloc).toBeDefined();
+                expect(node.data.attributes.functions).toBeDefined();
+                expect(node.data.attributes.mcc).toBeDefined();
+            });
+        });
+
+        it("leaves should have all metrics even if some attributesLists are undefined", ()=>{
+            a.root.children[0].attributes = undefined;
+            dataDecoratorService.decorateLeavesWithMissingMetrics([a, b],["some", "metrics", "rloc", "functions", "mcc"]);
+            let h = d3.hierarchy(a.root);
+            h.leaves().forEach((node)=>{
+                expect(node.data.attributes).toBeDefined();
+                expect(node.data.attributes.some).toBe(0);
+                expect(node.data.attributes.metrics).toBe(0);
+                expect(node.data.attributes.rloc).toBeDefined();
+                expect(node.data.attributes.functions).toBeDefined();
+                expect(node.data.attributes.mcc).toBeDefined();
+            });
+        });
+
+    });
+
+    describe("decorateParentNodesWithMeanAttributesOfChildren",() => {
+
+        it("all nodes should have an attribute list with all possible metrics", ()=>{
+            a.root.children[0].attributes = undefined;
+            a.root.children[1].attributes = { "some": 1 };
+            dataDecoratorService.decorateLeavesWithMissingMetrics([a],["some", "metrics", "rloc", "functions", "mcc"]);
+            dataDecoratorService.decorateParentNodesWithMeanAttributesOfChildren([a], ["some", "metrics", "rloc", "functions", "mcc"]);
             let h = d3.hierarchy(a.root);
             h.each((node)=>{
                 expect(node.data.attributes).toBeDefined();
+                expect(node.data.attributes.some).toBeDefined();
+                expect(node.data.attributes.metrics).toBeDefined();
             });
         });
 
         it("all nodes should have an attribute list with listed and available metrics", ()=>{
-            dataDecoratorService.decorateEmptyAttributeLists(a, ["rloc", "functions"]);
+            dataDecoratorService.decorateLeavesWithMissingMetrics([a],["rloc", "functions"]);
+            dataDecoratorService.decorateParentNodesWithMeanAttributesOfChildren([a], ["rloc", "functions"]);
             let h = d3.hierarchy(a.root);
             h.each((node)=>{
                 expect(node.data.attributes).toBeDefined();
@@ -44,7 +80,8 @@ describe("app.codeCharta.core.data.dataService", () => {
         });
 
         it("folders should have mean attributes of children", ()=>{
-            dataDecoratorService.decorateEmptyAttributeLists(a, ["rloc", "functions"]);
+            dataDecoratorService.decorateLeavesWithMissingMetrics([a],["rloc", "functions"]);
+            dataDecoratorService.decorateParentNodesWithMeanAttributesOfChildren([a], ["rloc", "functions"]);
             let h = d3.hierarchy(a.root);
             expect(h.data.attributes["rloc"]).toBeCloseTo(200/3, 1);
             expect(h.children[0].data.attributes["rloc"]).toBe(100);

--- a/visualization/app/codeCharta/core/data/data.decorator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.decorator.service.ts
@@ -118,13 +118,10 @@ export class DataDecoratorService {
         //make sure attributes exist
         this.createAttributesIfNecessary(node);
 
-        //count attributes except unary
-        //TODO necessery ? let attributesCounter = this.countAttributesExceptUnary(node);
-
         //if attributes is empty define property for each possible metric as a mean function of child metrics
         for (let i = 0; i < metrics.length; i++) {
             let metric = metrics[i];
-            if (/*attributesCounter == 0 &&*/ !node.data.attributes.hasOwnProperty(metric) && node.data.children && node.data.children.length > 0) {
+            if (!node.data.attributes.hasOwnProperty(metric) && node.data.children && node.data.children.length > 0) {
                 this.defineAttributeAsMeanMethod(node, metric);
             }
         }
@@ -144,18 +141,6 @@ export class DataDecoratorService {
                 return sum / count;
             }
         });
-    }
-
-    private countAttributesExceptUnary(node) {
-        let attributesCounter = 0;
-        for (let attribute in node.data.attributes) {
-            if (node.data.attributes.hasOwnProperty(attribute)) {
-                if (attribute !== "unary") {
-                    attributesCounter++;
-                }
-            }
-        }
-        return attributesCounter;
     }
 
     private createAttributesIfNecessary(node) {

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
@@ -25,7 +25,13 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         b = JSON.parse(JSON.stringify(TEST_DELTA_MAP_B));
     });
 
-    it("make it happen", ()=>{
+    function decorate(map: CodeMap) {
+        let dds = new DataDecoratorService();
+        dds.decorateMapWithPathAttribute(map);
+        dds.decorateMapWithOriginAttribute(map);
+    }
+
+    it("golden test", ()=>{
 
         a.root.children.push({
             name: "onlyA",
@@ -67,12 +73,11 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
             ]
         });
 
-        //we need the paths! TODO and nothing else ?
-        let dds = new DataDecoratorService();
-        dds.decorateMapWithPathAttribute(a);
-        dds.decorateMapWithPathAttribute(b);
+        decorate(a);
+        decorate(b);
 
-        let res = deltaCalculatorService.makeDeltasHappen(a,b);
+        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a,b);
+
         expect(a.root.children[2].children[0].children[0].attributes["special"]).toBe(42);
         expect(a.root.children[2].children[0].children[1].attributes["monster"]).toBe(0);
         expect(b.root.children[3].children[0].children[0].attributes["monster"]).toBe(666);
@@ -83,89 +88,63 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
     it("should remove all nodes with other origin than itself", ()=>{
         a.root.children[0].origin = "something else"
         a.root.children[1].origin = a.fileName;
-        let res = deltaCalculatorService.removeCrossOriginNodes(a);
-        let h = d3.hierarchy(res.root);
+        deltaCalculatorService.removeCrossOriginNodes(a);
+        let h = d3.hierarchy(a.root);
         h.each((node)=>{
             expect(node.data.origin === a.fileName);
         });
     });
 
     it("fill maps should return input maps when a map does not exist", ()=>{
-        let dds = new DataDecoratorService();
+        decorate(a);
+        decorate(b);
 
-        //we need the paths! TODO and nothing else ?
-        dds.decorateMapWithPathAttribute(a);
-        dds.decorateMapWithPathAttribute(b);
+        let na = null;
+        let nb = JSON.parse(JSON.stringify(b));
 
-        dds.decorateMapWithOriginAttribute(a);
-        dds.decorateMapWithOriginAttribute(b);
+        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(na, nb);
 
-        a = null;
-
-        let result = deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
-        let da = result.leftMap;
-        let db = result.rightMap;
-
-        expect(da).toBe(a);
-        expect(db).toBe(b);
+        expect(na).toBe(null);
+        expect(nb).toEqual(b);
 
     });
 
     it("fill maps should return input maps when a map has no root", ()=>{
-        let dds = new DataDecoratorService();
-
-        //we need the paths! TODO and nothing else ?
-        dds.decorateMapWithPathAttribute(a);
-        dds.decorateMapWithPathAttribute(b);
-
-        dds.decorateMapWithOriginAttribute(a);
-        dds.decorateMapWithOriginAttribute(b);
+        decorate(a);
+        decorate(b);
 
         a.root = null;
+        let na = JSON.parse(JSON.stringify(a));
+        let nb = JSON.parse(JSON.stringify(b));
 
-        let result = deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
-        let da = result.leftMap;
-        let db = result.rightMap;
+        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(na, nb);
 
-        expect(da).toBe(a);
-        expect(db).toBe(b);
+        expect(na).toEqual(a);
+        expect(nb).toEqual(b);
 
     });
 
     it("additionalLeaf from map b should exist in a after calling fillMapsWithNonExistingNodesFromOtherMap, metrics should be 0", ()=>{
-
-        let dds = new DataDecoratorService();
-
-        //we need the paths! TODO and nothing else ?
-        dds.decorateMapWithPathAttribute(a);
-        dds.decorateMapWithPathAttribute(b);
-
-        dds.decorateMapWithOriginAttribute(a);
-        dds.decorateMapWithOriginAttribute(b);
+        decorate(a);
+        decorate(b);
 
         a.root.children[0].origin = "hallo";
 
-        let result = deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
-        let da = result.leftMap;
-        let db = result.rightMap;
+        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
 
-        expect(da.root.children[2].name).toBe("additional leaf");
-        expect(db.root.children[1].name).toBe("additional leaf");
+        expect(a.root.children[2].name).toBe("additional leaf");
+        expect(b.root.children[1].name).toBe("additional leaf");
 
-        expect(da.root.children[2].attributes.rloc).toBe(0);
-        expect(db.root.children[1].attributes.rloc).toBe(10);
+        expect(a.root.children[2].attributes.rloc).toBe(0);
+        expect(b.root.children[1].attributes.rloc).toBe(10);
 
     });
 
     it("should result in expected delta maps", ()=>{
+        decorate(a);
+        decorate(b);
 
-        //we need the paths!
-        let dds = new DataDecoratorService();
-
-        dds.decorateMapWithPathAttribute(a);
-        dds.decorateMapWithPathAttribute(b);
-        
-        deltaCalculatorService.decorateMapsWithDeltas(a, b);
+        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
 
         expect(a.root.children[0].deltas["rloc"]).toBe(80);
         expect(b.root.children[0].deltas["rloc"]).toBe(-80);
@@ -176,7 +155,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         expect(b.root.children[2].children[1].deltas["mcc"]).toBe(undefined);
         expect(a.root.children[1].children[1].deltas["mcc"]).toBe(10);
 
-        expect(b.root.children[1].deltas).toBe(undefined);
+        expect(b.root.children[2].deltas).toBe(undefined);
 
     });
 

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
@@ -25,6 +25,61 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         b = JSON.parse(JSON.stringify(TEST_DELTA_MAP_B));
     });
 
+    it("make it happen", ()=>{
+
+        a.root.children.push({
+            name: "onlyA",
+            attributes: {},
+            path: "/root/onlyA",
+            children: [
+                {
+                    name: "special",
+                    attributes: {},
+                    path: "/root/onlyA/special",
+                    children: [
+                        {
+                            name: "unicorn",
+                            attributes: { "special": 42 },
+                            path: "/root/onlyA/special/unicorn"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        b.root.children.push({
+            name: "onlyA",
+            attributes: {},
+            path: "/root/onlyA",
+            children: [
+                {
+                    name: "special",
+                    attributes: {},
+                    path: "/root/onlyA/special",
+                    children: [
+                        {
+                            name: "Narwal",
+                            attributes: {"monster": 666 },
+                            path: "/root/onlyA/special/Narwal"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        //we need the paths! TODO and nothing else ?
+        let dds = new DataDecoratorService();
+        dds.decorateMapWithPathAttribute(a);
+        dds.decorateMapWithPathAttribute(b);
+
+        let res = deltaCalculatorService.makeDeltasHappen(a,b);
+        expect(a.root.children[2].children[0].children[0].attributes["special"]).toBe(42);
+        expect(a.root.children[2].children[0].children[1].attributes["monster"]).toBe(0);
+        expect(b.root.children[3].children[0].children[0].attributes["monster"]).toBe(666);
+        expect(b.root.children[3].children[0].children[1].attributes["special"]).toBe(0);
+    });
+
+
     it("should remove all nodes with other origin than itself", ()=>{
         a.root.children[0].origin = "something else"
         a.root.children[1].origin = a.fileName;
@@ -36,8 +91,12 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
     });
 
     it("fill maps should return input maps when a map does not exist", ()=>{
-
         let dds = new DataDecoratorService();
+
+        //we need the paths! TODO and nothing else ?
+        dds.decorateMapWithPathAttribute(a);
+        dds.decorateMapWithPathAttribute(b);
+
         dds.decorateMapWithOriginAttribute(a);
         dds.decorateMapWithOriginAttribute(b);
 
@@ -53,8 +112,12 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
     });
 
     it("fill maps should return input maps when a map has no root", ()=>{
-
         let dds = new DataDecoratorService();
+
+        //we need the paths! TODO and nothing else ?
+        dds.decorateMapWithPathAttribute(a);
+        dds.decorateMapWithPathAttribute(b);
+
         dds.decorateMapWithOriginAttribute(a);
         dds.decorateMapWithOriginAttribute(b);
 
@@ -72,6 +135,11 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
     it("additionalLeaf from map b should exist in a after calling fillMapsWithNonExistingNodesFromOtherMap, metrics should be 0", ()=>{
 
         let dds = new DataDecoratorService();
+
+        //we need the paths! TODO and nothing else ?
+        dds.decorateMapWithPathAttribute(a);
+        dds.decorateMapWithPathAttribute(b);
+
         dds.decorateMapWithOriginAttribute(a);
         dds.decorateMapWithOriginAttribute(b);
 
@@ -93,6 +161,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
 
         //we need the paths!
         let dds = new DataDecoratorService();
+
         dds.decorateMapWithPathAttribute(a);
         dds.decorateMapWithPathAttribute(b);
         

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.spec.ts
@@ -76,7 +76,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         decorate(a);
         decorate(b);
 
-        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a,b);
+        deltaCalculatorService.provideDeltas(a,b);
 
         expect(a.root.children[2].children[0].children[0].attributes["special"]).toBe(42);
         expect(a.root.children[2].children[0].children[1].attributes["monster"]).toBe(0);
@@ -102,7 +102,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         let na = null;
         let nb = JSON.parse(JSON.stringify(b));
 
-        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(na, nb);
+        deltaCalculatorService.provideDeltas(na, nb);
 
         expect(na).toBe(null);
         expect(nb).toEqual(b);
@@ -117,7 +117,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         let na = JSON.parse(JSON.stringify(a));
         let nb = JSON.parse(JSON.stringify(b));
 
-        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(na, nb);
+        deltaCalculatorService.provideDeltas(na, nb);
 
         expect(na).toEqual(a);
         expect(nb).toEqual(b);
@@ -130,7 +130,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
 
         a.root.children[0].origin = "hallo";
 
-        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
+        deltaCalculatorService.provideDeltas(a, b);
 
         expect(a.root.children[2].name).toBe("additional leaf");
         expect(b.root.children[1].name).toBe("additional leaf");
@@ -144,7 +144,7 @@ describe("app.codeCharta.core.data.deltaCalculatorService", function() {
         decorate(a);
         decorate(b);
 
-        deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(a, b);
+        deltaCalculatorService.provideDeltas(a, b);
 
         expect(a.root.children[0].deltas["rloc"]).toBe(80);
         expect(b.root.children[0].deltas["rloc"]).toBe(-80);

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -87,6 +87,11 @@ export class DeltaCalculatorService {
 
     public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap) {
 
+        //null checks
+        if(!leftMap || !rightMap || !leftMap.root || !rightMap.root){
+            return;
+        }
+
         //remove cross origin nodes from maps
         this.removeCrossOriginNodes(leftMap);
         this.removeCrossOriginNodes(rightMap);

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -48,7 +48,6 @@ export class DeltaCalculatorService {
 
     private insertNodes(firstLeafHashMap: Map<string, CodeMapNode>, secondLeafHashMap: Map<string, CodeMapNode>, firstMap: CodeMap, secondMap: CodeMap) {
         firstLeafHashMap.forEach((node, path) => {
-            console.log(path);
             if (!secondLeafHashMap.has(path)) {
                 // insert node into secondHashMap and secondMap
                 //secondHashMap.set(path, node); //TODO brauchen wir das ? wenn ja dann neue leere node
@@ -128,31 +127,31 @@ export class DeltaCalculatorService {
      */
     public decorateMapsWithDeltas(firstMap: CodeMap, secondMap: CodeMap) {
 
-        //if (firstMap && secondMap && firstMap.root && secondMap.root) {
-        //    let firstRoot = d3.hierarchy<CodeMapNode>(firstMap.root);
-        //    let firstLeaves: HierarchyNode<CodeMapNode>[] = firstRoot.leaves();
-        //    let secondRoot = d3.hierarchy(secondMap.root);
-        //    let secondLeaves: HierarchyNode<CodeMapNode>[] = secondRoot.leaves();
-//
-        //    for (var j = 0; j < firstLeaves.length; j++) {
-        //        for (var k = 0; k < secondLeaves.length; k++) {
-//
-        //            let fl: HierarchyNode<CodeMapNode> = firstLeaves[j];
-        //            let sl: HierarchyNode<CodeMapNode> = secondLeaves[k];
-//
-        //            if (fl.data.path === sl.data.path) {
-        //                //calculate delta for those nodes attributes and push it to the second leave
-        //                let firstDeltas = this.calculateAttributeListDelta(sl.data.attributes, fl.data.attributes);
-        //                let secondDeltas = this.calculateAttributeListDelta(fl.data.attributes, sl.data.attributes);
-//
-        //                firstLeaves[j].data.deltas = firstDeltas;
-        //                secondLeaves[k].data.deltas = secondDeltas;
-//
-        //            }
-        //        }
-        //    }
-//
-        //}
+        if (firstMap && secondMap && firstMap.root && secondMap.root) {
+            let firstRoot = d3.hierarchy<CodeMapNode>(firstMap.root);
+            let firstLeaves: HierarchyNode<CodeMapNode>[] = firstRoot.leaves();
+            let secondRoot = d3.hierarchy(secondMap.root);
+            let secondLeaves: HierarchyNode<CodeMapNode>[] = secondRoot.leaves();
+
+            for (var j = 0; j < firstLeaves.length; j++) {
+                for (var k = 0; k < secondLeaves.length; k++) {
+
+                    let fl: HierarchyNode<CodeMapNode> = firstLeaves[j];
+                    let sl: HierarchyNode<CodeMapNode> = secondLeaves[k];
+
+                    if (fl.data.path === sl.data.path) {
+                        //calculate delta for those nodes attributes and push it to the second leave
+                        let firstDeltas = this.calculateAttributeListDelta(sl.data.attributes, fl.data.attributes);
+                        let secondDeltas = this.calculateAttributeListDelta(fl.data.attributes, sl.data.attributes);
+
+                        firstLeaves[j].data.deltas = firstDeltas;
+                        secondLeaves[k].data.deltas = secondDeltas;
+
+                    }
+                }
+            }
+
+        }
 
     }
 
@@ -167,7 +166,6 @@ export class DeltaCalculatorService {
     public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap): { leftMap: CodeMap; rightMap: CodeMap; } {
 
         if (leftMap && rightMap && leftMap.root && rightMap.root) {
-            console.log("HE");
             //make hashmaps with paths as indices
             let firstLeafHashMap = new Map<string, CodeMapNode>();
             d3.hierarchy(leftMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
@@ -185,6 +183,7 @@ export class DeltaCalculatorService {
 
 
         }
+
 
         return {leftMap: leftMap, rightMap: rightMap};
 

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -24,6 +24,7 @@ export class DeltaCalculatorService {
             if (!secondLeafHashMap.has(path)) {
                 // insert node into secondHashMap and secondMap
                 let addedNode = this.deepcopy2(node);
+                console.log(addedNode.attributes.unary, node.attributes.unary);
                 secondLeafHashMap.set(path, addedNode);
                 this.insertNodeIntoMapByPath(addedNode, secondMap);
             }
@@ -136,12 +137,14 @@ export class DeltaCalculatorService {
         //deepcopy
         let copy: HierarchyNode<CodeMapNode> = deepcopy.default(nodes.copy()); //Hm this seems to be doing the right thing. First shallow copy then a deep copy ?!
 
-        //make own attributes 0
+        //make own attributes 0 (not unary)
         for (let property in copy.data.attributes) {
             if (copy.data.attributes.hasOwnProperty(property)) {
                 copy.data.attributes[property] = 0;
             }
         }
+
+        copy.data.attributes.unary = 1;
 
         ////make all ancestors attributes 0
         copy.each((node) => {
@@ -150,6 +153,7 @@ export class DeltaCalculatorService {
                     node.data.attributes[property] = 0;
                 }
             }
+            copy.data.attributes.unary = 1;
         });
 
         return copy;

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -19,41 +19,13 @@ export class DeltaCalculatorService {
 
     }
 
-    public makeDeltasHappen(firstMap: CodeMap, secondMap: CodeMap) {
-
-        //make hashmaps with paths as indices
-        let firstLeafHashMap = new Map<string, CodeMapNode>();
-        d3.hierarchy(firstMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
-            firstLeafHashMap.set(node.data.path, node.data);
-        });
-
-        let secondLeafHashMap = new Map<string, CodeMapNode>();
-        d3.hierarchy(secondMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
-            secondLeafHashMap.set(node.data.path, node.data);
-        });
-
-        // iterate over maps and insert nodes
-        this.insertNodes(firstLeafHashMap, secondLeafHashMap, firstMap, secondMap);
-        this.insertNodes(secondLeafHashMap, firstLeafHashMap, secondMap, firstMap);
-
-        //console.log(Array.from(firstHashMap.keys()));
-        //console.log(Array.from(secondHashMap.keys()));
-
-        // add nodes from the other trees
-        //let mergedMaps = this.fillMapsWithNonExistingNodesFromOtherMap(firstMap, secondMap);
-        //let mergedFirstMap = mergedMaps.leftMap;
-        //let mergedSecondMap = mergedMaps.rightMap;
-
-    }
-
-    private insertNodes(firstLeafHashMap: Map<string, CodeMapNode>, secondLeafHashMap: Map<string, CodeMapNode>, firstMap: CodeMap, secondMap: CodeMap) {
+    private insertNodesIntoMapsAndHashmaps(firstLeafHashMap: Map<string, CodeMapNode>, secondLeafHashMap: Map<string, CodeMapNode>, firstMap: CodeMap, secondMap: CodeMap) {
         firstLeafHashMap.forEach((node, path) => {
             if (!secondLeafHashMap.has(path)) {
                 // insert node into secondHashMap and secondMap
-                //secondHashMap.set(path, node); //TODO brauchen wir das ? wenn ja dann neue leere node
                 let addedNode = this.deepcopy2(node);
+                secondLeafHashMap.set(path, addedNode);
                 this.insertNodeIntoMapByPath(addedNode, secondMap);
-                //secondLeafHashMap.get(insertPath).children.push(addedNode); // TODO das ist der triviale fall für blatt inserts und nicht folder
             }
         });
     }
@@ -113,142 +85,45 @@ export class DeltaCalculatorService {
 
     }
 
-    /**
-     * This requires the map to have paths. e.g.
-     *
-     * let dds = new DataDecoratorService();
-     * dds.decorateMapWithPathAttribute(a);
-     * dds.decorateMapWithPathAttribute(b);
-     *
-     * TODO ensure paths through typings
-     *
-     * @param {CodeMap} firstMap
-     * @param {CodeMap} secondMap
-     */
-    public decorateMapsWithDeltas(firstMap: CodeMap, secondMap: CodeMap) {
+    public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap) {
 
-        if (firstMap && secondMap && firstMap.root && secondMap.root) {
-            let firstRoot = d3.hierarchy<CodeMapNode>(firstMap.root);
-            let firstLeaves: HierarchyNode<CodeMapNode>[] = firstRoot.leaves();
-            let secondRoot = d3.hierarchy(secondMap.root);
-            let secondLeaves: HierarchyNode<CodeMapNode>[] = secondRoot.leaves();
+        //remove cross origin nodes from maps
+        this.removeCrossOriginNodes(leftMap);
+        this.removeCrossOriginNodes(rightMap);
 
-            for (var j = 0; j < firstLeaves.length; j++) {
-                for (var k = 0; k < secondLeaves.length; k++) {
+        //build hash maps for fast search indices
+        let firstLeafHashMap = new Map<string, CodeMapNode>();
+        d3.hierarchy(leftMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
+            firstLeafHashMap.set(node.data.path, node.data);
+        });
 
-                    let fl: HierarchyNode<CodeMapNode> = firstLeaves[j];
-                    let sl: HierarchyNode<CodeMapNode> = secondLeaves[k];
+        let secondLeafHashMap = new Map<string, CodeMapNode>();
+        d3.hierarchy(rightMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
+            secondLeafHashMap.set(node.data.path, node.data);
+        });
 
-                    if (fl.data.path === sl.data.path) {
-                        //calculate delta for those nodes attributes and push it to the second leave
-                        let firstDeltas = this.calculateAttributeListDelta(sl.data.attributes, fl.data.attributes);
-                        let secondDeltas = this.calculateAttributeListDelta(fl.data.attributes, sl.data.attributes);
+        //insert nodes from the other map
+        this.insertNodesIntoMapsAndHashmaps(firstLeafHashMap, secondLeafHashMap, leftMap, rightMap);
+        this.insertNodesIntoMapsAndHashmaps(secondLeafHashMap, firstLeafHashMap, rightMap, leftMap);
 
-                        firstLeaves[j].data.deltas = firstDeltas;
-                        secondLeaves[k].data.deltas = secondDeltas;
-
-                    }
-                }
-            }
-
-        }
+        //calculate deltas between leaves
+        firstLeafHashMap.forEach((node, path) => {
+            let otherNode = secondLeafHashMap.get(path);
+            otherNode.deltas = this.calculateAttributeListDelta(node.attributes, otherNode.attributes);
+            node.deltas = this.calculateAttributeListDelta(otherNode.attributes, node.attributes);
+        });
 
     }
 
-    /**
-     * Unifies both maps and inserts unique nodes into the other map. The inserted nodes have all metrics set to zero.
-     * This will calculate deltas correctly between versions and add "empty" buildings to ensure all revisions have an
-     * equal building pool. These empty buildings should be viewed with the unary metric as area
-     * @param {CodeMap} leftMap
-     * @param {CodeMap} rightMap
-     * @returns {{leftMap: CodeMap; rightMap: CodeMap}}
-     */
-    public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap): { leftMap: CodeMap; rightMap: CodeMap; } {
+    private removeCrossOriginNodes(map: CodeMap) {
 
-        if (leftMap && rightMap && leftMap.root && rightMap.root) {
-            //make hashmaps with paths as indices
-            let firstLeafHashMap = new Map<string, CodeMapNode>();
-            d3.hierarchy(leftMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
-                firstLeafHashMap.set(node.data.path, node.data);
-            });
-
-            let secondLeafHashMap = new Map<string, CodeMapNode>();
-            d3.hierarchy(rightMap.root).leaves().forEach((node: HierarchyNode<CodeMapNode>) => {
-                secondLeafHashMap.set(node.data.path, node.data);
-            });
-
-            // iterate over maps and insert nodes
-            this.insertNodes(firstLeafHashMap, secondLeafHashMap, leftMap, rightMap);
-            this.insertNodes(secondLeafHashMap, firstLeafHashMap, rightMap, leftMap);
-
-
-        }
-
-
-        return {leftMap: leftMap, rightMap: rightMap};
-
-    }
-
-    public removeCrossOriginNodes(map: CodeMap): CodeMap {
-        if (map && map.root) {
-
-            let mapCopy: CodeMap = deepcopy.default(map);
-
-            let mapRoot = d3.hierarchy<CodeMapNode>(mapCopy.root);
+            let mapRoot = d3.hierarchy<CodeMapNode>(map.root);
             mapRoot.each((node) => {
                 if (node.data.children) {
-                    node.data.children = node.data.children.filter(x => (x.origin === mapCopy.fileName));
+                    node.data.children = node.data.children.filter(x => (x.origin === map.fileName));
                 }
             });
 
-            return mapCopy;
-
-        } else {
-            return map;
-        }
-    }
-
-    private insertLeftIntoRightWithZeroMetrics(left: HierarchyNode<CodeMapNode>, right: HierarchyNode<CodeMapNode>) {
-
-        // are these nodes mergable (same name and have children)?
-        if (left.data.name === right.data.name && left.children != undefined && right.children != undefined && left.children.length > 0 && right.children.length > 0) {
-
-            left.children.forEach((leftChild) => {
-
-                let leftChildExistsInRight = this.childExistsInHierarchy(right, leftChild);
-
-                //if left child does not exist in the right node's children, insert it as a new valueless node into rights children
-                if (!leftChildExistsInRight) {
-                    let copy = this.deepcopy(leftChild);
-                    right.data.children.push(copy.data);
-                } else {
-
-                    // if left child exists in right nodes children, skip, since we only look for direct children
-                    right.children.forEach((rightChildInner) => {
-                        left.children.forEach((leftChildInner) => {
-                            //step in with pre-filtering
-                            if (leftChildInner.data.name !== leftChild.data.name) {
-                                if (leftChildInner.data.name === rightChildInner.data.name && leftChildInner.children != undefined && rightChildInner.children != undefined && leftChildInner.children.length > 0 && rightChildInner.children.length > 0) {
-                                    this.insertLeftIntoRightWithZeroMetrics(leftChildInner, rightChildInner);
-                                }
-                            }
-                        });
-                    });
-                }
-
-            });
-
-        }
-    }
-
-    private childExistsInHierarchy(hierarchy: HierarchyNode<CodeMapNode>, child: HierarchyNode<CodeMapNode>): boolean {
-        let tmp = false;
-        hierarchy.children.forEach((rightChild) => {
-            if (child.data.name === rightChild.data.name) {
-                tmp = true;
-            }
-        });
-        return tmp;
     }
 
     private deepcopy(nodes: HierarchyNode<CodeMapNode>): HierarchyNode<CodeMapNode> {
@@ -283,7 +158,7 @@ export class DeltaCalculatorService {
 
     }
 
-    calculateAttributeListDelta(first: KVObject, second: KVObject) {
+    private calculateAttributeListDelta(first: KVObject, second: KVObject) {
         let deltas = {};
         for (var key in second) {
             if (key) {

--- a/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
+++ b/visualization/app/codeCharta/core/data/data.deltaCalculator.service.ts
@@ -23,8 +23,7 @@ export class DeltaCalculatorService {
         firstLeafHashMap.forEach((node, path) => {
             if (!secondLeafHashMap.has(path)) {
                 // insert node into secondHashMap and secondMap
-                let addedNode = this.deepcopy2(node);
-                console.log(addedNode.attributes.unary, node.attributes.unary);
+                let addedNode = this.deepcopy(node);
                 secondLeafHashMap.set(path, addedNode);
                 this.insertNodeIntoMapByPath(addedNode, secondMap);
             }
@@ -86,7 +85,7 @@ export class DeltaCalculatorService {
 
     }
 
-    public fillMapsWithNonExistingNodesFromOtherMap(leftMap: CodeMap, rightMap: CodeMap) {
+    public provideDeltas(leftMap: CodeMap, rightMap: CodeMap) {
 
         //null checks
         if(!leftMap || !rightMap || !leftMap.root || !rightMap.root){
@@ -132,10 +131,11 @@ export class DeltaCalculatorService {
 
     }
 
-    private deepcopy(nodes: HierarchyNode<CodeMapNode>): HierarchyNode<CodeMapNode> {
+    private deepcopy(nodes:CodeMapNode): CodeMapNode {
 
         //deepcopy
-        let copy: HierarchyNode<CodeMapNode> = deepcopy.default(nodes.copy()); //Hm this seems to be doing the right thing. First shallow copy then a deep copy ?!
+        let h = d3.hierarchy(nodes);
+        let copy: HierarchyNode<CodeMapNode> = deepcopy.default(h.copy()); //Hm this seems to be doing the right thing. First shallow copy then a deep copy ?!
 
         //make own attributes 0 (not unary)
         for (let property in copy.data.attributes) {
@@ -156,14 +156,7 @@ export class DeltaCalculatorService {
             copy.data.attributes.unary = 1;
         });
 
-        return copy;
-
-    }
-
-    private deepcopy2(node: CodeMapNode): CodeMapNode {
-
-        let h = d3.hierarchy(node);
-        return this.deepcopy(h).data;
+        return copy.data;
 
     }
 

--- a/visualization/app/codeCharta/core/data/data.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.service.spec.ts
@@ -163,24 +163,24 @@ describe("app.codeCharta.core.data.dataService", function() {
 
     it("process deltas should do nothing if maps are not set or deltas are not enabled", () => {
         dataService._deltasEnabled = false;
-        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
+        dataService.deltaCalculatorService.provideDeltas = jest.fn();
         dataService.processDeltas();
-        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).not.toHaveBeenCalled();
+        expect(dataService.deltaCalculatorService.provideDeltas).not.toHaveBeenCalled();
     });
 
     it("process deltas should call deltaCalculator if maps and deltas are set", () => {
         dataService._deltasEnabled = true;
         dataService._data.renderMap = "render map";
         dataService._lastComparisonMap = "comparison map";
-        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
+        dataService.deltaCalculatorService.provideDeltas = jest.fn();
         dataService.processDeltas();
-        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).toHaveBeenCalledWith("render map", "comparison map");
+        expect(dataService.deltaCalculatorService.provideDeltas).toHaveBeenCalledWith("render map", "comparison map");
     });
 
     it("only calculate deltas when two maps exist and deltas are enabled", () => {
 
         dataService.notify = jest.fn();
-        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
+        dataService.deltaCalculatorService.provideDeltas = jest.fn();
 
         dataService._deltasEnabled = true;
 
@@ -189,7 +189,7 @@ describe("app.codeCharta.core.data.dataService", function() {
         dataService.setReferenceMap(0);
         dataService.setComparisonMap(1);
 
-        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).toHaveBeenCalled();
+        expect(dataService.deltaCalculatorService.provideDeltas).toHaveBeenCalled();
 
     });
 

--- a/visualization/app/codeCharta/core/data/data.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.service.spec.ts
@@ -126,76 +126,61 @@ describe("app.codeCharta.core.data.dataService", function() {
         expect(dataService.data.renderMap.fileName).toBe(data.fileName);
     });
 
-    it("activating deltas when deltas are not enabled should set the flag and maps correctly", () => {
+    it("activating deltas when deltas are not enabled should toggle the delta flag and re-set the current comparison map", () => {
         dataService._lastReferenceIndex = 42;
         dataService._deltasEnabled = false;
         dataService.setComparisonMap = jest.fn();
-        dataService.setReferenceMap = jest.fn();
         dataService.onActivateDeltas();
         expect(dataService._deltasEnabled).toBe(true);
         expect(dataService.setComparisonMap).toHaveBeenCalledWith(42);
-        expect(dataService.setReferenceMap).toHaveBeenCalledWith(42);
     });
 
     it("activating deltas when deltas are enabled should do nothing", () => {
-        dataService._lastReferenceIndex = 42;
         dataService._deltasEnabled = true;
         dataService.setComparisonMap = jest.fn();
-        dataService.setReferenceMap = jest.fn();
         dataService.onActivateDeltas();
         expect(dataService._deltasEnabled).toBe(true);
         expect(dataService.setComparisonMap).not.toHaveBeenCalled();
-        expect(dataService.setReferenceMap).not.toHaveBeenCalled();
     });
+
 
     it("deactivating deltas when deltas are enabled should set the flag and maps correctly", () => {
         dataService._lastReferenceIndex = 42;
         dataService._deltasEnabled = true;
         dataService.setComparisonMap = jest.fn();
-        dataService.setReferenceMap = jest.fn();
         dataService.onDeactivateDeltas();
         expect(dataService._deltasEnabled).toBe(false);
         expect(dataService.setComparisonMap).toHaveBeenCalledWith(42);
-        expect(dataService.setReferenceMap).toHaveBeenCalledWith(42);
     });
 
     it("deactivating deltas when deltas are not enabled should do nothing", () => {
-        dataService._lastReferenceIndex = 42;
         dataService._deltasEnabled = false;
         dataService.setComparisonMap = jest.fn();
-        dataService.setReferenceMap = jest.fn();
         dataService.onDeactivateDeltas();
         expect(dataService._deltasEnabled).toBe(false);
         expect(dataService.setComparisonMap).not.toHaveBeenCalled();
-        expect(dataService.setReferenceMap).not.toHaveBeenCalled();
     });
 
-    it("apply node merging should retrieve the fillMapsWithNonExistingNodesFromOtherMap result and decorate it with unaries and deltas. after that write it back as current maps", NGMock.mock.inject(function (_dataService_, _deltaCalculatorService_, _dataDecoratorService_) {
-        _dataService_._data.renderMap = "OLD RENDER MAP";
-        _dataService_._lastComparisonMap = "OLD COMPARISON MAP";
+    it("process deltas should do nothing if maps are not set or deltas are not enabled", () => {
+        dataService._deltasEnabled = false;
+        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
+        dataService.processDeltas();
+        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).not.toHaveBeenCalled();
+    });
 
-        _deltaCalculatorService_.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
-        _deltaCalculatorService_.removeCrossOriginNodes = jest.fn();
-        _deltaCalculatorService_.fillMapsWithNonExistingNodesFromOtherMap.mockReturnValue({leftMap: "LEFT MAP WITH OTHER NODES", rightMap:"RIGHT MAP WITH OTHER NODES"});
-        _deltaCalculatorService_.removeCrossOriginNodes.mockReturnValue("MAP NO CROSS ORIGIN NODES");
-        _dataDecoratorService_.decorateMapWithUnaryMetric = jest.fn();
-        _deltaCalculatorService_.decorateMapsWithDeltas = jest.fn();
-
-        _dataService_.applyNodeMerging();
-
-        expect(_deltaCalculatorService_.fillMapsWithNonExistingNodesFromOtherMap).toHaveBeenCalledWith("MAP NO CROSS ORIGIN NODES", "MAP NO CROSS ORIGIN NODES");
-        expect(_deltaCalculatorService_.removeCrossOriginNodes).toHaveBeenCalledWith("OLD RENDER MAP");
-        expect(_deltaCalculatorService_.removeCrossOriginNodes).toHaveBeenCalledWith("OLD COMPARISON MAP");
-        expect(_dataDecoratorService_.decorateMapWithUnaryMetric).toHaveBeenCalledWith("RIGHT MAP WITH OTHER NODES");
-        expect(_dataDecoratorService_.decorateMapWithUnaryMetric).toHaveBeenCalledWith("LEFT MAP WITH OTHER NODES");
-        expect(_deltaCalculatorService_.decorateMapsWithDeltas).toHaveBeenCalledWith("LEFT MAP WITH OTHER NODES", "OLD COMPARISON MAP");
-
-    }));
+    it("process deltas should call deltaCalculator if maps and deltas are set", () => {
+        dataService._deltasEnabled = true;
+        dataService._data.renderMap = "render map";
+        dataService._lastComparisonMap = "comparison map";
+        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
+        dataService.processDeltas();
+        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).toHaveBeenCalledWith("render map", "comparison map");
+    });
 
     it("only calculate deltas when two maps exist and deltas are enabled", () => {
 
         dataService.notify = jest.fn();
-        dataService.deltaCalculatorService.decorateMapsWithDeltas = jest.fn();
+        dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap = jest.fn();
 
         dataService._deltasEnabled = true;
 
@@ -204,7 +189,7 @@ describe("app.codeCharta.core.data.dataService", function() {
         dataService.setReferenceMap(0);
         dataService.setComparisonMap(1);
 
-        expect(dataService.deltaCalculatorService.decorateMapsWithDeltas).toHaveBeenCalled();
+        expect(dataService.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap).toHaveBeenCalled();
 
     });
 

--- a/visualization/app/codeCharta/core/data/data.service.spec.ts
+++ b/visualization/app/codeCharta/core/data/data.service.spec.ts
@@ -66,12 +66,22 @@ describe("app.codeCharta.core.data.dataService", function() {
 
     it("set metrics should set metrics correctly", ()=>{
         dataService.setMap(data, 0);
-        dataService.setMetrics(0);
+        dataService.updateMetrics();
         expect(dataService.data.metrics).toEqual(["RLOC", "Functions", "MCC", "unary"]);
     });
 
-    it("set metrics should not set metrics when map is null", ()=>{
-        dataService.setMetrics(42);
+    it("set metrics should set metrics correctly with multiple maps", ()=>{
+        dataService.setMap(data, 0);
+        let data2 = JSON.parse(JSON.stringify(data));
+        data2.root.children[0].attributes["test"] = 0;
+        dataService.setMap(data2, 0);
+        dataService.updateMetrics();
+        expect(dataService.data.metrics).toEqual(["RLOC", "Functions", "MCC", "unary", "test"]);
+    });
+
+    it("set metrics should not set metrics when all maps are null", ()=>{
+        dataService._data.revisions = [];
+        dataService.updateMetrics();
         expect(dataService.data.metrics).toEqual([]);
     });
 
@@ -171,10 +181,11 @@ describe("app.codeCharta.core.data.dataService", function() {
     it("process deltas should call deltaCalculator if maps and deltas are set", () => {
         dataService._deltasEnabled = true;
         dataService._data.renderMap = "render map";
+        dataService._data.metrics = ["special"];
         dataService._lastComparisonMap = "comparison map";
         dataService.deltaCalculatorService.provideDeltas = jest.fn();
         dataService.processDeltas();
-        expect(dataService.deltaCalculatorService.provideDeltas).toHaveBeenCalledWith("render map", "comparison map");
+        expect(dataService.deltaCalculatorService.provideDeltas).toHaveBeenCalledWith("render map", "comparison map", ["special"]);
     });
 
     it("only calculate deltas when two maps exist and deltas are enabled", () => {

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -69,13 +69,13 @@ export class DataService {
     public setComparisonMap(index: number) {
         if (this._data.revisions[index] != null) {
             this._lastComparisonMap = this._data.revisions[index];
-            this.processDeltas(index);
+            this.processDeltas();
             this.notify();
         }
     }
 
-    private processDeltas(index: number) {
-        if (this._deltasEnabled && this.data.renderMap && this._lastComparisonMap) {
+    private processDeltas() {
+        if (this._deltasEnabled && this._data.renderMap && this._lastComparisonMap) {
             this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.renderMap,this._lastComparisonMap);
         }
     }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -61,7 +61,7 @@ export class DataService {
         if (this._data.revisions[index] != null) {
             this._lastReferenceIndex = index;
             this._data.renderMap = this._data.revisions[index];
-            this.processDeltas(index);
+            this.processDeltas();
             this.notify();
         }
     }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -43,9 +43,6 @@ export class DataService {
 
     }
 
-    //TODO check unit tests
-    //TODO check if deltas work this way
-    //TODO unary metrics are 0 for merged in nodes
     public setMap(map: CodeMap, revision: number) {
         this._data.revisions[revision] = map;
         this.dataDecoratorService.decorateMapWithOriginAttribute(this._data.revisions[revision]);
@@ -76,7 +73,7 @@ export class DataService {
 
     private processDeltas() {
         if (this._deltasEnabled && this._data.renderMap && this._lastComparisonMap) {
-            this.deltaCalculatorService.fillMapsWithNonExistingNodesFromOtherMap(this._data.renderMap,this._lastComparisonMap);
+            this.deltaCalculatorService.provideDeltas(this._data.renderMap,this._lastComparisonMap);
         }
     }
 
@@ -157,18 +154,5 @@ export class DataService {
         this._data.renderMap = null;
         this.notify();
     }
-
-    public getIndexOfMap(map: CodeMap) {
-
-        for(let i = 0; i<this._data.revisions.length; i++){
-            if(this._data.revisions[i] && map && this._data.revisions[i].fileName === map.fileName){
-                return i;
-            }
-        }
-
-        return -1;
-
-    }
-
 
 }

--- a/visualization/app/codeCharta/core/data/data.service.ts
+++ b/visualization/app/codeCharta/core/data/data.service.ts
@@ -162,7 +162,6 @@ export class DataService {
         if (!this._deltasEnabled) {
             this._deltasEnabled = true;
             this.setComparisonMap(this._lastReferenceIndex);
-            this.setReferenceMap(this._lastReferenceIndex);
         }
 
 
@@ -172,7 +171,6 @@ export class DataService {
         if (this._deltasEnabled) {
             this._deltasEnabled = false;
             this.setComparisonMap(this._lastReferenceIndex);
-            this.setReferenceMap(this._lastReferenceIndex);
         }
     }
 

--- a/visualization/app/codeCharta/core/treemap/treemap.service.ts
+++ b/visualization/app/codeCharta/core/treemap/treemap.service.ts
@@ -78,6 +78,7 @@ class TreeMapService {
      * @param {number} folderHeight height of folder
      */
     private transformNode(node, heightKey, heightScale, folderHeight) {
+        if(!node.data.attributes){console.log("treemap no attributes", node);}
         let heightValue = node.data.attributes[heightKey];
         if(heightValue === undefined || heightValue === null || heightValue === 0) {
             heightValue = 1;

--- a/visualization/app/codeCharta/ui/revisionChooser/revisionChooserComponent.ts
+++ b/visualization/app/codeCharta/ui/revisionChooser/revisionChooserComponent.ts
@@ -37,11 +37,11 @@ export class RevisionChooserController implements DataServiceSubscriber{
     }
 
     onReferenceChange(map: CodeMap) {
-        this.dataService.setReferenceMap(this.dataService.getIndexOfMap(map));
+        this.dataService.setReferenceMap(this.getIndexOfMap(map, this.dataService.data.revisions));
     }
 
     onComparisonChange(map: CodeMap) {
-        this.dataService.setComparisonMap(this.dataService.getIndexOfMap(map));
+        this.dataService.setComparisonMap(this.getIndexOfMap(map, this.dataService.data.revisions));
     }
 
     loadComparisonMap(key: number) {
@@ -52,6 +52,19 @@ export class RevisionChooserController implements DataServiceSubscriber{
     loadReferenceMap(key: number) {
         this.dataService.setReferenceMap(key);
     }
+
+    private getIndexOfMap(map: CodeMap, mapArray: CodeMap[]) {
+
+        for(let i = 0; i<mapArray.length; i++){
+            if(mapArray[i] && map && mapArray[i].fileName === map.fileName){
+                return i;
+            }
+        }
+
+        return -1;
+
+    }
+
 
 }
 


### PR DESCRIPTION
This PR refactors delta calculation, map merging and map loading. Even big maps like firefox or amazon are now fast enough (#91 ). 
A bug which prevented delta calculation because of missing intermediate attributes was fixed (#92).
Loading times and UI reaction times are acceptable on my machine (2.6Ghz i7, 8gb DDR3). 
Existing unit tests are passing and new unit tests were added but manual test results and feedback is appreciated and these cases will be added to the automatic tests.

# Firefox in comparison to itself with the height of one node changed
<img width="1461" alt="bildschirmfoto 2018-03-05 um 17 54 36" src="https://user-images.githubusercontent.com/2622069/36988787-0500acf8-20a0-11e8-95f1-19938a89cecf.png">

# corresponding task manager readings
<img width="476" alt="bildschirmfoto 2018-03-05 um 17 55 06" src="https://user-images.githubusercontent.com/2622069/36988793-082d04da-20a0-11e8-8a74-7ec41f8a2098.png">

# firefox in comparison to aws
<img width="1235" alt="bildschirmfoto 2018-03-05 um 17 52 55" src="https://user-images.githubusercontent.com/2622069/36988813-15959d3a-20a0-11e8-8763-8a738cd59c03.png">

