### PR TITLE
Bugfix/sonarimporterpaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed
 
 ### Fixed
+- a sonar importer bug which prevented the importer to fetch the last page #122
 
 ## [1.11.1] - 2018-04-11
 ### Added

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
@@ -72,9 +72,9 @@ class SonarMeasuresAPIDatasource(private val user: String, private val baseUrl: 
     private fun getMeasures(componentKey: String, sublist: List<String>): Flowable<Component> {
 
         return Flowable.create({ subscriber ->
-            var page = 0
-            var total = PAGE_SIZE.toLong()
-            while (++page < total / PAGE_SIZE + 1) {
+            var page = 1
+            var total = 0L
+            do {
                 val measures = getMeasures(componentKey, sublist, page)
                 total = measures.paging.total.toLong()
 
@@ -83,7 +83,8 @@ class SonarMeasuresAPIDatasource(private val user: String, private val baseUrl: 
                             .filter { c -> c.qualifier == Qualifier.FIL || c.qualifier == Qualifier.UTS }
                             .forEach({ subscriber.onNext(it) })
                 }
-            }
+
+            } while (page++ * PAGE_SIZE < total)
             subscriber.onComplete()
         }, BackpressureStrategy.BUFFER)
     }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMetricsAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMetricsAPIDatasource.kt
@@ -71,8 +71,16 @@ class SonarMetricsAPIDatasource(private val user: String, private val baseUrl: U
     val numberOfPages: Int
         get() {
             val response = getAvailableMetrics(1)
-            return response.total / PAGE_SIZE + 1
+            return calculateNumberOfPages(response.total)
         }
+
+    fun calculateNumberOfPages(total: Int): Int {
+        var incrementor = 0;
+        if(total % PAGE_SIZE > 0){
+            incrementor = 1;
+        }
+        return total / PAGE_SIZE + incrementor
+    }
 
     internal constructor(baseUrl: URL) : this("", baseUrl)
 

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
@@ -65,6 +65,23 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         return GSON.fromJson(responseString, Measures::class.java)
     }
 
+    @Test
+    @Throws(Exception::class)
+    fun getMeasures_from_server_if_no_authentication_needed_and_there_are_multiple_result_pages() {
+        // given
+        stubFor(get(urlEqualTo(URL_PATH))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)
+                        .withBody(createResponseString())))
+
+        // when
+        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val measures = ds.getMeasures(PROJECT_KEY, listOf("coverage"))
+
+        // then
+        assertThat(measures, `is`(createExpectedMeasures()))
+    }
 
     @Test
     @Throws(Exception::class)
@@ -175,8 +192,9 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         private const val PORT = 8089
         private const val USERNAME = "somename"
         private const val PROJECT_KEY = "someProject"
+        private const val PAGE = "1"
         private val GSON = GsonBuilder().create()
-        private const val URL_PATH = "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=1&ps=$PAGE_SIZE"
+        private const val URL_PATH = "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=$PAGE&ps=$PAGE_SIZE"
 
         private fun createBaseUrl(): URL {
             try {

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
@@ -47,8 +47,11 @@ import java.io.IOException
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URL
+import mu.KotlinLogging
 
 class SonarMeasuresAPIDatasourceIntegrationTest {
+
+    private val logger = KotlinLogging.logger {}
 
     @Rule
     @JvmField

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMetricsAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMetricsAPIDatasourceIntegrationTest.kt
@@ -54,6 +54,21 @@ class SonarMetricsAPIDatasourceIntegrationTest {
     }
 
     @Test
+    fun getNoOfPages() {
+        assertNoOfPages(1499, 3);
+        assertNoOfPages(1500, 3);
+        assertNoOfPages(1501, 4);
+        assertNoOfPages(0, 0);
+        assertNoOfPages(1, 1);
+    }
+
+    fun assertNoOfPages(total: Int, expectation: Int) {
+        val ds = SonarMetricsAPIDatasource(createBaseUrl())
+        val pages = ds.calculateNumberOfPages(total)
+        assertThat(pages, `is`(expectation))
+    }
+
+    @Test
     @Throws(Exception::class)
     fun getAvailableMetrics() {
         // given

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_1.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_1.json
@@ -1,0 +1,58 @@
+{
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 2,
+    "total": 5
+  },
+  "baseComponent": {
+    "id": "AVpgljwSAwvKRXcPxJMX",
+    "key": "de.maibornwolff.codecharta:codecharta",
+    "name": "codecharta",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "coverage",
+        "value": "85.1",
+        "periods": [
+          {
+            "index": 1,
+            "value": "0.0"
+          },
+          {
+            "index": 2,
+            "value": "0.0"
+          },
+          {
+            "index": 3,
+            "value": "0.0"
+          }
+        ]
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AVpglkG7K9udye1JocWL",
+      "key": "de.maibornwolff.codecharta:codecharta:import:SonarImporter:src/main/java/de/maibornwolff/codecharta/importer/sonar/dataaccess/AuthentificationHandler.java",
+      "name": "AuthentificationHandler.java",
+      "qualifier": "FIL",
+      "path": "src/main/java/de/maibornwolff/codecharta/importer/sonar/dataaccess/AuthentificationHandler.java",
+      "language": "java",
+      "measures": [
+        {
+          "metric": "coverage",
+          "value": "50.0"
+        }
+      ]
+    },
+    {
+      "id": "AVpglkG7K9udye1JocWZ",
+      "key": "de.maibornwolff.codecharta:codecharta:import:SonarImporter:src/test/java/de/maibornwolff/codecharta/importer/sonar/dataaccess/AuthentificationHandlerTest.java",
+      "name": "AuthentificationHandlerTest.java",
+      "qualifier": "UTS",
+      "path": "src/test/java/de/maibornwolff/codecharta/importer/sonar/dataaccess/AuthentificationHandlerTest.java",
+      "language": "java",
+      "measures": []
+    }
+  ]
+}

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_1.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_1.json
@@ -1,8 +1,8 @@
 {
   "paging": {
     "pageIndex": 1,
-    "pageSize": 2,
-    "total": 5
+    "pageSize": 500,
+    "total": 1499
   },
   "baseComponent": {
     "id": "AVpgljwSAwvKRXcPxJMX",

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_2.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_2.json
@@ -1,8 +1,8 @@
 {
   "paging": {
     "pageIndex": 2,
-    "pageSize": 2,
-    "total": 5
+    "pageSize": 500,
+    "total": 1499
   },
   "baseComponent": {
     "id": "AVpgljwSAwvKRXcPxJMX",

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_2.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_2.json
@@ -1,0 +1,58 @@
+{
+  "paging": {
+    "pageIndex": 2,
+    "pageSize": 2,
+    "total": 5
+  },
+  "baseComponent": {
+    "id": "AVpgljwSAwvKRXcPxJMX",
+    "key": "de.maibornwolff.codecharta:codecharta",
+    "name": "codecharta",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "coverage",
+        "value": "85.1",
+        "periods": [
+          {
+            "index": 1,
+            "value": "0.0"
+          },
+          {
+            "index": 2,
+            "value": "0.0"
+          },
+          {
+            "index": 3,
+            "value": "0.0"
+          }
+        ]
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AVqVTvnuK9udye1Jp0ax",
+      "key": "de.maibornwolff.codecharta:codecharta:model:src/main/java/de/maibornwolff/codecharta/nodeinserter/FileSystemPath.java",
+      "name": "FileSystemPath.java",
+      "qualifier": "FIL",
+      "path": "src/main/java/de/maibornwolff/codecharta/nodeinserter/FileSystemPath.java",
+      "language": "java",
+      "measures": [
+        {
+          "metric": "coverage",
+          "value": "78.0"
+        }
+      ]
+    },
+    {
+      "id": "AVqVTvnvK9udye1Jp0a3",
+      "key": "de.maibornwolff.codecharta:codecharta:model:src/test/java/de/maibornwolff/codecharta/nodeinserter/FileSystemPathTest.java",
+      "name": "FileSystemPathTest.java",
+      "qualifier": "UTS",
+      "path": "src/test/java/de/maibornwolff/codecharta/nodeinserter/FileSystemPathTest.java",
+      "language": "java",
+      "measures": []
+    }
+  ]
+}

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_3.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_3.json
@@ -1,8 +1,8 @@
 {
   "paging": {
     "pageIndex": 3,
-    "pageSize": 2,
-    "total": 5
+    "pageSize": 500,
+    "total": 1499
   },
   "baseComponent": {
     "id": "AVpgljwSAwvKRXcPxJMX",
@@ -32,29 +32,16 @@
   },
   "components": [
     {
-      "id": "AVpglkG6K9udye1JocV_",
-      "key": "de.maibornwolff.codecharta:codecharta:import",
-      "name": "import",
-      "qualifier": "BRC",
-      "path": "import",
+      "id": "AVpmw6eEK9udye1JpWHR",
+      "key": "de.maibornwolff.codecharta:codecharta:import:SonarImporter:src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarXMLImport.java",
+      "name": "SonarXMLImport.java",
+      "qualifier": "FIL",
+      "path": "src/main/java/de/maibornwolff/codecharta/importer/sonar/SonarXMLImport.java",
+      "language": "java",
       "measures": [
         {
           "metric": "coverage",
-          "value": "85.8",
-          "periods": [
-            {
-              "index": 1,
-              "value": "0.0"
-            },
-            {
-              "index": 2,
-              "value": "0.0"
-            },
-            {
-              "index": 3,
-              "value": "-0.7000000000000028"
-            }
-          ]
+          "value": "100.0"
         }
       ]
     }

--- a/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_3.json
+++ b/analysis/import/SonarImporter/src/test/resources/sonarqube_measures_paged_3.json
@@ -1,0 +1,62 @@
+{
+  "paging": {
+    "pageIndex": 3,
+    "pageSize": 2,
+    "total": 5
+  },
+  "baseComponent": {
+    "id": "AVpgljwSAwvKRXcPxJMX",
+    "key": "de.maibornwolff.codecharta:codecharta",
+    "name": "codecharta",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "coverage",
+        "value": "85.1",
+        "periods": [
+          {
+            "index": 1,
+            "value": "0.0"
+          },
+          {
+            "index": 2,
+            "value": "0.0"
+          },
+          {
+            "index": 3,
+            "value": "0.0"
+          }
+        ]
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AVpglkG6K9udye1JocV_",
+      "key": "de.maibornwolff.codecharta:codecharta:import",
+      "name": "import",
+      "qualifier": "BRC",
+      "path": "import",
+      "measures": [
+        {
+          "metric": "coverage",
+          "value": "85.8",
+          "periods": [
+            {
+              "index": 1,
+              "value": "0.0"
+            },
+            {
+              "index": 2,
+              "value": "0.0"
+            },
+            {
+              "index": 3,
+              "value": "-0.7000000000000028"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/node-wrapper/package-lock.json
+++ b/analysis/node-wrapper/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@maibornwolff/codecharta-analysis",
+  "name": "codecharta-analysis",
   "version": "1.11.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
# Paging bug in sonar importer

## Description

Fixes a bug which prevented the data access to fetch the correct number of pages and causing missing data.

First bug: 
`total items / PAGE_SIZE + 1 =/= number of pages` if items is 250 and PAGE_SIZE is 50.

Second bug: 
`++page < total / PAGE_SIZE + 1` is false not the correct loop condition.

Assuming we have 251 Entries, a page size of 50 and start at page 0. We should expect 6 loops.

* ++0 < 251 / 50 +1
* 1 < 251 / 50 +1
* 1 < 5 + 1 
* loop 1
* ++1 < 6
* 2 < 6
* loop 2
* ...
* ++5 < 6
* 6 < 6
* end / no loop 6

==> only 5 loops due to integer division. 251 divided by 50 (both integer types) results in 5.

The new implementation uses `do {...} while(page++ * PAGE_SIZE < total)` 
Assuming we have 251 Entries, a page size of 50 and start at page 1. We should expect 6 loops.

* loop 1
* 1++ * 50 < 251 => true, 50 < 251 (because of postfixed ++)
* loop 2
* ...
* 5++ * 50 < 250 => true, 250 < 250 (because of postfixed ++)
* loop 6

Importing the hadoop project on sonar resulted in 6247 elements on 13 pages with page size 500. The previous solution resulted in 12 pages. 

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
