### PR TITLE
Extend crococosmoimporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 - Added type, dirs, name to CSVExporter
 
 ### Changed
-
+- Crococosmo xml files will now generate a cc.json file for each version
+ 
 ### Removed
 
 ### Fixed

--- a/analysis/import/CrococosmoImporter/README.md
+++ b/analysis/import/CrococosmoImporter/README.md
@@ -10,7 +10,7 @@ Please contact this team concerning questions about Crococosmo.
 
 ## Usage
 
-Output goes to *stdout*.
+Output goes to *stdout* or to a file if specified by '-o'.
 
 ### Example
 

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverter.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverter.kt
@@ -29,18 +29,29 @@
 
 package de.maibornwolff.codecharta.importer.crococosmo
 
+import de.maibornwolff.codecharta.importer.crococosmo.model.Graph
+import de.maibornwolff.codecharta.importer.crococosmo.model.SchemaVersion
+import de.maibornwolff.codecharta.importer.crococosmo.model.Version
 import de.maibornwolff.codecharta.model.Node
 import de.maibornwolff.codecharta.model.NodeType
 import de.maibornwolff.codecharta.model.Project
-import de.maibornwolff.codecharta.importer.crococosmo.model.Graph
-import de.maibornwolff.codecharta.importer.crococosmo.model.Version
 
 class CrococosmoConverter {
 
-    fun convertToProject(projectName: String, graph: Graph): Project {
-        val version = graph.schema.versions.versions.first().id
-        return Project(projectName, createNodeListForProject(graph.nodes, version))
+    fun convertToProjectsMap(projectName: String, graph: Graph): Map<String, Project> {
+        return graph.schema.versions.versions
+                .associateBy({ createVersionName(it) }, { createProject(projectName, graph, it.id) })
     }
+
+    private fun createVersionName(it: SchemaVersion) =
+            when {
+                it.name.isNotEmpty() -> it.name
+                it.revision.isNotEmpty() -> it.revision
+                else -> it.id
+            }
+
+    fun createProject(projectName: String, graph: Graph, version: String = graph.schema.versions.versions.first().id) =
+            Project(projectName, createNodeListForProject(graph.nodes, version))
 
     private fun createNodeListForProject(nodes: List<de.maibornwolff.codecharta.importer.crococosmo.model.Node>, version: String): List<Node> {
         return listOf(Node("rootNode", NodeType.Folder, mapOf(), "", convertToNodeList(nodes, version)))

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
@@ -42,6 +42,6 @@ class Versions(@JsonProperty("version") val versions: List<SchemaVersion>)
 @JsonIgnoreProperties("date")
 class SchemaVersion(
         @JsonProperty("id") val id: String,
-        @JsonProperty("name") val name: String,
-        @JsonProperty("revision") val revision: String
+        @JsonProperty("name") val name: String = "",
+        @JsonProperty("revision") val revision: String = ""
 )

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
@@ -39,5 +39,9 @@ class Schema(@JsonProperty("versions") val versions: Versions) {
 
 class Versions(@JsonProperty("version") val versions: List<SchemaVersion>)
 
-@JsonIgnoreProperties("date", "name", "revision")
-class SchemaVersion(@JsonProperty("id") val id: String)
+@JsonIgnoreProperties("date")
+class SchemaVersion(
+        @JsonProperty("id") val id: String,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("revision") val revision: String
+)


### PR DESCRIPTION
# Extend crococosmoimporter

## Description

Extended experimental crococosmoimporter to generate multiple cc.json form one crococosmo xml

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [ ] **All** requirements mentioned in the issue are implemented
* [ ] Does match the Code of Conduct and the Contribution file 
* [ ] Task has its own **GitHub issue** (something it is solving)
  * [ ] Issue number is **included in the commit messages** for traceability
* [ ] **Update the README.md** with any changes/additions made
* [ ] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [ ] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [ ] **Manual testing** did not fail
