### PR TITLE
maximal margin set to 100 and testing

### DIFF
--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -271,7 +271,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
             margin = SettingsService.MARGIN_FACTOR * Math.round(Math.sqrt(
                 (totalArea / numberOfBuildings)));
 
-            margin = Math.max(SettingsService.MIN_MARGIN, margin);
+            margin = Math.min(100,Math.max(SettingsService.MIN_MARGIN, margin));
         }
 
         else {

--- a/visualization/app/codeCharta/core/settings/settings.spec.ts
+++ b/visualization/app/codeCharta/core/settings/settings.spec.ts
@@ -19,7 +19,7 @@ describe("settings.service", function() {
             "children": [
                 {
                     "name": "big leaf",
-                    "attributes": {"rloc": 100, "functions": 10, "mcc": 1},
+                    "attributes": {"rloc": 100, "functions": 10, "mcc": 1, "extremeMetric": 100000},
                     "link": "http://www.google.de"
                 },
                 {
@@ -28,12 +28,12 @@ describe("settings.service", function() {
                     "children": [
                         {
                             "name": "small leaf",
-                            "attributes": {"rloc": 30, "functions": 100, "mcc": 100},
+                            "attributes": {"rloc": 30, "functions": 100, "mcc": 100, "extremeMetric": 100000},
                             "children": []
                         },
                         {
                             "name": "other small leaf",
-                            "attributes": {"rloc": 70, "functions": 1000, "mcc": 10},
+                            "attributes": {"rloc": 70, "functions": 1000, "mcc": 10, "extremeMetric": 100000},
                             "children": []
                         }
                     ]
@@ -66,6 +66,11 @@ describe("settings.service", function() {
     it("compute margin should return default margin if metric does not exist", NGMock.mock.inject(function(settingsService: SettingsService){
         let computed = settingsService.computeMargin(validData, "nonExistant", 2, true);
         expect(computed).toBe(SettingsService.MIN_MARGIN);
+    }));
+
+    it("compute margin should return 100 as margin if computed margin bigger als 100 is", NGMock.mock.inject(function(settingsService: SettingsService){
+        let computed = settingsService.computeMargin(validData, "extremeMetric", 2, true);
+        expect(computed).toBe(100);
     }));
     
     //noinspection TypeScriptUnresolvedVariable


### PR DESCRIPTION
Too big margin avoidance

## Description

When the mean area was too long the margin was bigger than 100, which does not match to the slider and buttons maximal margin, 100. 
Maximal margin was set to 100 also for dynamic margin computing

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [ ] Task has its own **GitHub issue** (something it is solving)
  * [ ] Issue number is **included in the commit messages** for traceability
* [ ] **Update the README.md** with any changes/additions made
* [ ] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail