### PR TITLE
Feature/153/labeling packages in legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
 ### Added
+- Show names of marked packages in legend
 
 ### Changed
 

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -50,7 +50,6 @@ export interface Settings {
     maximizeDetailPanel: boolean;
     invertHeight: boolean;
     dynamicMargin: boolean;
-    markingPackages: MarkingPackages[];
 }
 
 export interface SettingsServiceSubscriber {
@@ -121,8 +120,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
             showDependencies: false,
             maximizeDetailPanel: false,
             invertHeight: false,
-            dynamicMargin: true,
-            markingPackages: []
+            dynamicMargin: true
         };
 
         return settings;
@@ -391,7 +389,6 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
         this._settings.maximizeDetailPanel = settings.maximizeDetailPanel;
         this._settings.invertHeight = settings.invertHeight;
         this._settings.dynamicMargin = settings.dynamicMargin;
-        this._settings.markingPackages = settings.markingPackages;
 
         //TODO what to do with map ? should it even be a part of settings ? deep copy of map ?
         this._settings.map = settings.map || this.settings.map;

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -22,6 +22,16 @@ export interface Scale {
     z: number;
 }
 
+export interface MarkingPackages {
+    markingColor: string,
+    packageItem: PackageItem[],
+}
+
+export interface PackageItem {
+    name: string,
+    path: string,
+}
+
 export interface Settings {
 
     map: CodeMap;
@@ -40,6 +50,7 @@ export interface Settings {
     maximizeDetailPanel: boolean;
     invertHeight: boolean;
     dynamicMargin: boolean;
+    markingPackages: MarkingPackages[];
 }
 
 export interface SettingsServiceSubscriber {
@@ -110,7 +121,8 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
             showDependencies: false,
             maximizeDetailPanel: false,
             invertHeight: false,
-            dynamicMargin: true
+            dynamicMargin: true,
+            markingPackages: []
         };
 
         return settings;
@@ -379,6 +391,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
         this._settings.maximizeDetailPanel = settings.maximizeDetailPanel;
         this._settings.invertHeight = settings.invertHeight;
         this._settings.dynamicMargin = settings.dynamicMargin;
+        this._settings.markingPackages = settings.markingPackages;
 
         //TODO what to do with map ? should it even be a part of settings ? deep copy of map ?
         this._settings.map = settings.map || this.settings.map;

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -22,16 +22,6 @@ export interface Scale {
     z: number;
 }
 
-export interface MarkingPackages {
-    markingColor: string,
-    packageItem: PackageItem[],
-}
-
-export interface PackageItem {
-    name: string,
-    path: string,
-}
-
 export interface Settings {
 
     map: CodeMap;

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -1,6 +1,6 @@
 import {CodeMapNode} from "../../core/data/model/CodeMap";
 import {hierarchy} from "d3-hierarchy";
-import {MarkingPackages, SettingsService} from "../../core/settings/settings.service";
+import {SettingsService} from "../../core/settings/settings.service";
 import {ThreeOrbitControlsService} from "./threeViewer/threeOrbitControlsService";
 
 export class CodeMapActionsService {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -44,7 +44,6 @@ export class CodeMapActionsService {
             }
         };
         recFn(node);
-        this.addPackageLabelToLegend(node, color.substr(1));
         this.apply();
     }
 
@@ -59,42 +58,7 @@ export class CodeMapActionsService {
             }
         };
         recFn(node);
-        this.removePackageLabelFromLegend(node);
         this.apply();
-    }
-
-    private addPackageLabelToLegend(node: CodeMapNode, newColor: string) {
-        const markingPackages = this.settingsService.settings.markingPackages;
-        const markingPackageItem : MarkingPackages = {
-            markingColor: newColor,
-            packageItem: [{name: node.name, path: node.path}]
-        };
-
-        if(markingPackages) {
-            for(const pl of markingPackages) {
-                if (pl.packageItem[0].name == markingPackageItem.packageItem[0].name) {
-                    const index = markingPackages.indexOf(pl);
-                    this.settingsService.settings.markingPackages.splice(index);
-                }
-            }
-            this.settingsService.settings.markingPackages.push(markingPackageItem);
-        } else {
-            this.settingsService.settings.markingPackages = [markingPackageItem];
-        }
-    }
-
-    private removePackageLabelFromLegend(node: CodeMapNode) {
-        const markingPackages = this.settingsService.settings.markingPackages;
-
-        if(markingPackages) {
-            for(var i = 0; i < markingPackages.length; i++) {
-
-                if( markingPackages[i].packageItem[0].path.indexOf(node.path) >= 0){
-                    const index = markingPackages.indexOf(markingPackages[i]);
-                    this.settingsService.settings.markingPackages.splice(index);
-                }
-            }
-        }
     }
 
     isolateNode(node: CodeMapNode) {

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
@@ -27,8 +27,8 @@
     </div>
     <div class="legend-block" ng-if="$ctrl.markingPackages" ng-repeat="markingPackage in $ctrl.markingPackages">
         <img src="{{::markingPackage.markingColor}}">
-        <span ng-repeat="item in markingPackage.packageItem">
-            <span title="{{::item.path}}">{{::item.name}}{{$last ? '' : ',&nbsp;'}}</span>
+        <span class="{{$first ? '' : 'set-left-margin'}}" ng-repeat="item in markingPackage.packageItem" title="{{::item.path}}">
+            {{::item.name}}{{$last ? '' : ',&nbsp;'}}
         </span>
     </div>
 </div>

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
@@ -25,6 +25,12 @@
         <img id="negativeDelta" alt="negative delta color">
         -&Delta;
     </div>
+    <div class="legend-block" ng-if="$ctrl.markingPackages" ng-repeat="markingPackage in $ctrl.markingPackages">
+        <img src="{{::markingPackage.markingColor}}">
+        <span ng-repeat="item in markingPackage.packageItem">
+            <span title="{{::item.path}}">{{::item.name}}</span><span ng-if="::item.isLast">{{::item.isLast}}</span>
+        </span>
+    </div>
 </div>
 <md-button class="panel-button md-raised md-primary dark_shadow_opacity" ng-click="$ctrl.toggle()">Legend</md-button>
 

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
@@ -25,6 +25,7 @@
         <img id="negativeDelta" alt="negative delta color">
         -&Delta;
     </div>
+    <hr ng-show="$ctrl.markingPackages[0]">
     <div class="legend-block" ng-if="$ctrl.markingPackages" ng-repeat="markingPackage in $ctrl.markingPackages">
         <img src="{{::markingPackage.markingColor}}">
         <span class="{{$first ? '' : 'set-left-margin'}}" ng-repeat="item in markingPackage.packageItem" title="{{::item.path}}">

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.html
@@ -28,7 +28,7 @@
     <div class="legend-block" ng-if="$ctrl.markingPackages" ng-repeat="markingPackage in $ctrl.markingPackages">
         <img src="{{::markingPackage.markingColor}}">
         <span ng-repeat="item in markingPackage.packageItem">
-            <span title="{{::item.path}}">{{::item.name}}</span><span ng-if="::item.isLast">{{::item.isLast}}</span>
+            <span title="{{::item.path}}">{{::item.name}}{{$last ? '' : ',&nbsp;'}}</span>
         </span>
     </div>
 </div>

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
@@ -18,6 +18,14 @@ legend-panel-component {
     background-color: #fff;
     padding: 10px;
 
+
+    hr {
+      border-right-style: none;
+      border-left-style: none;
+      border-bottom-style: none;
+      color: #000;
+    }
+
     .legend-block {
 
       display: block;
@@ -46,7 +54,6 @@ legend-panel-component {
       .set-left-margin {
          margin-left: 18px;
        }
-
 
     }
 

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
@@ -21,7 +21,7 @@ legend-panel-component {
     .legend-block {
 
       display: block;
-      height: 25px;
+      min-height: 25px;
       margin-bottom: 5px;
       max-width: 250px;
 
@@ -42,6 +42,11 @@ legend-panel-component {
       span {
         display: inline-block;
       }
+
+      .set-left-margin {
+         margin-left: 18px;
+       }
+
 
     }
 

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.scss
@@ -23,6 +23,7 @@ legend-panel-component {
       display: block;
       height: 25px;
       margin-bottom: 5px;
+      max-width: 250px;
 
       i, img {
         display: inline-block;

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
@@ -13,7 +13,6 @@ import {STATISTIC_OPS} from "../../core/statistic/statistic.service";
 import "./legendPanel.scss";
 import {CodeMapNode} from "../../core/data/model/CodeMap";
 import {hierarchy} from "d3-hierarchy";
-import Code = marked.Tokens.Code;
 
 export class LegendPanelController implements DataServiceSubscriber, SettingsServiceSubscriber {
 
@@ -84,7 +83,6 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
                     const mp = this.getNewMarkingPackageFromNode(node);
                     if (this.legendContainsMarkingPackages()) {
                         this.handleMarkingPackageWithExistingColor(mp);
-
                     } else {
                         this.markingPackages = [mp];
                     }

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
@@ -51,22 +51,6 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
         this.dataService.subscribe(this);
 
         this.initAnimations();
-
-        //this.testData();
-
-    }
-
-    private testData() {
-        this.markingPackages = [
-            {
-                markingColor: this.getImageDataUri(Number("0xFFF000")),
-                packageItem: [{
-                    name: "mytest.kt",
-                    path: "/src/maibornwolff/kotlin/mytest.kt",
-                }],
-            },
-
-        ];
     }
 
     onDataChanged(data: DataModel) {
@@ -164,7 +148,7 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
                 var markingPackage: MarkingPackages = {
                     markingColor: this.getImageDataUri(Number(allMP[i].markingColor)),
                     packageItem: [{
-                        name: allMP[i].packageItem[0].name,
+                        name: this.getPackagePathPreview(allMP[i]),
                         path: allMP[i].packageItem[0].path,
                     }],
                 };
@@ -177,6 +161,31 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
                     this.markingPackages.push(markingPackage);
                 }
             }
+        }
+    }
+
+    getPackagePathPreview(mp: MarkingPackages) {
+        const MAX_NAME_LENGTH = {
+            lowerLimit: 24,
+            upperLimit: 28,
+        };
+        const packageName = mp.packageItem[0].name;
+        const packagePath = mp.packageItem[0].path;
+
+        if (packageName.length > MAX_NAME_LENGTH.lowerLimit && packageName.length < MAX_NAME_LENGTH.upperLimit) {
+            return ".../" + packageName;
+
+        } else if (packageName.length > MAX_NAME_LENGTH.upperLimit) {
+            const firstPart = packageName.substr(0, MAX_NAME_LENGTH.lowerLimit / 2);
+            const secondPart = packageName.substr(packageName.length - MAX_NAME_LENGTH.lowerLimit / 2);
+            return firstPart + "..." + secondPart;
+
+        } else {
+            const from = Math.max(packagePath.length - MAX_NAME_LENGTH.lowerLimit, 0);
+            const previewPackagePath = packagePath.substring(from);
+            const rootNode = this.settingsService.settings.map.root;
+            const startingDots = (previewPackagePath.startsWith(rootNode.path)) ? "" : "...";
+            return startingDots + previewPackagePath;
         }
     }
 

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
@@ -52,6 +52,21 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
 
         this.initAnimations();
 
+        //this.testData();
+
+    }
+
+    private testData() {
+        this.markingPackages = [
+            {
+                markingColor: this.getImageDataUri(Number("0xFFF000")),
+                packageItem: [{
+                    name: "mytest.kt",
+                    path: "/src/maibornwolff/kotlin/mytest.kt",
+                }],
+            },
+
+        ];
     }
 
     onDataChanged(data: DataModel) {
@@ -75,7 +90,7 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
 
 
     private setMarkingPackagesIntoLegend() {
-        this.settingsService.settings.markingPackages = [];
+        this.markingPackages = [];
         if (this.settingsService.settings.map) {
             var rootNode: CodeMapNode = this.settingsService.settings.map.root;
 
@@ -87,7 +102,7 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
                         this.handleMarkingPackageWithExistingColor(mp);
 
                     } else {
-                        this.settingsService.settings.markingPackages = [mp];
+                        this.markingPackages = [mp];
                     }
                 }
             });
@@ -95,9 +110,9 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
     }
 
     private legendContainsMarkingPackages() {
-        return this.settingsService.settings.markingPackages &&
-            this.settingsService.settings.markingPackages.length > 0 &&
-            this.settingsService.settings.markingPackages != [];
+        return this.markingPackages &&
+            this.markingPackages.length > 0 &&
+            this.markingPackages != [];
     }
 
     private getNewMarkingPackageFromNode(node: CodeMapNode) {
@@ -112,7 +127,7 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
 
     private handleMarkingPackageWithExistingColor(mp: MarkingPackages) {
         var addMP = true;
-        const packagesWithSameMarkingColor: MarkingPackages[] = this.getPackagesWithSameMarkingColor(mp, this.settingsService.settings.markingPackages);
+        const packagesWithSameMarkingColor: MarkingPackages[] = this.getPackagesWithSameMarkingColor(mp);
         if (packagesWithSameMarkingColor != []) {
             for (const mpWithSameColor of packagesWithSameMarkingColor) {
                 if (this.isPartOfSecondPackage(mp, mpWithSameColor)) {
@@ -123,13 +138,13 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
             addMP = true;
         }
         if (addMP) {
-            this.settingsService.settings.markingPackages.push(mp);
+            this.markingPackages.push(mp);
         }
     }
 
-    private getPackagesWithSameMarkingColor(mp: MarkingPackages, allMP: MarkingPackages[]) {
+    private getPackagesWithSameMarkingColor(mp: MarkingPackages) {
         var packagesWithSameMarkingColor: MarkingPackages[] = [];
-        for(const otherMP of allMP) {
+        for(const otherMP of this.markingPackages) {
             if (otherMP.markingColor == mp.markingColor) {
                 packagesWithSameMarkingColor.push(otherMP);
             }
@@ -141,7 +156,8 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
         return mp1.packageItem[0].path.indexOf(mp2.packageItem[0].path) >= 0;
     }
 
-    private combineMarkingPackagesByColors(allMP: MarkingPackages[]) {
+    private combineMarkingPackagesByColors() {
+        const allMP = this.markingPackages;
         this.markingPackages = [];
         if (allMP) {
             for (var i = 0; i < allMP.length; i++) {
@@ -153,13 +169,9 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
                     }],
                 };
 
-                const markingPackageWithSameColor = this.getPackagesWithSameMarkingColor(markingPackage, this.markingPackages);
+                const markingPackageWithSameColor = this.getPackagesWithSameMarkingColor(markingPackage);
                 if (markingPackageWithSameColor != [] && markingPackageWithSameColor.length > 0) {
-                    console.log(markingPackageWithSameColor);
                     const index = this.markingPackages.indexOf(markingPackageWithSameColor[0]);
-                    console.log(index);
-                    console.log(this.markingPackages[index].packageItem);
-                    console.log(markingPackage.packageItem[0]);
                     this.markingPackages[index].packageItem.push(markingPackage.packageItem[0]);
                 } else {
                     this.markingPackages.push(markingPackage);
@@ -189,7 +201,7 @@ export class LegendPanelController implements DataServiceSubscriber, SettingsSer
 
         this.refreshDeltaColors();
         this.setMarkingPackagesIntoLegend();
-        this.combineMarkingPackagesByColors(s.markingPackages);
+        this.combineMarkingPackagesByColors();
     }
 
     getImageDataUri(hex: number): string {

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts
@@ -3,8 +3,7 @@ import {
     SettingsServiceSubscriber,
     SettingsService,
     Settings,
-    Range,
-    MarkingPackages
+    Range
 } from "../../core/settings/settings.service";
 import $ from "jquery";
 import {MapColors} from "../codeMap/rendering/renderSettings";
@@ -13,6 +12,16 @@ import {STATISTIC_OPS} from "../../core/statistic/statistic.service";
 import "./legendPanel.scss";
 import {CodeMapNode} from "../../core/data/model/CodeMap";
 import {hierarchy} from "d3-hierarchy";
+
+export interface MarkingPackages {
+    markingColor: string,
+    packageItem: PackageItem[],
+}
+
+export interface PackageItem {
+    name: string,
+    path: string,
+}
 
 export class LegendPanelController implements DataServiceSubscriber, SettingsServiceSubscriber {
 


### PR DESCRIPTION
# Feature/153/labeling packages in legend

## Description

solves #153 

The Legend now shows the package names and paths of the packages, which were assigned to a marking color. As an example an image of the legend:

<img width="30%" src="https://user-images.githubusercontent.com/23529226/43607258-fb25a8ea-969d-11e8-96d9-2ca8be1c37dc.jpg">

- Hovering over the package name shows a tooltip-title with the full path
- The overall length of the shown path is set variably with [`MAX_NAME_LENGTH`](https://github.com/MaibornWolff/codecharta/blob/feature/153/labeling-packages-in-legend/visualization/app/codeCharta/ui/legendPanel/legendPanelComponent.ts#L166)
1. When the package name is short enough: a part of the package path is shown
2. When the package name is too long: it shows the first and last part with ... in between

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail