### PR TITLE
Feature/multiple files in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
 ### Added
-
+- add the option to add multiple files via url parameter (e.g. ?file=a&file=b...)
 ### Changed
 
 ### Removed

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -71,7 +71,7 @@ certain settings. Query params are added by appending a `?` to the url,
 followed by a key value pair `key=value`. Additional parameters can be 
 added by appending `&key2=value2`. E.g. `http://yourdomain.com/pathtocc/index.html?file=something.json&scaling.x=2&areaMetric=myMetric`
 
-* The `file` parameter is a special parameter which accepts a file location. The file must be reachable through XHR.
+* The `file` parameter is a special parameter which accepts a file location. The file must be reachable through XHR. You can use this parameter multiple times in order to load more than one map e.g. `http://localhost:3000/?file=firefox.json&file=firefox_single_delta.json`
 * All other parameters are defined by the [Settings class](/visualization/app/codeCharta/core/settings/model/settings.js). 
 `areaMetric=myMetric` therefore sets the value of settings.areaMetric to `myMetric`. Nested properties like `settings.scale.x` can be 
 set by the query parameter `scaling.x=42`

--- a/visualization/app/codeCharta/codeCharta.component.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.component.spec.ts
@@ -6,8 +6,7 @@ import {SettingsService} from "./core/settings/settings.service";
 import {ScenarioService} from "./core/scenario/scenario.service";
 import {ThreeOrbitControlsService} from "./ui/codeMap/threeViewer/threeOrbitControlsService";
 import {DataLoadingService} from "./core/data/data.loading.service";
-import {UrlService} from "./core/url/url.service";
-import {IRootScopeService} from "angular";
+import {NameDataPair, UrlService} from "./core/url/url.service";
 import {NodeContextMenuComponent} from "./ui/nodeContextMenu/nodeContextMenu.component";
 
 jest.mock("./core/data/data.service");
@@ -32,6 +31,8 @@ describe("codecharta component", ()=>{
     let dialogService: DialogService;
 
     let tmpEventListener;
+
+    let singleNameDataPair: NameDataPair[] = [{name: "a", data: {}}];
 
     beforeEach(()=>{
         tmpEventListener = document.body.addEventListener;
@@ -66,50 +67,57 @@ describe("codecharta component", ()=>{
         document.body.addEventListener = tmpEventListener;
     });
 
-    describe("#trySettingGivenData",()=>{
+    describe("#tryLoadingFiles",()=>{
 
         it("should try to load file with the correct indices",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(dataLoadingService.loadMapFromFileContent).toHaveBeenCalledWith("a", expect.anything(), 0);
         });
 
         it("should apply scenario ONCE when map is loaded",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(scenarioService.applyScenarioOnce).toHaveBeenCalled();
+        });
+
+        it("should apply scenario NOT ONCE when map is loaded and flag is set",async ()=>{
+            dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
+            await cc.tryLoadingFiles(singleNameDataPair, false);
+            expect(scenarioService.applyScenarioOnce).not.toHaveBeenCalled();
+            expect(scenarioService.applyScenario).toHaveBeenCalled();
         });
 
         it("should update settings by url params when map is loaded",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(settingsService.updateSettingsFromUrl).toHaveBeenCalled();
         });
 
         it("should decrement loading tasks when map is loaded",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
             cc.viewModel.numberOfLoadingTasks = 99;
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(cc.viewModel.numberOfLoadingTasks).toBe(98);
         });
 
         it("should print errors when map is loaded",async ()=>{
             cc.printErrors = jest.fn();
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.reject());
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(cc.printErrors).toHaveBeenCalled();
         });
 
         it("should decrement loading tasks when sample map is not loaded",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.reject());
             cc.viewModel.numberOfLoadingTasks = 99;
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(cc.viewModel.numberOfLoadingTasks).toBe(98);
         });
 
         it("should set maps correctly when map is loaded",async ()=>{
             dataLoadingService.loadMapFromFileContent = jest.fn(() => Promise.resolve());
-            await cc.trySettingGivenData("a", {});
+            await cc.tryLoadingFiles(singleNameDataPair);
             expect(dataService.setComparisonMap).toHaveBeenCalledWith(0);
             expect(dataService.setReferenceMap).toHaveBeenCalledWith(0);
         });
@@ -168,31 +176,23 @@ describe("codecharta component", ()=>{
 
     describe("#loadFileOrSample",()=>{
 
-        it("should show error dialog when url param is valid and maps cannot be loaded",async ()=>{
-            cc.tryLoadingSampleFiles = jest.fn();
-            cc.trySettingGivenData = jest.fn();
+        it("should show error dialog when url param is valid and maps cannot be loaded amd load sample data",async ()=>{
+            cc.tryLoadingFiles = jest.fn();
             urlService.getParam = jest.fn(()=>"some file that should have been loaded");
             urlService.getFileDataFromQueryParam = jest.fn(() => Promise.reject());
             await cc.loadFileOrSample();
             expect(dialogService.showErrorDialog).toHaveBeenCalled();
-        });
-
-        it("should load sample with no warning if file parameter is not set and therefore no valid data exists",async ()=>{
-            cc.tryLoadingSampleFiles = jest.fn();
-            cc.trySettingGivenData = jest.fn();
-            urlService.getParam = jest.fn(()=>null);
-            urlService.getFileDataFromQueryParam = jest.fn(() => Promise.reject());
-            await cc.loadFileOrSample();
-            expect(cc.tryLoadingSampleFiles).toHaveBeenCalled();
-            expect(dialogService.showErrorDialog).not.toHaveBeenCalled();
-            expect(cc.trySettingGivenData).not.toHaveBeenCalled();
+            expect(cc.tryLoadingFiles).toHaveBeenCalledWith([
+                { name: "sample1.json", data: require("./assets/sample1.json") },
+                { name: "sample2.json", data: require("./assets/sample2.json") },
+            ], false);
         });
 
         it("should try setting given data if file in url is valid",async ()=>{
-            cc.trySettingGivenData = jest.fn();
+            cc.tryLoadingFiles = jest.fn();
             urlService.getFileDataFromQueryParam = jest.fn(() => Promise.resolve("SOME_DATA"));
             await cc.loadFileOrSample();
-            expect(cc.trySettingGivenData).toHaveBeenCalled();
+            expect(cc.tryLoadingFiles).toHaveBeenCalled();
         });
 
         it("should increase number of loading tasks",async ()=>{

--- a/visualization/app/codeCharta/codeCharta.component.ts
+++ b/visualization/app/codeCharta/codeCharta.component.ts
@@ -1,16 +1,13 @@
 import {DataLoadingService} from "./core/data/data.loading.service";
-import {UrlService} from "./core/url/url.service";
+import {NameDataPair, UrlService} from "./core/url/url.service";
 import {SettingsService} from "./core/settings/settings.service";
 import {ScenarioService} from "./core/scenario/scenario.service";
 import {DataService} from "./core/data/data.service";
-import $ from "jquery";
 import {IRootScopeService} from "angular";
 import "./codeCharta.component.scss";
 import {DialogService} from "./ui/dialog/dialog.service";
-import {queryParamDialog} from "./ui/dialog/queryParam.dialog";
 import {ThreeOrbitControlsService} from "./ui/codeMap/threeViewer/threeOrbitControlsService";
-import {nodeContextMenuComponent, NodeContextMenuComponent} from "./ui/nodeContextMenu/nodeContextMenu.component";
-
+import {NodeContextMenuComponent} from "./ui/nodeContextMenu/nodeContextMenu.component";
 
 /**
  * This is the main controller of the CodeCharta application
@@ -68,22 +65,34 @@ export class CodeChartaController {
     loadFileOrSample() {
         this.viewModel.numberOfLoadingTasks++;
         return this.urlService.getFileDataFromQueryParam().then(
-            (data)=>{
-                this.trySettingGivenData(this.urlService.getParam("file"), data);
-            },
-            ()=>{
-                if(this.urlService.getParam("file")){
-                    this.dialogService.showErrorDialog("File from the given file URL parameter could not be loaded. Loading sample files instead.");
+            (data: NameDataPair[])=>{
+                if(data.length > 0) {
+                    this.tryLoadingFiles(data);
+                } else {
+                    this.tryLoadingSampleFiles();
                 }
-                this.tryLoadingSampleFiles();
-            }
+            },
+            this.tryLoadingSampleFiles.bind(this)
         );
     }
 
-    trySettingGivenData(name, data) {
-        this.dataLoadingService.loadMapFromFileContent(name, data, 0).then(
+    tryLoadingFiles(nameDataPairs: NameDataPair[], applyScenarioOnce = true) {
+
+        let tasks = [];
+
+        nameDataPairs.forEach((o, i)=>{
+           tasks.push(
+               this.dataLoadingService.loadMapFromFileContent(o.name, o.data, i)
+           );
+        });
+
+        return Promise.all(tasks).then(
             () => {
-                this.scenarioService.applyScenarioOnce(this.scenarioService.getDefaultScenario());
+                if(applyScenarioOnce) {
+                    this.scenarioService.applyScenarioOnce(this.scenarioService.getDefaultScenario());
+                } else {
+                    this.scenarioService.applyScenario(this.scenarioService.getDefaultScenario());
+                }
                 this.dataService.setComparisonMap(0);
                 this.dataService.setReferenceMap(0);
                 this.settingsService.updateSettingsFromUrl();
@@ -94,25 +103,17 @@ export class CodeChartaController {
                 this.viewModel.numberOfLoadingTasks--;
             }
         );
+
     }
 
     tryLoadingSampleFiles() {
-        return Promise.all([
-            this.dataLoadingService.loadMapFromFileContent("sample1.json", require("./assets/sample1.json"), 0),
-            this.dataLoadingService.loadMapFromFileContent("sample2.json", require("./assets/sample2.json"), 1)
-        ]).then(
-            () => {
-                this.scenarioService.applyScenario(this.scenarioService.getDefaultScenario());
-                this.dataService.setComparisonMap(0);
-                this.dataService.setReferenceMap(0);
-                this.settingsService.updateSettingsFromUrl();
-                this.viewModel.numberOfLoadingTasks--;
-            },
-            (r) => {
-                this.printErrors(r);
-                this.viewModel.numberOfLoadingTasks--;
-            }
-        );
+        if(this.urlService.getParam("file")){
+            this.dialogService.showErrorDialog("One or more files from the given file URL parameter could not be loaded. Loading sample files instead.");
+        }
+        return this.tryLoadingFiles([
+            { name: "sample1.json", data: require("./assets/sample1.json") },
+            { name: "sample2.json", data: require("./assets/sample2.json") },
+        ], false);
     }
 
     printErrors(errors: Object) {

--- a/visualization/app/codeCharta/core/data/data.loading.service.ts
+++ b/visualization/app/codeCharta/core/data/data.loading.service.ts
@@ -20,11 +20,7 @@ export class DataLoadingService {
      * @returns {Promise} which resolves when the filecontent is valid and stored in dataService.
      * The Promise rejects when errors happen. The errors are provided as parameters of the rejection function
      */
-    loadMapFromFileContent(fileName: string, fileContent: any, revision: number): Promise<CodeMap> {
-
-        if (!revision) {
-            revision = 0;
-        }
+    loadMapFromFileContent(fileName: string, fileContent: any, revision: number = 0): Promise<CodeMap> {
 
         return new Promise((resolve, reject) => {
 

--- a/visualization/app/codeCharta/core/url/url.spec.ts
+++ b/visualization/app/codeCharta/core/url/url.spec.ts
@@ -2,7 +2,7 @@ import {NGMock} from "../../../../mocks/ng.mockhelper";
 import {IRootScopeService, ILocationService, IHttpBackendService} from "angular";
 import DoneCallback = jest.DoneCallback;
 
-import {UrlService} from "./url.service";
+import {NameDataPair, UrlService} from "./url.service";
 import "./url.module";
 import {VALID_TEST_DATA} from "./url.mocks";
 import {CodeMap} from "../data/model/CodeMap";
@@ -41,8 +41,41 @@ describe("url.service", ()=>{
         $location.url(url);
 
         urlService.getFileDataFromQueryParam().then(
-            (data: CodeMap) => {
-                expect(data.fileName).toBe("valid.json");
+            (data: NameDataPair[]) => {
+                expect(data.length).toBe(1);
+                expect(data[0].name).toBe("valid.json");
+                done();
+            }
+        );
+
+        $httpBackend.flush();
+
+    });
+
+
+    it("file parameter should correctly resolve to multiple files", (done: DoneCallback) => {
+
+        // mocks + values
+        let url = "http://testurl?file=valid.json&file=other.json";
+
+        $httpBackend
+            .when("GET", "valid.json")
+            .respond(200, data);
+
+        let otherData = VALID_TEST_DATA;
+        otherData.fileName = "other.json";
+
+        $httpBackend
+            .when("GET", "other.json")
+            .respond(200, otherData);
+
+        $location.url(url);
+
+        urlService.getFileDataFromQueryParam().then(
+            (data: NameDataPair[]) => {
+                expect(data.length).toBe(2);
+                expect(data[0].name).toBe("valid.json");
+                expect(data[1].name).toBe("other.json");
                 done();
             }
         );
@@ -63,8 +96,8 @@ describe("url.service", ()=>{
         $location.url(url);
 
         urlService.getFileDataFromQueryParam().then(
-            (data: CodeMap) => {
-                expect(data.fileName).toBe("http://someurl.com/some.json");
+            (data: NameDataPair[]) => {
+                expect(data[0].name).toBe("http://someurl.com/some.json");
                 done();
             },() => {
                 done.fail("should succeed");

--- a/visualization/app/codeCharta/e2e/actionButtons.po.ts
+++ b/visualization/app/codeCharta/e2e/actionButtons.po.ts
@@ -1,0 +1,10 @@
+export class ActionButtonsPageObject {
+
+    constructor(private page) {}
+
+    async toggleSideMenu() {
+        const selector = '#actionButtons > button:nth-child(3)';
+        return this.page.click(selector);
+    }
+
+}

--- a/visualization/app/codeCharta/e2e/url.e2e.ts
+++ b/visualization/app/codeCharta/e2e/url.e2e.ts
@@ -1,0 +1,98 @@
+import {CC_URL, puppeteer} from "../../puppeteer.helper";
+import {RevisionChooserPageObject} from "../ui/revisionChooser/revisionChooser.po";
+import {ErrorDialogPageObject} from "../ui/dialog/errorDialog.po";
+import {ActionButtonsPageObject} from "./actionButtons.po";
+import {SettingsPanelPageObject} from "../ui/settingsPanel/settingsPanel.po";
+
+jest.setTimeout(15000);
+
+describe("codecharta",()=>{
+
+    let browser, page;
+
+    beforeEach(async ()=>{
+        browser = await puppeteer.launch(
+            {
+                headless: true,
+                args: ["--allow-file-access-from-files"]
+            }
+        );
+        page = await browser.newPage();
+    });
+
+    afterEach(async ()=>{
+        await browser.close();
+    });
+
+    async function navigateToRevisionChooser() {
+        let actionButtons = new ActionButtonsPageObject(page);
+        await page.waitFor(3000);
+        await actionButtons.toggleSideMenu();
+        let settingsPanel = new SettingsPanelPageObject(page);
+        await page.waitFor(1000);
+        return settingsPanel.toggleMapsPanel();
+    }
+
+    async function handleErrorDialog() {
+        let errorDialog = new ErrorDialogPageObject(page);
+        let msg = await errorDialog.getMessage();
+        expect(msg).toEqual("One or more files from the given file URL parameter could not be loaded. Loading sample files instead.");
+        await page.waitFor(1000);
+        return errorDialog.clickOk();
+    }
+
+    async function checkSelectedRevisionName(shouldBe: string) {
+        let revisionChooser = new RevisionChooserPageObject(page);
+        await page.waitFor(1000);
+        let name = await revisionChooser.getSelectedName();
+        expect(name).toEqual(shouldBe);
+    }
+
+    async function checkAllRevisionNames(shouldBe: string[]) {
+        let revisionChooser = new RevisionChooserPageObject(page);
+        await page.waitFor(1000);
+        await revisionChooser.clickChooser();
+        await page.waitFor(1000);
+        let names = await revisionChooser.getAllNames();
+        expect(names).toEqual(shouldBe);
+    }
+
+    async function mockResponses() {
+        await page.setRequestInterception(true);
+        page.on('request', request => {
+            if (request.url().includes("/fileOne.json")) {
+                request.respond({
+                    content: 'application/json',
+                    headers: {"Access-Control-Allow-Origin": "*"},
+                    body: JSON.stringify(require("../assets/sample2.json"))
+                });
+            } else if (request.url().includes("/fileTwo.json")) {
+                request.respond({
+                    content: 'application/json',
+                    headers: {"Access-Control-Allow-Origin": "*"},
+                    body: JSON.stringify(require("../assets/sample3.json"))
+                });
+            }
+            else {
+                request.continue();
+            }
+        });
+    }
+
+    it("should load data when file parameters in url are valid", async ()=>{
+        await mockResponses();
+        await page.goto(CC_URL + "?file=fileOne.json&file=fileTwo.json");
+        await navigateToRevisionChooser();
+        await checkSelectedRevisionName("fileOne.json");
+        await checkAllRevisionNames(["fileOne.json", "fileTwo.json"]);
+    });
+
+    it("should throw errors when file parameters in url are invalid and load sample data instead", async ()=>{
+        await page.goto(CC_URL + "?file=invalid234");
+        await handleErrorDialog();
+        await navigateToRevisionChooser();
+        await checkSelectedRevisionName("sample1.json");
+        await checkAllRevisionNames(["sample1.json", "sample2.json"]);
+    });
+
+});

--- a/visualization/app/codeCharta/ui/dialog/errorDialog.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/errorDialog.po.ts
@@ -1,0 +1,14 @@
+export class ErrorDialogPageObject {
+
+    constructor(private page) {}
+
+    async getMessage() {
+        return await this.page.evaluate(() => document.querySelector('.md-dialog-content-body p')['innerText']);
+    }
+
+    async clickOk() {
+        const selector = 'md-dialog-actions button';
+        return this.page.click(selector);
+    }
+
+}

--- a/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.po.ts
+++ b/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.po.ts
@@ -1,0 +1,18 @@
+export class RevisionChooserPageObject {
+
+    constructor(private page) {}
+
+    async getSelectedName() {
+        return await this.page.evaluate(() => document.querySelector('revision-chooser-component md-select .md-text')["innerText"]);
+    }
+
+    async clickChooser() {
+        return this.page.click("revision-chooser-component md-select");
+    }
+
+    async getAllNames() {
+        let content = await this.page.evaluate(() => document.querySelector('.md-select-menu-container.md-active > md-select-menu')["innerText"]);
+        return content.split("\n");
+    }
+
+}

--- a/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.po.ts
+++ b/visualization/app/codeCharta/ui/settingsPanel/settingsPanel.po.ts
@@ -1,0 +1,10 @@
+export class SettingsPanelPageObject {
+
+    constructor(private page) {}
+
+    async toggleMapsPanel() {
+        const selector = 'settings-panel-component > md-expansion-panel-group > md-expansion-panel';
+        return this.page.click(selector);
+    }
+
+}

--- a/visualization/app/index.html
+++ b/visualization/app/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>CodeCharta</title>
         <meta charset="utf-8">
-        <link rel="shortcut icon" href="assets/icon.ico" />
+        <link rel="shortcut icon" href="icon.ico" />
     </head>
 
     <body ng-app="app" ng-cloak>


### PR DESCRIPTION
# Multiple files in url

## Description

Solves #136 . Codecharta now accepts multiple file url parameters to load multiple maps e.g `http://localhost:3000?file=firstFile.json&file=secondFile.json&file=thirdFile.json`

I also fixed a very small bug I found, see index.html. The icon path was not correct anymore.  
I also implemented some e2e and unit tests which should cover this feature. 

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
