### PR TITLE
Feature/268/add isolate type to blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
 ### Added
+- Isolate node shows up in the blacklist
+- Option to Unisolate node from NodeContextMenu in TreeView
+- Option to only hide dependent edges
 
 ### Changed
+- Isolating a node does not remove the blacklist items of type Hide
 
 ### Removed
 

--- a/visualization/app/codeCharta/core/data/model/CodeMap.ts
+++ b/visualization/app/codeCharta/core/data/model/CodeMap.ts
@@ -54,5 +54,6 @@ export interface Exclude {
 
 export enum ExcludeType {
     hide = "hide",
-    exclude = "exclude"
+    exclude = "exclude",
+    isolate = "isolate"
 }

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.html
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.html
@@ -21,10 +21,11 @@
 
     <div class="sub-list">
         <md-list-item
-                      ng-repeat="item in $ctrl.blacklist | orderBy: [$ctrl.sortByExcludes,'path']"
+                      ng-repeat="item in $ctrl.blacklist | orderBy: [$ctrl.sortByIsolateAndExcludes,'path']"
                       title="{{::item.path}}">
 
             <div class="md-icon item-type" layout="column">
+                <i ng-if="::item.type == 'isolate'" class="fa fa-bullseye" title="Isolate"></i>
                 <i ng-if="::item.type == 'hide'" class="fa fa-eye-slash" title="Hide"></i>
                 <i ng-if="::item.type == 'exclude'" class="fa fa-times" title="Exclude"></i>
             </div>

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.ts
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.ts
@@ -71,8 +71,13 @@ export class BlacklistPanelController implements SettingsServiceSubscriber{
         }).length != 0;
     }
 
-    sortByExcludes(item: Exclude) {
-        return (item && item.type == ExcludeType.exclude) ? 0 : 1;
+    sortByIsolateAndExcludes(item: Exclude) {
+        if (item) {
+            if (item.type == ExcludeType.isolate) {
+                return 0;
+            }
+            return (item.type == ExcludeType.exclude) ? 1 : 2;
+        }
     }
 }
 

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.ts
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.ts
@@ -35,7 +35,7 @@ export class BlacklistPanelController implements SettingsServiceSubscriber{
     }
 
     removeBlacklistEntry(entry: Exclude){
-        this.codeMapActionsService.includeNode(entry);
+        this.codeMapActionsService.removeBlacklistEntry(entry);
         this.onChange();
     }
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
@@ -4,7 +4,6 @@ import {CodeMapNode, Exclude, ExcludeType} from "../../core/data/model/CodeMap";
 
 import {SettingsService} from "../../core/settings/settings.service";
 import {ThreeOrbitControlsService} from "./threeViewer/threeOrbitControlsService";
-import {ColorKeywords} from "three";
 
 jest.mock("../../core/settings/settings.service");
 
@@ -35,24 +34,28 @@ describe("code map action service tests", ()=>{
        hiddenNode = {name: "test", type: "File", attributes: {}, visible: false};
        simpleHiddenHierarchy = {
             name: "root",
+            path: "/root",
             type: "Folder",
             attributes: {},
             visible: false,
             children: [
                 {
                     name: "a",
+                    path: "/root/a",
                     type: "Folder",
                     attributes: {},
                     visible: false,
                     children: [
                         {
                             name: "aa",
+                            path: "/root/a/aa",
                             type: "File",
                             attributes: {},
                             visible: false
                         },
                         {
                             name: "ab",
+                            path: "/root/a/ab",
                             type: "File",
                             attributes: {},
                             visible: false
@@ -61,6 +64,7 @@ describe("code map action service tests", ()=>{
                 },
                 {
                     name: "b",
+                    path: "/root/b",
                     type: "File",
                     attributes: {},
                     visible: false
@@ -153,17 +157,15 @@ describe("code map action service tests", ()=>{
             };
         });
 
-        it("showing all nodes should make all nodes visible", ()=>{
+        it("showing all nodes should remove all nodes of type hidden from blacklist", ()=>{
             codeMapActionService.showAllNodes();
-            checkBlacklistItems(ExcludeType.hide, simpleHiddenHierarchy, false);
+            checkBlacklistItems(ExcludeType.hide, simpleHiddenHierarchy.children[0].children[0], false);
+            checkBlacklistItems(ExcludeType.hide, simpleHiddenHierarchy.children[1], false);
         });
 
-        it("isolationg node should show all descendants and hide all ascendants", ()=>{
-            simpleHiddenHierarchy.visible = true;
-            codeMapActionService.isolateNode(simpleHiddenHierarchy.children[0]);
-            expect(simpleHiddenHierarchy.visible).toBe(false);
-            checkTreeVisibility(simpleHiddenHierarchy.children[0], true);
-            checkTreeVisibility(simpleHiddenHierarchy.children[1], false);
+        it("isolationg node should add the node to the blacklist", ()=>{
+            codeMapActionService.isolateNode(simpleHiddenHierarchy.children[1]);
+            checkBlacklistItems(ExcludeType.isolate, simpleHiddenHierarchy.children[1], true);
         });
 
         it("hiding visible node should create blacklistHide item", ()=>{
@@ -186,7 +188,7 @@ describe("code map action service tests", ()=>{
             let tmp = codeMapActionService.hideNode;
             codeMapActionService.hideNode = jest.fn();
             codeMapActionService.toggleNodeVisibility(visibleNode);
-            expect(codeMapActionService.hideNode).toHaveBeenCalledWith(visibleNode)
+            expect(codeMapActionService.hideNode).toHaveBeenCalledWith(visibleNode);
             codeMapActionService.hideNode = tmp;
         });
 
@@ -194,7 +196,7 @@ describe("code map action service tests", ()=>{
             let tmp = codeMapActionService.showNode;
             codeMapActionService.showNode = jest.fn();
             codeMapActionService.toggleNodeVisibility(hiddenNode);
-            expect(codeMapActionService.showNode).toHaveBeenCalledWith(hiddenNode)
+            expect(codeMapActionService.showNode).toHaveBeenCalledWith(hiddenNode);
             codeMapActionService.showNode = tmp;
         });
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
@@ -263,10 +263,10 @@ describe("code map action service tests", ()=>{
             checkBlacklistItems(ExcludeType.exclude, simpleHiddenHierarchy, true);
         });
 
-        it("including node should remove blacklistExcluded item", ()=>{
+        it("removing node should remove blacklistExcluded item", ()=>{
             codeMapActionService.excludeNode(simpleHiddenHierarchy);
             checkBlacklistItems(ExcludeType.exclude, simpleHiddenHierarchy, true);
-            codeMapActionService.includeNode({path: "/root", type: ExcludeType.exclude});
+            codeMapActionService.removeBlacklistEntry({path: "/root", type: ExcludeType.exclude});
             checkBlacklistItems(ExcludeType.exclude, simpleHiddenHierarchy, false);
         });
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -62,15 +62,15 @@ export class CodeMapActionsService {
     }
 
     isolateNode(node: CodeMapNode) {
-        this.setVisibilityOfNodeAndDescendants(this.settingsService.settings.map.root, false);
-        this.setVisibilityOfNodeAndDescendants(node, true);
+        this.removeAllBlacklistItemsOfType([ExcludeType.isolate]);
+        this.settingsService.settings.blacklist.push({path: node.path, type: ExcludeType.isolate});
         this.autoFit();
         this.apply();
     }
 
     showAllNodes() {
         this.setVisibilityOfNodeAndDescendants(this.settingsService.settings.map.root, true);
-        this.removeAllBlacklistItemsOfTypeHidden();
+        this.removeAllBlacklistItemsOfType([ExcludeType.isolate, ExcludeType.hide]);
         this.autoFit();
         this.apply();
     }
@@ -156,14 +156,14 @@ export class CodeMapActionsService {
         }
     }
 
-    private removeAllBlacklistItemsOfTypeHidden() {
-        var onlyExcludeItems = [];
+    private removeAllBlacklistItemsOfType(excludeTypeArray: ExcludeType[]) {
+        var remainingItems = [];
         this.settingsService.settings.blacklist.forEach((item)=> {
-            if(item.type == ExcludeType.exclude) {
-                onlyExcludeItems.push(item);
+            if(!excludeTypeArray.includes(item.type)) {
+                remainingItems.push(item);
             }
         });
-        this.settingsService.settings.blacklist = onlyExcludeItems;
+        this.settingsService.settings.blacklist = remainingItems;
     }
 
     private edgeContainsNode(edge: Edge, node: CodeMapNode) {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -62,6 +62,7 @@ export class CodeMapActionsService {
     }
 
     isolateNode(node: CodeMapNode) {
+        this.removeBlacklistEntry({path: node.path, type: ExcludeType.hide});
         this.removeAllBlacklistItemsOfType([ExcludeType.isolate]);
         this.settingsService.settings.blacklist.push({path: node.path, type: ExcludeType.isolate});
         this.autoFit();

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -88,8 +88,12 @@ export class CodeMapActionsService {
         this.apply();
     }
 
-    includeNode(entry: Exclude) {
-        this.settingsService.settings.blacklist = this.settingsService.settings.blacklist.filter(obj => !this.isEqualObjects(obj, entry));
+    removeBlacklistEntry(entry: Exclude) {
+        this.settingsService.settings.blacklist = this.settingsService.settings.blacklist.filter(obj =>
+            !this.isEqualObjects(obj, entry));
+        if (entry.type == ExcludeType.isolate) {
+            this.autoFit();
+        }
         this.apply();
     }
 
@@ -144,7 +148,7 @@ export class CodeMapActionsService {
         }
     }
 
-    private removeBlacklistEntry(item) {
+    /*private removeBlacklistEntry(item) {
         if(this.settingsService.settings.blacklist) {
             var foundItem = this.settingsService.settings.blacklist.filter(obj => this.isEqualObjects(obj, item));
             if (foundItem.length != 0) {
@@ -154,7 +158,7 @@ export class CodeMapActionsService {
                 }
             }
         }
-    }
+    }*/
 
     private removeAllBlacklistItemsOfType(excludeTypeArray: ExcludeType[]) {
         var remainingItems = [];

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -114,7 +114,7 @@ export class CodeMapActionsService {
         this.changeEdgesVisibility(false);
     }
 
-    nodeIsIsolated(node: CodeMapNode) {
+    isNodeIsolated(node: CodeMapNode) {
         var foundItem =  this.settingsService.settings.blacklist.filter(obj =>
             this.isEqualObjects(obj, {path: node.path, type: ExcludeType.isolate}));
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.util.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.util.service.ts
@@ -34,6 +34,15 @@ export class CodeMapUtilService {
         return ig.ignores(CodeMapUtilService.transformPath(node.path));
     }
 
+    getAnyCodeMapNodeFromPath(path: string) {
+        var firstTryNode = this.getCodeMapNodeFromPath(path, "File");
+        if(!firstTryNode) {
+            return this.getCodeMapNodeFromPath(path, "Folder");
+        }
+        return firstTryNode;
+
+    }
+
     getCodeMapNodeFromPath(path: string, nodeType: string) {
         let res = null;
         const rootNode = this.settingsService.settings.map.root;

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
@@ -17,8 +17,10 @@
 
     <div class="button-group">
         <md-button ng-disabled="true">Node</md-button>
-        <md-button ng-click="$ctrl.hideNode()" title="Hide node and children-nodes, but keep an empty space"><i class="fa fa-eye-slash"></i> Hide</md-button>
-        <md-button ng-click="$ctrl.isolateNode()" title="Only show selected nodes with children-nodes"><i class="fa fa-bullseye"></i> Isolate</md-button>
+        <md-button ng-if="$ctrl.contextMenuBuilding.visible" ng-click="$ctrl.hideNode()" title="Hide node and children-nodes, but keep an empty space"><i class="fa fa-eye-slash"></i> Hide</md-button>
+        <md-button ng-if="!$ctrl.contextMenuBuilding.visible" ng-click="$ctrl.showNode()" title="Show node and children-nodes"><i class="fa fa-eye"></i> Show</md-button>
+        <md-button ng-if="!$ctrl.nodeIsIsolated" ng-click="$ctrl.isolateNode()" title="Only show selected nodes with children-nodes"><i class="fa fa-bullseye"></i> Isolate</md-button>
+        <md-button ng-if="$ctrl.nodeIsIsolated" ng-click="$ctrl.unisolateNode()" title="Remove Isolation and show map like before"><i class="fa fa-bullseye"></i> Unisolate</md-button>
         <md-button ng-click="$ctrl.showAllNodes()" title="Show all nodes and remove blacklist items of type 'Hide'"><i class="fa fa-eye"></i> Show all</md-button>
         <md-button ng-click="$ctrl.excludeNode()" title="Exclude node and children-nodes and reorder the CodeMap"><i class="fa fa-times"></i> Exclude</md-button>
     </div>

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
@@ -25,15 +25,15 @@
         <md-button ng-click="$ctrl.excludeNode()" title="Exclude node and children-nodes and reorder the CodeMap"><i class="fa fa-times"></i> Exclude</md-button>
     </div>
 
-    <div class="button-group" ng-if="$ctrl.nodeHasEdges || $ctrl.anyEdgeIsVisible">
+    <div class="button-group" ng-if="$ctrl.amountOfDependentEdges > 0 || $ctrl.anyEdgeIsVisible">
         <md-divider></md-divider>
         <md-button ng-disabled="true">Edges</md-button>
-        <md-button ng-if="$ctrl.nodeHasEdges && ! $ctrl.allDependentEdgesAreVisible"
+        <md-button ng-if="$ctrl.amountOfDependentEdges > 0 && $ctrl.amountOfVisibleDependentEdges < $ctrl.amountOfDependentEdges"
                    ng-click="$ctrl.showDependentEdges()"
                    title="Show edges which are connected to this node">
             <i class="fa fa-eye"></i> Show
         </md-button>
-        <md-button ng-if="$ctrl.nodeHasEdges && $ctrl.allDependentEdgesAreVisible"
+        <md-button ng-if="$ctrl.amountOfVisibleDependentEdges > 0"
                    ng-click="$ctrl.hideDependentEdges()"
                    title="Hide edges which are connected to this node">
             <i class="fa fa-eye-slash"></i> Hide

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
@@ -19,8 +19,8 @@
         <md-button ng-disabled="true">Node</md-button>
         <md-button ng-if="$ctrl.contextMenuBuilding.visible" ng-click="$ctrl.hideNode()" title="Hide node and children-nodes, but keep an empty space"><i class="fa fa-eye-slash"></i> Hide</md-button>
         <md-button ng-if="!$ctrl.contextMenuBuilding.visible" ng-click="$ctrl.showNode()" title="Show node and children-nodes"><i class="fa fa-eye"></i> Show</md-button>
-        <md-button ng-if="!$ctrl.nodeIsIsolated" ng-click="$ctrl.isolateNode()" title="Only show selected nodes with children-nodes"><i class="fa fa-bullseye"></i> Isolate</md-button>
-        <md-button ng-if="$ctrl.nodeIsIsolated" ng-click="$ctrl.unisolateNode()" title="Remove Isolation and show map like before"><i class="fa fa-bullseye"></i> Unisolate</md-button>
+        <md-button ng-if="!$ctrl.isNodeIsolated" ng-click="$ctrl.isolateNode()" title="Only show selected nodes with children-nodes"><i class="fa fa-bullseye"></i> Isolate</md-button>
+        <md-button ng-if="$ctrl.isNodeIsolated" ng-click="$ctrl.unisolateNode()" title="Remove Isolation and show map like before"><i class="fa fa-bullseye"></i> Unisolate</md-button>
         <md-button ng-click="$ctrl.showAllNodes()" title="Show all nodes and remove blacklist items of type 'Hide'"><i class="fa fa-eye"></i> Show all</md-button>
         <md-button ng-click="$ctrl.excludeNode()" title="Exclude node and children-nodes and reorder the CodeMap"><i class="fa fa-times"></i> Exclude</md-button>
     </div>

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -46,7 +46,7 @@ export class NodeContextMenuComponent {
             this.amountOfDependentEdges = this.codeMapActionsService.amountOfDependentEdges(this.contextMenuBuilding);
             this.amountOfVisibleDependentEdges = this.codeMapActionsService.amountOfVisibleDependentEdges(this.contextMenuBuilding);
             this.anyEdgeIsVisible = this.codeMapActionsService.anyEdgeIsVisible();
-            this.nodeIsIsolated = this.codeMapActionsService.nodeIsIsolated(this.contextMenuBuilding);
+            this.nodeIsIsolated = this.codeMapActionsService.isNodeIsolated(this.contextMenuBuilding);
 
             let w = this.$element[0].children[0].clientWidth;
             let h = this.$element[0].children[0].clientHeight;

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -4,13 +4,12 @@ import angular from "angular";
 import {highlightColors} from "../codeMap/rendering/renderSettings";
 import {CodeMapActionsService} from "../codeMap/codeMap.actions.service";
 import {CodeMapUtilService} from "../codeMap/codeMap.util.service";
-import {ExcludeType} from "../../core/data/model/CodeMap";
 
 export class NodeContextMenuComponent {
 
     private contextMenuBuilding;
-    public nodeHasEdges;
-    public allDependentEdgesAreVisible;
+    public amountOfDependentEdges;
+    public amountOfVisibleDependentEdges;
     public anyEdgeIsVisible;
     public nodeIsIsolated;
 
@@ -44,8 +43,8 @@ export class NodeContextMenuComponent {
         this.$timeout(() => {
             this.contextMenuBuilding = this.codeMapUtilService.getCodeMapNodeFromPath(path, nodeType);
         }, 50).then(() => {
-            this.nodeHasEdges = this.codeMapActionsService.nodeHasEdges(this.contextMenuBuilding);
-            this.allDependentEdgesAreVisible = this.codeMapActionsService.allDependentEdgesAreVisible(this.contextMenuBuilding);
+            this.amountOfDependentEdges = this.codeMapActionsService.amountOfDependentEdges(this.contextMenuBuilding);
+            this.amountOfVisibleDependentEdges = this.codeMapActionsService.amountOfVisibleDependentEdges(this.contextMenuBuilding);
             this.anyEdgeIsVisible = this.codeMapActionsService.anyEdgeIsVisible();
             this.nodeIsIsolated = this.codeMapActionsService.nodeIsIsolated(this.contextMenuBuilding);
 

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -11,7 +11,7 @@ export class NodeContextMenuComponent {
     public amountOfDependentEdges;
     public amountOfVisibleDependentEdges;
     public anyEdgeIsVisible;
-    public nodeIsIsolated;
+    public isNodeIsolated;
 
     private colors = highlightColors;
 
@@ -46,7 +46,7 @@ export class NodeContextMenuComponent {
             this.amountOfDependentEdges = this.codeMapActionsService.amountOfDependentEdges(this.contextMenuBuilding);
             this.amountOfVisibleDependentEdges = this.codeMapActionsService.amountOfVisibleDependentEdges(this.contextMenuBuilding);
             this.anyEdgeIsVisible = this.codeMapActionsService.anyEdgeIsVisible();
-            this.nodeIsIsolated = this.codeMapActionsService.isNodeIsolated(this.contextMenuBuilding);
+            this.isNodeIsolated = this.codeMapActionsService.isNodeIsolated(this.contextMenuBuilding);
 
             let w = this.$element[0].children[0].clientWidth;
             let h = this.$element[0].children[0].clientHeight;

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -12,6 +12,7 @@ export class NodeContextMenuComponent {
     public nodeHasEdges;
     public allDependentEdgesAreVisible;
     public anyEdgeIsVisible;
+    public nodeIsIsolated;
 
     private colors = highlightColors;
 
@@ -46,6 +47,7 @@ export class NodeContextMenuComponent {
             this.nodeHasEdges = this.codeMapActionsService.nodeHasEdges(this.contextMenuBuilding);
             this.allDependentEdgesAreVisible = this.codeMapActionsService.allDependentEdgesAreVisible(this.contextMenuBuilding);
             this.anyEdgeIsVisible = this.codeMapActionsService.anyEdgeIsVisible();
+            this.nodeIsIsolated = this.codeMapActionsService.nodeIsIsolated(this.contextMenuBuilding);
 
             let w = this.$element[0].children[0].clientWidth;
             let h = this.$element[0].children[0].clientHeight;
@@ -59,6 +61,11 @@ export class NodeContextMenuComponent {
     hideNode() {
         this.hideContextMenu();
         this.codeMapActionsService.hideNode(this.contextMenuBuilding);
+    }
+
+    showNode() {
+        this.hideContextMenu();
+        this.codeMapActionsService.showNode(this.contextMenuBuilding);
     }
 
     clickColor(color: string) {
@@ -89,6 +96,11 @@ export class NodeContextMenuComponent {
     isolateNode() {
         this.hideContextMenu();
         this.codeMapActionsService.isolateNode(this.contextMenuBuilding);
+    }
+
+    unisolateNode() {
+        this.hideContextMenu();
+        this.codeMapActionsService.unisolateNode(this.contextMenuBuilding);
     }
 
     showAllNodes() {


### PR DESCRIPTION
# Feature/268/add isolate type to blacklist

Connects #268 Closes #268

## Description

### Added
- Isolated node shows up in the blacklist
- NodeContextMenu: Option to Unisolate node in TreeView
- NodeContextMenu: Option to only hide dependent edges

 ### Changed
- Isolating a node does not remove the blacklist items of type Hide

### Question
- Do you think **blacklist** is still the correct word and if not do you have a better idea?

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail