### PR TITLE
Tech/265/add tests download service

### DIFF
--- a/visualization/app/codeCharta/core/download/__snapshots__/download.service.spec.ts.snap
+++ b/visualization/app/codeCharta/core/download/__snapshots__/download.service.spec.ts.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app.codeCharta.core.download  should remove visible attribute from settings.map 1`] = `
+Object {
+  "attributes": Object {},
+  "children": Array [
+    Object {
+      "attributes": Object {},
+      "children": Array [
+        Object {
+          "attributes": Object {},
+          "name": "aa",
+          "path": "/root/a/aa",
+          "type": "File",
+        },
+      ],
+      "name": "a",
+      "path": "/root/a",
+      "type": "Folder",
+    },
+    Object {
+      "attributes": Object {},
+      "name": "b",
+      "path": "/root/b",
+      "type": "File",
+    },
+  ],
+  "name": "root",
+  "path": "/root",
+  "type": "Folder",
+}
+`;
+
+exports[`app.codeCharta.core.download  should return correct project json content 1`] = `
+Object {
+  "apiVersion": "1.1.1",
+  "attributeTypes": "myAttributeTypes",
+  "blacklist": undefined,
+  "edges": "myEdges",
+  "fileName": "myFilename.14_12_2018.json",
+  "nodes": Array [
+    Object {
+      "attributes": Object {},
+      "children": Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "name": "aa",
+              "path": "/root/a/aa",
+              "type": "File",
+            },
+          ],
+          "name": "a",
+          "path": "/root/a",
+          "type": "Folder",
+        },
+        Object {
+          "attributes": Object {},
+          "name": "b",
+          "path": "/root/b",
+          "type": "File",
+        },
+      ],
+      "name": "root",
+      "path": "/root",
+      "type": "Folder",
+    },
+  ],
+  "projectName": "myProjectName",
+}
+`;

--- a/visualization/app/codeCharta/core/download/download.service.spec.ts
+++ b/visualization/app/codeCharta/core/download/download.service.spec.ts
@@ -2,6 +2,7 @@ import "./download.module";
 import {getService, instantiateModule} from "../../../../mocks/ng.mockhelper";
 import {SettingsService} from "../settings/settings.service";
 import {DownloadService} from "./download.service";
+import { stubDate } from '../../../../mocks/dateMock.helper';
 
 describe("app.codeCharta.core.download", function() {
 
@@ -79,6 +80,8 @@ describe("app.codeCharta.core.download", function() {
     });
 
     describe("", ()=> {
+
+        stubDate(new Date('2018-12-14T09:39:59'));
 
         it("should add json extension to given string", function() {
             expect(downloadService.addJsonFileEndingIfNecessary("abc")).toBe("abc.json");

--- a/visualization/app/codeCharta/core/download/download.service.spec.ts
+++ b/visualization/app/codeCharta/core/download/download.service.spec.ts
@@ -1,0 +1,110 @@
+import "./download.module";
+import {getService, instantiateModule} from "../../../../mocks/ng.mockhelper";
+import {SettingsService} from "../settings/settings.service";
+import {DownloadService} from "./download.service";
+
+describe("app.codeCharta.core.download", function() {
+
+    let services, downloadService: DownloadService;
+
+    beforeEach(() => {
+        restartSystem();
+        withSettingsServiceMock();
+        rebuildController();
+    });
+
+    function restartSystem() {
+        instantiateModule("app.codeCharta.core.download");
+
+        services = {
+            settingsService: getService<SettingsService>("settingsService"),
+        };
+    }
+
+    function rebuildController() {
+        downloadService = new DownloadService(
+            services.settingsService
+        );
+    }
+
+    function withSettingsServiceMock() {
+        services.settingsService = {
+            settings: {
+                map: {
+                    edges: "myEdges",
+                    attributeTypes: "myAttributeTypes",
+                    projectName: "myProjectName",
+                    apiVersion: "1.1.1",
+                    fileName: "myFilename",
+                    root: {
+                        name: "root",
+                        type: "Folder",
+                        path: "/root",
+                        visible: "true",
+                        attributes: {},
+                        children: [
+                            {
+                                name: "a",
+                                type: "Folder",
+                                path: "/root/a",
+                                visible: "false",
+                                attributes: {},
+                                children: [
+                                    {
+                                        name: "aa",
+                                        type: "File",
+                                        path: "/root/a/aa",
+                                        visible: "true",
+                                        attributes: {},
+                                    }
+                                ]
+                            },
+                            {
+                                name: "b",
+                                type: "File",
+                                path: "/root/b",
+                                visible: "false",
+                                attributes: {},
+                            }
+                        ]
+                    }
+                },
+            },
+            blacklist: "myBlacklistItems",
+        };
+    }
+
+    afterEach(()=>{
+        jest.resetAllMocks();
+    });
+
+    describe("", ()=> {
+
+        it("should add json extension to given string", function() {
+            expect(downloadService.addJsonFileEndingIfNecessary("abc")).toBe("abc.json");
+        });
+
+        it("should keep json extension with given string", function() {
+            expect(downloadService.addJsonFileEndingIfNecessary("abc.json")).toBe("abc.json");
+        });
+
+
+        it("should add date string before json extension", function() {
+            const filenameWithDate = downloadService.addDateToFileName("abc.json");
+            var regexp = new RegExp('^abc\.\\d{2}_\\d{2}_\\d{4}\.json$');
+            expect(regexp.test(filenameWithDate)).toBeTruthy();
+        });
+
+        it("should remove visible attribute from settings.map", function() {
+            withSettingsServiceMock();
+            const rootNode = services.settingsService.settings.map.root;
+            expect(downloadService.removeVisibleAttribute(rootNode)).toMatchSnapshot();
+        });
+
+        it("should return correct project json content", function() {
+            downloadService.downloadData = jest.fn(function() {return true;});
+            expect(downloadService.getProjectDataAsCCJsonFormat()).toMatchSnapshot();
+        });
+
+    });
+});

--- a/visualization/app/codeCharta/core/download/download.service.ts
+++ b/visualization/app/codeCharta/core/download/download.service.ts
@@ -35,14 +35,17 @@ export class DownloadService {
     }
 
     public downloadCurrentMap() {
-        var settings: Settings = this.settingsService.settings;
-        var map: CodeMap = settings.map;
+        const data = this.getProjectDataAsCCJsonFormat();
+        this.downloadData(data, this.getNewFileName());
+    }
 
-        const datedFileName = this.addDateToFileName(map.fileName);
-        const resultingFileName = this.addJsonFileEndingIfNecessary(datedFileName);
+    private getProjectDataAsCCJsonFormat() {
+        let settings: Settings = this.settingsService.settings;
+        let map: CodeMap = settings.map;
+        let newFileName = this.getNewFileName();
 
-        let data = {
-            fileName: resultingFileName,
+        return {
+            fileName: newFileName,
             projectName: map.projectName,
             apiVersion: map.apiVersion,
             nodes: [this.removeVisibleAttribute(map.root)],
@@ -50,7 +53,11 @@ export class DownloadService {
             attributeTypes: map.attributeTypes,
             blacklist: settings.blacklist,
         };
-        this.downloadData(data, resultingFileName);
+    }
+
+    private getNewFileName() {
+        const datedFileName = this.addDateToFileName(this.settingsService.settings.map.fileName);
+        return this.addJsonFileEndingIfNecessary(datedFileName);
     }
 
     private downloadData(data, fileName) {

--- a/visualization/mocks/dateMock.helper.ts
+++ b/visualization/mocks/dateMock.helper.ts
@@ -1,0 +1,19 @@
+export const stubDate = fixedDate => {
+  let _originalDate;
+
+  beforeAll(() => {
+    _originalDate = Date;
+
+    global["Date"] = class extends Date {
+      constructor() {
+        super();
+
+        return fixedDate;
+      }
+    } as DateConstructor;
+  });
+
+  afterAll(() => {
+    global["Date"] = _originalDate;
+  });
+};


### PR DESCRIPTION
# Tech/265/add tests download service

Related to #265 

## Description

- Add tests for the content produced of `download.service`
- A test for the actual download process is not included

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [ ] **All** requirements mentioned in the issue are implemented
* [ ] Does match the Code of Conduct and the Contribution file 
* [ ] Task has its own **GitHub issue** (something it is solving)
  * [ ] Issue number is **included in the commit messages** for traceability
* [ ] **Update the README.md** with any changes/additions made
* [ ] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [ ] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [ ] **Manual testing** did not fail