### PR TITLE
Bug/233/Standalone-logo

### DIFF
--- a/visualization/app/app.ts
+++ b/visualization/app/app.ts
@@ -37,6 +37,9 @@ angular.module("app")
             template: "<test-ville-component>Loading testVille...</test-ville-component>"
         });
 
-    }).run(function($state) {
+    }).config(['$compileProvider', function($compileProvider) {
+        $compileProvider.imgSrcSanitizationWhitelist(/^\s*((https?|ftp|file|blob|chrome-extension):|data:image\/)/);
+        $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|chrome-extension):/);
+    }]).run(function($state) {
         $state.go("CodeCharta");
     });


### PR DESCRIPTION
# Bug/233/Standalone-logo

closes #233
Merge permission: CC-Member

## Description

This PR fixes a bug, which moulded load the logo image inside the Nw.Js standalone application. The official [NW.Js docs](http://docs.nwjs.io/en/latest/For%20Users/FAQ/#images-are-broken-in-angularjs-and-receive-failed-to-load-resource-xxx-neterr_unknown_url_scheme-in-devtools) mention this issue as below:

> #### Images are broken in AngularJS and receive `Failed to load resource XXX net::ERR_UNKNOWN_URL_SCHEME` in DevTools
> AngularJS added `unsafe:` prefix for unknown scheme to prevent XSS attack. URLs in NW.js and Chrome apps are started with `chrome-extension:` scheme, which is unknown to AngularJS. The solution is to config the whitelist of known schemes with AngularJS by adding following lines:

-> See changed file

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail