### PR TITLE
Bug/307/navigating-text-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 - Removed option to add blacklist entries from inside the blacklistPanel #298
 
 ### Fixed
+- CodeMap does not move anymore when navigating in text-fields #307
 
 ## [1.20.1] - 2018-12-19
 ### Added

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
@@ -54,6 +54,8 @@ export class ThreeViewerService {
 
         // handles resizing the renderer when the window is resized
         window.addEventListener("resize", this.onWindowResize.bind(this), false);
+        window.addEventListener("focusin", this.onFocusIn.bind(this), false);
+        window.addEventListener("focusout", this.onFocusOut.bind(this), false);
     }
 
     /**
@@ -65,6 +67,18 @@ export class ThreeViewerService {
         this.threeRendererService.renderer.setSize(window.innerWidth, window.innerHeight);
         this.threeCameraService.camera.aspect = window.innerWidth / window.innerHeight;
         this.threeCameraService.camera.updateProjectionMatrix();
+    }
+
+    onFocusIn(event) {
+        if(event.target.nodeName == "INPUT") {
+            this.threeOrbitControlsService.controls.enableKeys = false;
+        }
+    }
+
+    onFocusOut(event) {
+        if(event.target.nodeName == "INPUT") {
+            this.threeOrbitControlsService.controls.enableKeys = true;
+        }
     }
 
     /**


### PR DESCRIPTION
# Bug/307/navigating-text-fields

closes #307 
Merge permission: CC-Member

## Description

- CodeMap does not move anymore when navigating in text-fields with arrow-keys
- Added EvenetListener on input fields:
    - `onFocusIn` -> disable codeMap movements
    - `onFocusOut` -> enable codeMap movements again

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail