### PR TITLE
Bug/settings-service-calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Hide/Flatten all buildings, if searchPattern can't find any matching nodes #225
 -   Show maxValue of each metric in metricChooser select list #204
 -   Colored color-slider inside the RibbonBar #318
--   Color positive buildings white and set as default option #311
+-   Option to color positive buildings white #311
 -   Clicking the ribbonBar section-titles toggles the ribbonBar #324
 -   View-Cube displayed in top right corner #274
 -   Adding prettier formatter

--- a/visualization/app/codeCharta/core/settings/settings.service.ts
+++ b/visualization/app/codeCharta/core/settings/settings.service.ts
@@ -128,7 +128,7 @@ export class SettingsService implements DataServiceSubscriber, CameraChangeSubsc
             invertHeight: false,
             dynamicMargin: true,
             isWhiteBackground: false,
-            whiteColorBuildings: true,
+            whiteColorBuildings: false,
             blacklist: [],
             focusedNodePath: null,
             searchedNodePaths: [],

--- a/visualization/app/codeCharta/ui/colorSettingsPanel/colorSettingsPanel.component.html
+++ b/visualization/app/codeCharta/ui/colorSettingsPanel/colorSettingsPanel.component.html
@@ -1,19 +1,19 @@
 <range-slider-component></range-slider-component>
 
-<md-input-container class="md-block" ng-if="$ctrl.settingsService.settings.mode != $ctrl.deltaMode">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.neutralColorRange.flipped" ng-change="$ctrl.settingsService.applySettings()">
+<md-input-container class="md-block" ng-if="$ctrl._settingsService_.settings.mode != $ctrl._deltaMode">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.neutralColorRange.flipped" ng-change="$ctrl._settingsService_.applySettings()">
         Invert Colors
     </md-checkbox>
 </md-input-container>
 
-<md-input-container class="md-block" ng-if="$ctrl.settingsService.settings.mode == $ctrl.deltaMode" >
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.deltaColorFlipped" ng-change="$ctrl.settingsService.applySettings()">
+<md-input-container class="md-block" ng-if="$ctrl.settingsService.settings.mode == $ctrl._deltaMode" >
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.deltaColorFlipped" ng-change="$ctrl._settingsService_.applySettings()">
         Invert Colors
     </md-checkbox>
 </md-input-container>
 
 <md-input-container class="md-block">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.whiteColorBuildings" ng-change="$ctrl.settingsService.applySettings()">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.whiteColorBuildings" ng-change="$ctrl._settingsService_.applySettings()">
         White Positive Buildings
     </md-checkbox>
 </md-input-container>

--- a/visualization/app/codeCharta/ui/optionsPanel/optionsPanel.component.html
+++ b/visualization/app/codeCharta/ui/optionsPanel/optionsPanel.component.html
@@ -1,23 +1,23 @@
 <md-input-container class="md-block">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.enableEdgeArrows" ng-change="$ctrl.settingsService.applySettings()">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.enableEdgeArrows" ng-change="$ctrl._settingsService_.applySettings()">
         Enable Edge Arrows
     </md-checkbox>
 </md-input-container>
 
 <md-input-container class="md-block">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.hideFlatBuildings" ng-change="$ctrl.settingsService.applySettings()">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.hideFlatBuildings" ng-change="$ctrl._settingsService_.applySettings()">
         Hide Flattened Buildings
     </md-checkbox>
 </md-input-container>
 
 <md-input-container class="md-block">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.maximizeDetailPanel" ng-change="$ctrl.settingsService.applySettings()">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.maximizeDetailPanel" ng-change="$ctrl._settingsService_.applySettings()">
         Maximize Detail Panel
     </md-checkbox>
 </md-input-container>
 
 <md-input-container class="md-block">
-    <md-checkbox class="md-primary" ng-model="$ctrl.settingsService.settings.isWhiteBackground" ng-change="$ctrl.settingsService.applySettings()">
+    <md-checkbox class="md-primary" ng-model="$ctrl._settingsService_.settings.isWhiteBackground" ng-change="$ctrl._settingsService_.applySettings()">
         White Background
     </md-checkbox>
 </md-input-container>


### PR DESCRIPTION
# Bug/settings-service-calls

Merge permission: CC-Member

## Description

- Fixes the use of the injected private `_settingsService_` class inside the html file of the optionsPanel and the colorSettingsPanel.
- Set `settings.whiteColorBuildings` default to `false`, as mentioned by @Richargh 

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [ ] **All** requirements mentioned in the issue are implemented
* [ ] Does match the Code of Conduct and the Contribution file 
* [ ] Task has its own **GitHub issue** (something it is solving)
  * [ ] Issue number is **included in the commit messages** for traceability
* [ ] **Update the README.md** with any changes/additions made
* [ ] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [ ] **All tests pass**    
* [ ] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [ ] **Manual testing** did not fail