### PR TITLE
Hovering over items in the Treeview shows metrics and highlights them in the map #351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
 ### Added
-
+- Hovering a node in the map also hovers it in the tree view #351
 ### Changed
 
 ### Removed
 
 ### Fixed
+-  Fixing sync between treeview hovering and map hovering #351
 
 ## [1.21.0] - 2019-02-16
 

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.scss
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.scss
@@ -17,7 +17,7 @@ map-tree-view-component {
         margin-left: 22px;
     }
 
-    .tree-element-label:hover {
+    .tree-element-label:hover, .tree-element-label.hovered {
         background-color: #efefef;
     }
 

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
@@ -1,6 +1,6 @@
 <div ng-if="!$ctrl.isBlacklisted($ctrl.node)" class="{{::$ctrl.depth?'':'tree-root'}} tree-element-{{::$ctrl.depth?$ctrl.depth:0}} {{::$ctrl.isLeaf()?'tree-leaf':'tree-parent'}}">
 
-    <div class="tree-element-label-{{::$ctrl.depth?$ctrl.depth:0}} tree-element-label ng-mouseenter="$ctrl.onMouseEnter()" ng-mouseleave="$ctrl.onMouseLeave()" ng-right-click="$ctrl.onRightClick($event)">
+    <div class="tree-element-label-{{::$ctrl.depth?$ctrl.depth:0}} tree-element-label" ng-mouseenter="$ctrl.onMouseEnter()" ng-mouseleave="$ctrl.onMouseLeave()" ng-right-click="$ctrl.onRightClick($event)">
 
         <span ng-click="$ctrl.onFolderClick()">
             <span role="img" ng-if="!$ctrl.isLeaf() && $ctrl.collapsed" class="fa fa-folder cursor-pointer" ng-style="{'color': $ctrl.node.markingColor.replace('0x','#') }" aria-hidden="true"></span>

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
@@ -1,6 +1,6 @@
 <div ng-if="!$ctrl.isBlacklisted($ctrl.node)" class="{{::$ctrl.depth?'':'tree-root'}} tree-element-{{::$ctrl.depth?$ctrl.depth:0}} {{::$ctrl.isLeaf()?'tree-leaf':'tree-parent'}}">
 
-    <div class="tree-element-label-{{::$ctrl.depth?$ctrl.depth:0}} tree-element-label" ng-mouseenter="$ctrl.onMouseEnter()" ng-mouseleave="$ctrl.onMouseLeave()" ng-right-click="$ctrl.onRightClick($event)">
+    <div class="tree-element-label-{{::$ctrl.depth?$ctrl.depth:0}} tree-element-label {{$ctrl._isHoveredInCodeMap ? 'hovered':''}}" ng-mouseenter="$ctrl.onMouseEnter()" ng-mouseleave="$ctrl.onMouseLeave()" ng-right-click="$ctrl.onRightClick($event)">
 
         <span ng-click="$ctrl.onFolderClick()">
             <span role="img" ng-if="!$ctrl.isLeaf() && $ctrl.collapsed" class="fa fa-folder cursor-pointer" ng-style="{'color': $ctrl.node.markingColor.replace('0x','#') }" aria-hidden="true"></span>

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
@@ -1,249 +1,299 @@
-import {MapTreeViewHoverEventSubscriber, MapTreeViewLevelController} from "./mapTreeView.level.component";
-import {CodeMapActionsService} from "../codeMap/codeMap.actions.service";
-import {SettingsService} from "../../core/settings/settings.service";
-import {CodeMapUtilService} from "../codeMap/codeMap.util.service";
-import {CodeMapNode, BlacklistType} from "../../core/data/model/CodeMap";
-import {IRootScopeService} from "angular";
-import "./mapTreeView";
-import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper";
+import { MapTreeViewHoverEventSubscriber, MapTreeViewLevelController } from "./mapTreeView.level.component"
+import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
+import { SettingsService } from "../../core/settings/settings.service"
+import { CodeMapUtilService } from "../codeMap/codeMap.util.service"
+import { CodeMapNode, BlacklistType } from "../../core/data/model/CodeMap"
+import { IRootScopeService } from "angular"
+import "./mapTreeView"
+import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
+import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
+import { Node } from "../codeMap/rendering/node"
+import { CodeMapBuildingTransition, CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service"
 
 describe("MapTreeViewLevelController", () => {
+	let mapTreeViewLevelController: MapTreeViewLevelController
+	let $rootScope
+	let $event
+	let subscriber
+	let threeOrbitControlsService
+	let $timeout
 
-    let mapTreeViewLevelController: MapTreeViewLevelController;
-    let $rootScope;
-    let $event;
-    let subscriber;
-    let threeOrbitControlsService;
-    let $timeout;
+	let codeMapActionsService: CodeMapActionsService
+	let settingsServiceMock: SettingsService
+	let codeMapUtilService: CodeMapUtilService
+	let simpleHierarchy: CodeMapNode
 
-    let codeMapActionsService: CodeMapActionsService;
-    let settingsServiceMock: SettingsService;
-    let codeMapUtilService: CodeMapUtilService;
-    let simpleHierarchy: CodeMapNode;
+	function mockEverything() {
+		const MockSubscriber = jest.fn<MapTreeViewHoverEventSubscriber>(() => ({
+			onShouldHoverNode: jest.fn(),
+			onShouldUnhoverNode: jest.fn()
+		}))
 
-    function mockEverything() {
+		subscriber = new MockSubscriber()
 
+		$rootScope = jest.fn()
 
-        const MockSubscriber = jest.fn<MapTreeViewHoverEventSubscriber>(()=>({
-            onShouldHoverNode: jest.fn(),
-            onShouldUnhoverNode: jest.fn()
-        }));
+		$timeout = jest.fn()
 
+		$rootScope = {
+			$broadcast: jest.fn(),
+			$on: jest.fn()
+		}
 
-        subscriber = new MockSubscriber();
+		$event = {
+			clientX: jest.fn(),
+			clientY: jest.fn()
+		}
 
-        $rootScope = jest.fn();
+		const SettingsServiceMock = jest.fn<SettingsService>(() => ({
+			subscribe: jest.fn(),
+			applySettings: jest.fn(),
+			settings: {
+				map: {
+					nodes: null,
+					blacklist: {}
+				}
+			}
+		}))
 
-        $timeout = jest.fn();
+		settingsServiceMock = new SettingsServiceMock()
 
-        $rootScope = {
-            $broadcast: jest.fn(),
-            $on: jest.fn()
-        };
+		simpleHierarchy = {
+			name: "root",
+			type: "Folder",
+			path: "/root",
+			attributes: {},
+			children: [
+				{
+					name: "a",
+					type: "Folder",
+					path: "/root/a",
+					attributes: {},
+					children: [
+						{
+							name: "ab",
+							type: "Folder",
+							path: "/root/a/ab",
+							attributes: {},
+							children: [
+								{
+									name: "aba",
+									path: "/root/a/ab/aba",
+									type: "File",
+									attributes: {}
+								}
+							]
+						}
+					]
+				}
+			]
+		}
 
-        $event = {
-            clientX: jest.fn(),
-            clientY: jest.fn()
-        };
+		codeMapUtilService = new CodeMapUtilService(settingsServiceMock)
+		settingsServiceMock.settings.map.nodes = simpleHierarchy
+		codeMapActionsService = new CodeMapActionsService(settingsServiceMock, threeOrbitControlsService, $timeout)
+		mapTreeViewLevelController = new MapTreeViewLevelController($rootScope, codeMapActionsService, settingsServiceMock)
+	}
 
-        const SettingsServiceMock = jest.fn<SettingsService>(() => ({
-            subscribe: jest.fn(),
-            applySettings: jest.fn(),
-            settings: {
-                map: {
-                    nodes: null,
-                    blacklist: {},
-                }
-            }
-        }));
+	beforeEach(function() {
+		mockEverything()
+	})
 
-        settingsServiceMock = new SettingsServiceMock();
+	describe("Listen to code map hovering", () => {
+		function buildNodeAt(path: string): CodeMapNode {
+			return ({ path: "somePath" } as any) as CodeMapNode
+		}
 
-        simpleHierarchy = {
-            name: "root",
-            type: "Folder",
-            path: "/root",
-            attributes: {},
-            children: [
-                {
-                    name: "a",
-                    type: "Folder",
-                    path: "/root/a",
-                    attributes: {},
-                    children: [
-                        {
-                            name: "ab",
-                            type: "Folder",
-                            path: "/root/a/ab",
-                            attributes: {},
-                            children: [
-                                {
-                                    name: "aba",
-                                    path: "/root/a/ab/aba",
-                                    type: "File",
-                                    attributes: {},
-                                }
-                            ]
-                        },
-                    ]
-                }
-            ]
-        };
+		function buildTransitionTo(path: string): CodeMapBuildingTransition {
+			const hoveredCodeMapBuilding: CodeMapBuilding = ({ node: ({ path: path } as any) as Node } as any) as CodeMapBuilding
+			return { from: null, to: hoveredCodeMapBuilding }
+		}
 
-        codeMapUtilService = new CodeMapUtilService(settingsServiceMock);
-        settingsServiceMock.settings.map.nodes = simpleHierarchy;
-        codeMapActionsService = new CodeMapActionsService(settingsServiceMock, threeOrbitControlsService, $timeout);
-        mapTreeViewLevelController = new MapTreeViewLevelController($rootScope, codeMapActionsService, settingsServiceMock);
-    }
+		it("should set _isHoveredInCodeMap to true if hovered node path from the event is the same as the node path assigned to this controller", () => {
+			const controllerNode: CodeMapNode = buildNodeAt("somePath")
+			const transition: CodeMapBuildingTransition = buildTransitionTo("somePath")
+			mapTreeViewLevelController.node = controllerNode
+			mapTreeViewLevelController.onBuildingHovered(transition, null)
+			expect(mapTreeViewLevelController._isHoveredInCodeMap).toBe(true)
+		})
 
-    beforeEach(function() {
-        mockEverything();
-    });
+		it("should set _isHoveredInCodeMap to false if hovered node path from the event is not the same as the node path assigned to this controller", () => {
+			const controllerNode: CodeMapNode = buildNodeAt("somePath")
+			const transition: CodeMapBuildingTransition = buildTransitionTo("someOtherPath")
+			mapTreeViewLevelController.node = controllerNode
+			mapTreeViewLevelController.onBuildingHovered(transition, null)
+			expect(mapTreeViewLevelController._isHoveredInCodeMap).toBe(false)
+		})
 
-    describe("Folder Color", () => {
+		it("should set _isHoveredInCodeMap to false if hovered node is null", () => {
+			const transition: CodeMapBuildingTransition = { from: null, to: null }
+			mapTreeViewLevelController.onBuildingHovered(transition, null)
+			expect(mapTreeViewLevelController._isHoveredInCodeMap).toBe(false)
+		})
 
-        it("Black color if no folder", () => {
-            expect(mapTreeViewLevelController.getFolderColor()).toBe("#000");
-        });
+		it("should set _isHoveredInCodeMap initially to false", () => {
+			expect(mapTreeViewLevelController._isHoveredInCodeMap).toBe(false)
+		})
 
-        it("Return the color defined in the folder", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            mapTreeViewLevelController.node.markingColor = "0xff3210";
-            expect(mapTreeViewLevelController.getFolderColor()).toBe("#ff3210");
-        });
+		it("should subscribe itself to events", () => {
+			CodeMapMouseEventService.subscribe = jest.fn()
+			mockEverything()
+			expect(CodeMapMouseEventService.subscribe).toBeCalledWith(expect.any($rootScope.constructor), mapTreeViewLevelController)
+		})
+	})
 
-        it("Return black if no markingColor in node", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            expect(mapTreeViewLevelController.getFolderColor()).toBe("#000");
-        });
-    });
+	describe("Folder Color", () => {
+		it("Black color if no folder", () => {
+			expect(mapTreeViewLevelController.getFolderColor()).toBe("#000")
+		})
 
-    describe("Mouse movement", () => {
+		it("Return the color defined in the folder", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			mapTreeViewLevelController.node.markingColor = "0xff3210"
+			expect(mapTreeViewLevelController.getFolderColor()).toBe("#ff3210")
+		})
 
-        it("Mouse enter", () => {
-            mapTreeViewLevelController.onMouseEnter();
-            expect($rootScope.$broadcast).toHaveBeenCalledWith("should-hover-node", mapTreeViewLevelController.node);
-        });
+		it("Return black if no markingColor in node", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			expect(mapTreeViewLevelController.getFolderColor()).toBe("#000")
+		})
+	})
 
-        it("Mouse leave", () => {
-            mapTreeViewLevelController.onMouseLeave();
-            expect($rootScope.$broadcast).toHaveBeenCalledWith("should-unhover-node", mapTreeViewLevelController.node);
-        });
-    });
+	describe("Mouse movement", () => {
+		it("Mouse enter", () => {
+			mapTreeViewLevelController.onMouseEnter()
+			expect($rootScope.$broadcast).toHaveBeenCalledWith("should-hover-node", mapTreeViewLevelController.node)
+		})
 
+		it("Mouse leave", () => {
+			mapTreeViewLevelController.onMouseLeave()
+			expect($rootScope.$broadcast).toHaveBeenCalledWith("should-unhover-node", mapTreeViewLevelController.node)
+		})
+	})
 
-    describe("Clicks behaviour", () => {
+	describe("Clicks behaviour", () => {
+		it("Right click", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			let context = {
+				path: mapTreeViewLevelController.node.path,
+				type: mapTreeViewLevelController.node.type,
+				x: $event.clientX,
+				y: $event.clientY
+			}
+			mapTreeViewLevelController.onRightClick($event)
 
-        it("Right click", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            let context = {"path": mapTreeViewLevelController.node.path, "type": mapTreeViewLevelController.node.type, "x": $event.clientX, "y": $event.clientY};
-            mapTreeViewLevelController.onRightClick($event);
+			expect($rootScope.$broadcast).toHaveBeenCalledWith("hide-node-context-menu")
+			expect($rootScope.$broadcast).toHaveBeenCalledWith("show-node-context-menu", context)
+		})
 
-            expect($rootScope.$broadcast).toHaveBeenCalledWith("hide-node-context-menu");
-            expect($rootScope.$broadcast).toHaveBeenCalledWith("show-node-context-menu", context);
-        });
+		it("Folder click collapse", () => {
+			mapTreeViewLevelController.collapsed = true
+			mapTreeViewLevelController.onFolderClick()
+			expect(mapTreeViewLevelController.collapsed).toBeFalsy()
+		})
 
-        it("Folder click collapse", () => {
-            mapTreeViewLevelController.collapsed = true;
-            mapTreeViewLevelController.onFolderClick();
-            expect(mapTreeViewLevelController.collapsed).toBeFalsy();
-        });
+		it("Folder click uncollapse", () => {
+			mapTreeViewLevelController.collapsed = false
+			mapTreeViewLevelController.onFolderClick()
+			expect(mapTreeViewLevelController.collapsed).toBeTruthy()
+		})
 
-        it("Folder click uncollapse", () => {
-            mapTreeViewLevelController.collapsed = false;
-            mapTreeViewLevelController.onFolderClick();
-            expect(mapTreeViewLevelController.collapsed).toBeTruthy();
-        });
+		it("Label click", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/", "Folder")
+			mapTreeViewLevelController.codeMapActionsService.focusNode = jest.fn()
+			mapTreeViewLevelController.onLabelClick()
 
-        it("Label click", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/", "Folder");
-            mapTreeViewLevelController.codeMapActionsService.focusNode = jest.fn();
-            mapTreeViewLevelController.onLabelClick();
+			expect(mapTreeViewLevelController.codeMapActionsService.focusNode).toHaveBeenCalledWith(mapTreeViewLevelController.node)
+		})
 
-            expect(mapTreeViewLevelController.codeMapActionsService.focusNode).toHaveBeenCalledWith(mapTreeViewLevelController.node);
-        });
+		it("Eye click", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/", "Folder")
+			mapTreeViewLevelController.codeMapActionsService.toggleNodeVisibility = jest.fn()
+			mapTreeViewLevelController.onEyeClick()
 
-        it("Eye click", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/", "Folder");
-            mapTreeViewLevelController.codeMapActionsService.toggleNodeVisibility = jest.fn();
-            mapTreeViewLevelController.onEyeClick();
+			expect(mapTreeViewLevelController.codeMapActionsService.toggleNodeVisibility).toHaveBeenCalledWith(
+				mapTreeViewLevelController.node
+			)
+		})
 
-            expect(mapTreeViewLevelController.codeMapActionsService.toggleNodeVisibility).toHaveBeenCalledWith(mapTreeViewLevelController.node);
-        });
+		it("Is leaf", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File")
+			expect(mapTreeViewLevelController.isLeaf()).toBeTruthy()
+		})
 
-        it("Is leaf", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File");
-            expect(mapTreeViewLevelController.isLeaf()).toBeTruthy();
-        });
+		it("Is not leaf", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			expect(mapTreeViewLevelController.isLeaf(mapTreeViewLevelController.node)).toBeFalsy()
+		})
 
-        it("Is not leaf", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            expect(mapTreeViewLevelController.isLeaf(mapTreeViewLevelController.node)).toBeFalsy();
-        });
+		it("Is blacklisted", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
 
-        it("Is blacklisted", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
+			CodeMapUtilService.isBlacklisted = jest.fn()
+			mapTreeViewLevelController.isBlacklisted(mapTreeViewLevelController.node)
 
-            CodeMapUtilService.isBlacklisted = jest.fn();
-            mapTreeViewLevelController.isBlacklisted(mapTreeViewLevelController.node);
+			expect(CodeMapUtilService.isBlacklisted).toHaveBeenCalledWith(
+				mapTreeViewLevelController.node,
+				settingsServiceMock.settings.blacklist,
+				BlacklistType.exclude
+			)
+		})
 
-            expect(CodeMapUtilService.isBlacklisted).toHaveBeenCalledWith(
-                mapTreeViewLevelController.node, settingsServiceMock.settings.blacklist, BlacklistType.exclude);
-        });
+		it("Not blacklisted, not exist", () => {
+			CodeMapUtilService.isBlacklisted = jest.fn()
+			let blacklisted = mapTreeViewLevelController.isBlacklisted(mapTreeViewLevelController.node)
+			expect(blacklisted).toBeFalsy()
+		})
 
-        it("Not blacklisted, not exist", () => {
-            CodeMapUtilService.isBlacklisted = jest.fn();
-            let blacklisted = mapTreeViewLevelController.isBlacklisted(mapTreeViewLevelController.node);
-            expect(blacklisted).toBeFalsy();
-        });
+		it("Is searched", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			mapTreeViewLevelController.settingsService.settings.searchedNodePaths = ["/root/a", "/root/a/ab"]
+			let searched = mapTreeViewLevelController.isSearched(mapTreeViewLevelController.node)
+			expect(searched).toBeTruthy()
+		})
 
-        it("Is searched", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            mapTreeViewLevelController.settingsService.settings.searchedNodePaths = ["/root/a", "/root/a/ab"];
-            let searched = mapTreeViewLevelController.isSearched(mapTreeViewLevelController.node);
-            expect(searched).toBeTruthy();
-        });
+		it("Is not searched", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			mapTreeViewLevelController.settingsService.settings.searchedNodePaths = ["/root/a"]
+			let searched = mapTreeViewLevelController.isSearched(mapTreeViewLevelController.node)
+			expect(searched).toBeFalsy()
+		})
 
-        it("Is not searched", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            mapTreeViewLevelController.settingsService.settings.searchedNodePaths = ["/root/a"];
-            let searched = mapTreeViewLevelController.isSearched(mapTreeViewLevelController.node);
-            expect(searched).toBeFalsy();
-        });
+		it("Sort leaf", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File")
+			let sortValue = mapTreeViewLevelController.sortByFolder(mapTreeViewLevelController.node)
+			expect(sortValue).toBe(0)
+		})
 
-        it("Sort leaf", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File");
-            let sortValue = mapTreeViewLevelController.sortByFolder(mapTreeViewLevelController.node);
-            expect(sortValue).toBe(0);
-        });
+		it("Sort not a leaf", () => {
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder")
+			let sortValue = mapTreeViewLevelController.sortByFolder(mapTreeViewLevelController.node)
+			expect(sortValue).toBe(1)
+		})
 
-        it("Sort not a leaf", () => {
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab", "Folder");
-            let sortValue = mapTreeViewLevelController.sortByFolder(mapTreeViewLevelController.node);
-            expect(sortValue).toBe(1);
-        });
+		it("Subscribe Hover", () => {
+			instantiateModule("app.codeCharta.ui.mapTreeView")
 
-        it("Subscribe Hover", () => {
+			const services = {
+				$rootScope: getService<IRootScopeService>("$rootScope"),
+				settingsService: getService<SettingsService>("settingsService"),
+				codeMapActionsService: getService<CodeMapActionsService>("codeMapActionsService")
+			}
 
-            instantiateModule("app.codeCharta.ui.mapTreeView"); 
+			mapTreeViewLevelController = new MapTreeViewLevelController(
+				services.$rootScope,
+				services.codeMapActionsService,
+				services.settingsService
+			)
 
-            const services = {
-                $rootScope: getService<IRootScopeService>("$rootScope"),
-                settingsService: getService<SettingsService>("settingsService"),
-                codeMapActionsService: getService<CodeMapActionsService>("codeMapActionsService"),
-            };
+			mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File")
+			MapTreeViewLevelController.subscribeToHoverEvents(services.$rootScope, subscriber)
+			mapTreeViewLevelController.onMouseEnter()
+			mapTreeViewLevelController.onMouseLeave()
+			services.$rootScope.$digest()
 
-            mapTreeViewLevelController = new MapTreeViewLevelController(services.$rootScope, services.codeMapActionsService, services.settingsService);
-
-            mapTreeViewLevelController.node = codeMapUtilService.getCodeMapNodeFromPath("/root/a/ab/aba", "File");
-            MapTreeViewLevelController.subscribeToHoverEvents(services.$rootScope, subscriber);
-            mapTreeViewLevelController.onMouseEnter();
-            mapTreeViewLevelController.onMouseLeave();
-            services.$rootScope.$digest();
-
-            expect(subscriber.onShouldHoverNode).toBeCalledWith(mapTreeViewLevelController.node);
-            expect(subscriber.onShouldUnhoverNode).toBeCalledWith(mapTreeViewLevelController.node);
-
-        });
-    });
-});
+			expect(subscriber.onShouldHoverNode).toBeCalledWith(mapTreeViewLevelController.node)
+			expect(subscriber.onShouldUnhoverNode).toBeCalledWith(mapTreeViewLevelController.node)
+		})
+	})
+})

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
@@ -1,18 +1,21 @@
 import {SettingsService} from "../../core/settings/settings.service";
-import {IRootScopeService} from "angular";
+import {IRootScopeService, IAngularEvent} from "angular";
 import {CodeMapNode, BlacklistType} from "../../core/data/model/CodeMap";
 import {NodeContextMenuController} from "../nodeContextMenu/nodeContextMenu.component";
 import {CodeMapActionsService} from "../codeMap/codeMap.actions.service";
 import {CodeMapUtilService} from "../codeMap/codeMap.util.service";
 import {AngularColors} from "../codeMap/rendering/renderSettings";
+import { CodeMapMouseEventServiceSubscriber, CodeMapBuildingTransition, CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service";
+import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding";
 
 export interface MapTreeViewHoverEventSubscriber {
     onShouldHoverNode(node: CodeMapNode);
     onShouldUnhoverNode(node: CodeMapNode);
 }
 
-export class MapTreeViewLevelController {
+export class MapTreeViewLevelController implements CodeMapMouseEventServiceSubscriber{
 
+    public _isHoveredInCodeMap: boolean = false;
     public node: CodeMapNode = null;
     public depth: number = 0;
     public collapsed: boolean = true;
@@ -24,7 +27,7 @@ export class MapTreeViewLevelController {
         private codeMapActionsService: CodeMapActionsService,
         private settingsService: SettingsService
     ) {
-
+        CodeMapMouseEventService.subscribe(this.$rootScope, this);
     }
 
     public getFolderColor() {
@@ -32,6 +35,20 @@ export class MapTreeViewLevelController {
             return "#000";
         }
         return this.node.markingColor ? "#" + this.node.markingColor.substr(2) : "#000";
+    }
+
+    public onBuildingHovered(data: CodeMapBuildingTransition, event: IAngularEvent) {
+        if(data.to && data.to.node.path === this.node.path) {
+            this._isHoveredInCodeMap = true;
+        } else {
+            this._isHoveredInCodeMap = false;
+        }
+    }
+    public onBuildingSelected(data: CodeMapBuildingTransition, event: IAngularEvent) {
+        // unused
+    }
+    public onBuildingRightClicked(building: CodeMapBuilding, x: number, y: number, event: IAngularEvent) {
+        // unused
     }
 
     public onMouseEnter() {

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
@@ -38,7 +38,7 @@ export class MapTreeViewLevelController implements CodeMapMouseEventServiceSubsc
     }
 
     public onBuildingHovered(data: CodeMapBuildingTransition, event: IAngularEvent) {
-        if(data.to && data.to.node.path === this.node.path) {
+        if(data.to && data.to.node && this.node && this.node.path && data.to.node.path === this.node.path) {
             this._isHoveredInCodeMap = true;
         } else {
             this._isHoveredInCodeMap = false;


### PR DESCRIPTION
closes #351
Merge permission: {CC-Member}

## Description

This PR closes #351. This was falsely identified as a feature request since it was already implemented but non functional due to a typo in the html template (see [this commit](https://github.com/MaibornWolff/codecharta/commit/4be9f46851eee31c3299f385d5010ace23076ee0)).

This PR also adds the functionality to mark a tree view element when it is hovered in the codemap (the other way round).  

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [ ] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
