### PR TITLE
Feature/391/select buttons multiple mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ## [unreleased]
 ### Added
 
+-	Added buttons to select all/none/inversion of revisions/maps in multiple mode #391
+
 ### Changed
 
 ### Removed

--- a/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.html
+++ b/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.html
@@ -1,10 +1,13 @@
 <md-input-container class="md-block">
-    <i class="fa fa-folder-open"></i>
-    <i class="fa fa-download"></i>
+	<i class="fa fa-folder-open"></i>
+	<i class="fa fa-download"></i>
 
-    <md-select ng-model="$ctrl.selectedMapIndices" multiple="{{true}}" ng-change="$ctrl.onMultipleChange()">
-        <md-option ng-repeat="(key, value) in $ctrl.revisions" value="{{::key}}">
-            {{::value.fileName}}
-        </md-option>
-    </md-select>
+	<md-select ng-model="$ctrl.selectedMapIndices" multiple="{{ true }}" ng-change="$ctrl.onMultipleChange()">
+		<md-button ng-click="$ctrl.selectAllRevisions()">All</md-button>
+		<md-button ng-click="$ctrl.selectNoRevisions()">None</md-button>
+		<md-button ng-click="$ctrl.intertRevisionSelection()">Invert</md-button>
+		<md-option ng-repeat="(key, value) in $ctrl.revisions" value="{{::key}}">
+			{{::value.fileName}}
+		</md-option>
+	</md-select>
 </md-input-container>

--- a/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.spec.ts
@@ -198,4 +198,46 @@ describe("multipleFilePanelController", function() {
 			expect(multipleFilePanelController.selectedMapIndices).toEqual([0, 1])
 		})
 	})
+
+	describe("selectAllRevisions", () => {
+		it("should select all Revisions", () => {
+			multipleFilePanelController.revisions = [file1, file2]
+			multipleFilePanelController.selectedMapIndices = []
+
+			multipleFilePanelController.selectAllRevisions()
+
+			expect(multipleFilePanelController.selectedMapIndices).toEqual([0, 1])
+		})
+	})
+
+	describe("selectNoRevisions", () => {
+		it("should unselect all Revisions", () => {
+			multipleFilePanelController.revisions = [file1, file2, file1]
+			multipleFilePanelController.selectedMapIndices = [1, 2]
+
+			multipleFilePanelController.selectNoRevisions()
+
+			expect(multipleFilePanelController.selectedMapIndices).toEqual([])
+		})
+
+		it("should unselect all Revisions", () => {
+			multipleFilePanelController.revisions = [file1, file2]
+			multipleFilePanelController.selectedMapIndices = [0, 1]
+
+			multipleFilePanelController.selectNoRevisions()
+
+			expect(multipleFilePanelController.selectedMapIndices).toEqual([])
+		})
+	})
+
+	describe("invertRevisionSelection", () => {
+		it("should invert all revision selections", () => {
+			multipleFilePanelController.revisions = [file1, file2, file1]
+			multipleFilePanelController.selectedMapIndices = [1]
+
+			multipleFilePanelController.intertRevisionSelection()
+
+			expect(multipleFilePanelController.selectedMapIndices).toEqual([0, 2])
+		})
+	})
 })

--- a/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.ts
+++ b/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.ts
@@ -3,6 +3,7 @@ import "./multipleFilePanel.component.scss"
 import { DataModel, DataService, DataServiceSubscriber } from "../../core/data/data.service"
 import { CodeMap } from "../../core/data/model/CodeMap"
 import { MultipleFileService } from "../../core/multipleFile/multipleFile.service"
+import { type } from "os"
 
 export class MultipleFilePanelController implements DataServiceSubscriber, SettingsServiceSubscriber {
 	public settings: Settings
@@ -45,6 +46,30 @@ export class MultipleFilePanelController implements DataServiceSubscriber, Setti
 
 	public onSettingsChanged(settings: Settings, event: Event) {
 		this.settings = settings
+	}
+
+	public selectAllRevisions() {
+		this.selectedMapIndices = []
+		for (let i = 0; i < this.revisions.length; i++) {
+			this.selectedMapIndices.push(i)
+		}
+		this.onMultipleChange()
+	}
+
+	public selectNoRevisions() {
+		this.selectedMapIndices = []
+		this.onMultipleChange()
+	}
+
+	public intertRevisionSelection() {
+		const oldRevisions = this.selectedMapIndices.map(Number)
+		this.selectedMapIndices = []
+		for (let i = 0; i < this.revisions.length; i++) {
+			if (!oldRevisions.includes(i)) {
+				this.selectedMapIndices.push(i)
+			}
+		}
+		this.onMultipleChange()
 	}
 
 	private updateSelectedMapIndices() {

--- a/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.ts
+++ b/visualization/app/codeCharta/ui/multipleFilePanel/multipleFilePanel.component.ts
@@ -3,7 +3,6 @@ import "./multipleFilePanel.component.scss"
 import { DataModel, DataService, DataServiceSubscriber } from "../../core/data/data.service"
 import { CodeMap } from "../../core/data/model/CodeMap"
 import { MultipleFileService } from "../../core/multipleFile/multipleFile.service"
-import { type } from "os"
 
 export class MultipleFilePanelController implements DataServiceSubscriber, SettingsServiceSubscriber {
 	public settings: Settings


### PR DESCRIPTION
# Added buttons to select all/none revision/maps or invert selection in multiple file mode

closes #391 
Merge permission: {CC-Member | @member}

## Description

- Added buttons to multipleFilePanel to select all/none loaded revisions/maps or invert the selection.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [ ] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
