### PR TITLE
Setting reference map to chosen revision/map on change of revision mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+-	Fixed bug that code map was not re-loaded when changing from multiple to single revision mode #396
+
 ## [1.21.2] - 2019-02-26
 
 ### Added

--- a/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.component.spec.ts
@@ -1,75 +1,106 @@
-import {RevisionChooserController} from "./revisionChooser.component";
-import {DataService} from "../../core/data/data.service";
-import {SettingsService} from "../../core/settings/settings.service";
+import { RevisionChooserController } from "./revisionChooser.component"
+import { DataService, DataModel } from "../../core/data/data.service"
+import { SettingsService, Settings } from "../../core/settings/settings.service"
+import { CodeMap } from "../../core/data/model/CodeMap"
 
 describe("RevisionChooserController", () => {
+	let dataServiceMock: DataService
+	let settingsServiceMock: SettingsService
+	let revisionChooserController: RevisionChooserController
+	const revs = [{ fileName: "java" } as CodeMap, { fileName: "kotlin" } as CodeMap]
 
-    let dataServiceMock: DataService;
-    let settingsServiceMock: SettingsService;
-    let revisionChooserController: RevisionChooserController;
+	function buildController() {
+		revisionChooserController = new RevisionChooserController(dataServiceMock, settingsServiceMock, {
+			$on: jest.fn(),
+			$broadcast: jest.fn()
+		})
+	}
 
-    function rebuildSUT() {
-        revisionChooserController = new RevisionChooserController(dataServiceMock, settingsServiceMock, {
-            $on: jest.fn(),
-            $broadcast: jest.fn()
-        });
-    }
+	function mockEverything() {
+		const DataServiceMock = jest.fn<DataService>(() => ({
+			setComparisonMap: jest.fn(),
+			setReferenceMap: jest.fn(),
+			subscribe: jest.fn(),
+			getComparisonMap: jest.fn(),
+			getReferenceMap: jest.fn(),
+			getIndexOfMap: jest.fn(),
+			$rootScope: {
+				$on: jest.fn(),
+				$broadcast: jest.fn()
+			},
+			data: {
+				revisions: revs
+			},
+			notify: () => {
+				revisionChooserController.onDataChanged(dataServiceMock.data)
+			}
+		}))
 
-    function mockEverything() {
+		dataServiceMock = new DataServiceMock()
 
-        const DataServiceMock = jest.fn<DataService>(() => ({
-            setComparisonMap: jest.fn(),
-            setReferenceMap: jest.fn(),
-            subscribe: jest.fn(),
-            getComparisonMap: jest.fn(),
-            getReferenceMap: jest.fn(),
-            getIndexOfMap: jest.fn(),
-            $rootScope: {
-                $on: jest.fn(),
-                $broadcast: jest.fn()
-            },
-            data: {
-                revisions: []
-            },
-            notify: ()=>{
-                revisionChooserController.onDataChanged(dataServiceMock.data);
-            }
-        }));
+		const SettingsServiceMock = jest.fn<SettingsService>(() => ({ applySettings: jest.fn() }))
 
-        dataServiceMock = new DataServiceMock();
+		settingsServiceMock = new SettingsServiceMock()
+	}
 
-        const SettingsServiceMock = jest.fn<SettingsService>(() => ({}));
+	beforeAll(() => {
+		mockEverything()
+		buildController()
+	})
 
-        settingsServiceMock = new SettingsServiceMock();
+	beforeEach(() => {
+		jest.resetAllMocks()
+	})
 
-        rebuildSUT();
+	it("should subscribe to dataService on construction", () => {
+		const revisionChooserController = new RevisionChooserController(dataServiceMock, settingsServiceMock, {
+			$on: jest.fn(),
+			$broadcast: jest.fn()
+		})
+		expect(dataServiceMock.subscribe).toHaveBeenCalledWith(revisionChooserController)
+	})
 
-    }
+	it("should get revisions from data service on startup", () => {
+		expect(revisionChooserController.revisions).toBe(dataServiceMock.data.revisions)
+	})
 
-    beforeEach(()=>{
-        mockEverything();
-    });
+	it("onDataChanged should refresh revisions", () => {
+		revisionChooserController.onDataChanged({ revisions: revs } as DataModel)
 
-    it("should subscribe to dataService on construction", () => {
-        expect(dataServiceMock.subscribe).toHaveBeenCalledWith(revisionChooserController);
-    });
+		expect(revisionChooserController.revisions).toBe(revs)
+		expect(dataServiceMock.getIndexOfMap).toHaveBeenCalledTimes(2)
+		expect(dataServiceMock.getComparisonMap).toHaveBeenCalledTimes(1)
+		expect(dataServiceMock.getReferenceMap).toHaveBeenCalledTimes(1)
+	})
 
-    it("should get revisions from data service on startup", () => {
-        dataServiceMock.data.revisions = ["Some Revision"];
-        rebuildSUT();
-        expect(revisionChooserController.revisions).toBe(dataServiceMock.data.revisions);
-    });
+	it("onReferenceChange should set the referenceMap", () => {
+		revisionChooserController.onReferenceChange(42)
 
-    it("onDataChanged should refresh revisions", () => {
-        const revs = ["some", "revisions"];
-        revisionChooserController.onDataChanged({revisions: revs});
-        expect(revisionChooserController.revisions).toBe(revs);
-    });
+		expect(dataServiceMock.setReferenceMap).toBeCalledWith(42)
+		expect(dataServiceMock.setReferenceMap).toHaveBeenCalledTimes(1)
+	})
 
-    it("onDataChanged should be called when dataService.notify is called", () => {
-        revisionChooserController.onDataChanged = jest.fn();
-        dataServiceMock.notify();
-        expect(revisionChooserController.onDataChanged).toHaveBeenCalled();
-    });
+	it("onComparisonChange should set the comparisonMap", () => {
+		revisionChooserController.onComparisonChange(42)
 
-});
+		expect(dataServiceMock.setComparisonMap).toBeCalledWith(42)
+		expect(dataServiceMock.setComparisonMap).toHaveBeenCalledTimes(1)
+	})
+
+	it("onShowChange should update the settings and set the referenceMap", () => {
+		const expected = { areaMetric: "rloc" } as Settings
+
+		revisionChooserController.onShowChange(expected)
+
+		expect(revisionChooserController.settings).toBe(expected)
+		expect(settingsServiceMock.applySettings).toHaveBeenCalledTimes(1)
+		expect(dataServiceMock.setReferenceMap).toHaveBeenCalledTimes(1)
+		expect(dataServiceMock.setReferenceMap).toBeCalledWith(revisionChooserController.ui.chosenReference)
+	})
+
+	it("onDataChanged should be called when dataService.notify is called", () => {
+		revisionChooserController.onDataChanged = jest.fn()
+		dataServiceMock.notify()
+		expect(revisionChooserController.onDataChanged).toHaveBeenCalled()
+	})
+})

--- a/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.component.ts
+++ b/visualization/app/codeCharta/ui/revisionChooser/revisionChooser.component.ts
@@ -1,78 +1,67 @@
-import {DataServiceSubscriber, DataService, DataModel} from "../../core/data/data.service";
-import {KindOfMap, Settings, SettingsService} from "../../core/settings/settings.service";
-import {CodeMap} from "../../core/data/model/CodeMap";
-import "./revisionChooser.component.scss";
-import "./revisionChooserFileDropDown.component.scss";
+import { DataServiceSubscriber, DataService, DataModel } from "../../core/data/data.service"
+import { KindOfMap, Settings, SettingsService } from "../../core/settings/settings.service"
+import { CodeMap } from "../../core/data/model/CodeMap"
+import "./revisionChooser.component.scss"
+import "./revisionChooserFileDropDown.component.scss"
 
 /**
  * Controls the RevisionChooser
  */
-export class RevisionChooserController implements DataServiceSubscriber{
+export class RevisionChooserController implements DataServiceSubscriber {
+	public revisions: CodeMap[]
+	public settings: Settings
+	public ui = {
+		chosenReference: null,
+		chosenComparison: null
+	}
+	public show = KindOfMap
 
-    public revisions: CodeMap[];
-    public settings: Settings;
-    public ui = {
-        chosenReference: null,
-        chosenComparison: null,
-    };
-    public show = KindOfMap;
+	/* @ngInject */
 
-    /* @ngInject */
+	/**
+	 * @listens {data-changed}
+	 * @constructor
+	 * @param {DataService} dataService
+	 */
+	constructor(private dataService: DataService, private settingsService: SettingsService, private $rootScope) {
+		this.revisions = dataService.data.revisions
+		this.settings = settingsService.settings
+		this.ui.chosenComparison = this.dataService.getIndexOfMap(this.dataService.getComparisonMap(), this.revisions)
+		this.ui.chosenReference = this.dataService.getIndexOfMap(this.dataService.getReferenceMap(), this.revisions)
+		dataService.subscribe(this)
+		this.$rootScope.$on("revision-mode-changed", (event, data) => {
+			this.show = data
+		})
+	}
 
-    /**
-     * @listens {data-changed}
-     * @constructor
-     * @param {DataService} dataService
-     */
-    constructor(
-        private dataService: DataService,
-        private settingsService: SettingsService,
-        private $rootScope
-    ) {
-        this.revisions = dataService.data.revisions;
-        this.settings = settingsService.settings;
-        this.ui.chosenComparison = this.dataService.getIndexOfMap(this.dataService.getComparisonMap(), this.revisions);
-        this.ui.chosenReference = this.dataService.getIndexOfMap(this.dataService.getReferenceMap(), this.revisions);
-        dataService.subscribe(this);
-        this.$rootScope.$on("revision-mode-changed", (event, data)=>{
-            this.show = data;
-        });
+	public onDataChanged(data: DataModel) {
+		this.revisions = data.revisions
+		this.ui.chosenComparison = this.dataService.getIndexOfMap(this.dataService.getComparisonMap(), this.revisions)
+		this.ui.chosenReference = this.dataService.getIndexOfMap(this.dataService.getReferenceMap(), this.revisions)
+	}
 
-    }
+	public onReferenceChange(mapIndex: number) {
+		this.dataService.setReferenceMap(mapIndex)
+	}
 
-    public onDataChanged(data: DataModel) {
-        this.revisions = data.revisions;
-        this.ui.chosenComparison= this.dataService.getIndexOfMap(this.dataService.getComparisonMap(), this.revisions);
-        this.ui.chosenReference = this.dataService.getIndexOfMap(this.dataService.getReferenceMap(), this.revisions);
-    }
+	public onComparisonChange(mapIndex: number) {
+		this.dataService.setComparisonMap(mapIndex)
+	}
 
-    public onReferenceChange(mapIndex: number) {
-        this.dataService.setReferenceMap(mapIndex);
-    }
-
-    public onComparisonChange(mapIndex: number) {
-        this.dataService.setComparisonMap(mapIndex);
-    }
-
-
-
-    public onShowChange(settings: Settings){
-        this.settings = settings;
-        this.settingsService.applySettings();
-
-     }
+	public onShowChange(settings: Settings) {
+		this.settings = settings
+		this.settingsService.applySettings()
+		this.dataService.setReferenceMap(this.ui.chosenReference)
+	}
 }
 
 export const revisionChooserComponent = {
-    selector: "revisionChooserComponent",
-    template: require("./revisionChooser.component.html"),
-    controller: RevisionChooserController
-};
+	selector: "revisionChooserComponent",
+	template: require("./revisionChooser.component.html"),
+	controller: RevisionChooserController
+}
 export const revisionChooserFileDropDownComponent = {
-    selector: "revisionChooserFileDropDownComponent",
-    template: require("./revisionChooserFileDropDown.component.html"),
-    controller: RevisionChooserController
-};
-
-
-
+	selector: "revisionChooserFileDropDownComponent",
+	template: require("./revisionChooserFileDropDown.component.html"),
+	controller: RevisionChooserController
+}

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -713,7 +713,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -4917,7 +4917,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
@@ -7331,7 +7331,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "dev": true,
       "requires": {
@@ -7368,7 +7368,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -7391,7 +7391,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -10146,7 +10146,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -10794,7 +10794,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -11277,7 +11277,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/visualization/tsconfig.json
+++ b/visualization/tsconfig.json
@@ -18,5 +18,5 @@
 		"strictNullChecks": false,
 		"declaration": false
 	},
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/visualization/tsconfig.json
+++ b/visualization/tsconfig.json
@@ -1,29 +1,22 @@
 {
-    "compileOnSave": true,
-    "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "lib": [
-            "dom",
-            "es2015",
-            "es2016"
-        ],
-        "jsx": "preserve",
-        "target": "es2016",
-        "module": "es2015",
-        "moduleResolution": "node",
-        "noImplicitAny": false,
-        "noUnusedLocals": false,
-        "noUnusedParameters": false,
-        "removeComments": true,
-        "preserveConstEnums": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "allowJs": false,
-        "strictNullChecks": false,
-        "declaration": false
-    },
-    "exclude": [
-        "node_modules",
-        "**/*.spec.ts"
-    ]
+	"compileOnSave": true,
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"lib": ["dom", "es2015", "es2016"],
+		"jsx": "preserve",
+		"target": "es2016",
+		"module": "es2015",
+		"moduleResolution": "node",
+		"noImplicitAny": false,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"removeComments": true,
+		"preserveConstEnums": true,
+		"sourceMap": true,
+		"skipLibCheck": true,
+		"allowJs": false,
+		"strictNullChecks": false,
+		"declaration": false
+	},
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Setting reference map to chosen revision/map on change of revision mode

closes #396 
Merge permission: {CC-Member | @member}

## Description

- Setting reference map to chosen revision/map on change of revision mode. This is done to fix the issue that the code map would not be re-rendered when switching from multiple to single revision mode.
- Increased test coverage for `revisionChooser.component.ts`

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
