### PR TITLE
MergeFilter can merge all files within folder(s) #392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added
 
 -	Added buttons to select all/none/inversion of revisions/maps in multiple mode #391
+-	Merge filter can merge all files of folders #392
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added
 
-<<<<<<< HEAD
--	Added buttons to select all/none/inversion of revisions/maps in multiple mode #391
--	Merge filter can merge all files of folders #392
-=======
 -   Added buttons to select all/none/inversion of revisions/maps in multiple mode #391
->>>>>>> master
+-   Merge filter can merge all files of folders #392
 
 ### Changed
 
@@ -24,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
--	Fixed bug that code map was not re-loaded when changing from multiple to single revision mode #396
+-   Fixed bug that code map was not re-loaded when changing from multiple to single revision mode #396
 
 ## [1.21.2] - 2019-02-26
 

--- a/analysis/filter/MergeFilter/build.gradle
+++ b/analysis/filter/MergeFilter/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     implementation project(':model')
 
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
+    implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
+
 
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spek2_version") {

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -73,11 +73,7 @@ class MergeFilter : Callable<Void?> {
 
         val sourceFiles = mutableListOf<File>()
         for(source in sources){
-            if(source.isDirectory){
-                sourceFiles.addAll(getFilesInFolder(source))
-            } else {
-                sourceFiles.add(source)
-            }
+            sourceFiles.addAll(getFilesInFolder(source))
         }
 
         val srcProjects = sourceFiles

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -42,7 +42,7 @@ class MergeFilter : Callable<Void?> {
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
 
-    @CommandLine.Parameters(arity = "1..*", paramLabel = "FILE", description = ["files to merge"])
+    @CommandLine.Parameters(arity = "1..*", paramLabel = "FILE or FOLDER", description = ["files to merge"])
     private var sources: Array<File> = arrayOf()
 
     @CommandLine.Option(names = ["-a", "--add-missing"], description = ["enable adding missing nodes to reference"])
@@ -68,6 +68,12 @@ class MergeFilter : Callable<Void?> {
                     else -> throw IllegalArgumentException("Only one merging strategy must be set")
                 }
 
+        for(source in sources){
+            if(source.isDirectory){
+                sources += getFilesInFolder(source)
+            }
+        }
+
         val srcProjects = sources
                 .map { it.bufferedReader() }
                 .map { ProjectDeserializer.deserializeProject(it) }
@@ -78,6 +84,11 @@ class MergeFilter : Callable<Void?> {
         ProjectSerializer.serializeProject(mergedProject, writer)
 
         return null
+    }
+
+    private fun getFilesInFolder(folder: File): Array<File>{
+        val files =  folder.walk().filter{ !it.name.startsWith(".")}
+        return files.toList().toTypedArray()
     }
 
     companion object {

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -1,0 +1,62 @@
+package de.maibornwolff.codecharta.filter.mergefilter
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.PrintStream
+import java.io.ByteArrayOutputStream
+
+
+
+class MergeFilterTest : Spek({
+    val outContent = ByteArrayOutputStream()
+    val originalOut = System.out
+    val errContent = ByteArrayOutputStream()
+    val originalErr = System.err
+    describe("merge filter test") {
+
+        context("merging a folder") {
+            val projectLocation = "src/test/resources/mergeFolderTest"
+            val valueInFile1 = "SourceMonCsvConverterTest.java"
+            val valueInFile2 = "SourceMonCsvConverter.java"
+            val invalidFile = "invalid.json"
+
+            System.setOut(PrintStream(outContent))
+            System.setErr(PrintStream(errContent))
+            MergeFilter.main(arrayOf(projectLocation)).toString()
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+
+            it("should ignore files starting with a dot") {
+                assertThat(outContent.toString(), not(containsString("ShouldNotAppear.java")))
+            }
+
+            it("should merge all valid projects in folder") {
+                assertThat(outContent.toString(), containsString(valueInFile1))
+                assertThat(outContent.toString(), containsString(valueInFile2))
+            }
+
+            it("should warn about skipped files"){
+                assertThat(errContent.toString(), containsString(invalidFile))
+            }
+        }
+
+        context("merging files"){
+            System.setOut(PrintStream(outContent))
+            MergeFilter.main(
+                    arrayOf(
+                            "src/test/resources/mergeFolderTest/file1.cc.json",
+                            "src/test/resources/mergeFolderTest/file2.cc.json"
+                    )).toString()
+            System.setOut(originalOut)
+            val valueInFile1 = "SourceMonCsvConverterTest.java"
+            val valueInFile2 = "SourceMonCsvConverter.java"
+
+            it("should merge all indicated files") {
+                assertThat(outContent.toString(), containsString(valueInFile1))
+                assertThat(outContent.toString(), containsString(valueInFile2))
+            }
+        }
+    }
+})

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/.doNotScan
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/.doNotScan
@@ -1,0 +1,36 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": []
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "ShouldNotAppear.java",
+                  "type": "File",
+                  "attributes": {
+                    "nloc*": 80.0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1.cc.json
@@ -1,0 +1,36 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "SourceMonCsvConverter.java",
+                  "type": "File",
+                  "attributes": {
+                    "nloc*": 80.0
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2.cc.json
@@ -1,0 +1,36 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": []
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "SourceMonCsvConverterTest.java",
+                  "type": "File",
+                  "attributes": {
+                    "nloc*": 80.0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/invalid.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/invalid.json
@@ -1,0 +1,1 @@
+{"object": "whatever"}


### PR DESCRIPTION
# MergeFilter can merge all files within folder(s)

closes #392 
Merge permission: {CC-Member | @member}

## Description

- MergeFilter, accepts now folders as input parameters. When a folder location is provided, it is scanned for valid project files, which will then be merged. For each invalid file a warning is given, files starting with a dot are ignored.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
