### PR TITLE
Feature/394/project name can be specified on merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ## [unreleased]
 
 ### Added
+-   Project Name can be specified for merge filter #394
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+-   Throw a MergeException if project names do not match in MergeFilter #394 
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Project Name can be specified for merge filter #394
 
 ### Changed
+-   Throw a MergeException if project names do not match in MergeFilter #394 
 
 ### Removed
 
 ### Fixed
--   Throw a MergeException if project names do not match in MergeFilter #394 
 
 ### Chore
 

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -58,6 +58,9 @@ class MergeFilter : Callable<Void?> {
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
 
+    @CommandLine.Option(names = ["-p", "--project-name"], description = ["Specify project name for merged file"])
+    private var projectName: String? = null
+
     @CommandLine.Option(names = ["--ignore-case"], description = ["ignores case when checking node names"])
     private var ignoreCase = false
 
@@ -87,7 +90,7 @@ class MergeFilter : Callable<Void?> {
                     }
                 }
 
-        val mergedProject = ProjectMerger(srcProjects, nodeMergerStrategy).merge()
+        val mergedProject = ProjectMerger(srcProjects, nodeMergerStrategy, projectName).merge()
 
         val writer = outputFile?.bufferedWriter() ?: System.out.bufferedWriter()
         ProjectSerializer.serializeProject(mergedProject, writer)

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
@@ -35,7 +35,12 @@ class ProjectMerger(private val projects: List<Project>, private val nodeMerger:
 
     fun extractProjectName(): String {
         if(projectName != null) return projectName
-        return projects.map { p -> p.projectName }.first()
+
+        val projectNames = projects.map { p -> p.projectName }
+        if (!projectNames.all { p -> p == projectNames.first() }){
+            throw MergeException("Project Names do not match. If files with different project names should be merged, a new project name must be provided using -p.")
+        }
+        return projectNames.first()
     }
 
     fun merge(): Project {

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
@@ -31,9 +31,10 @@ package de.maibornwolff.codecharta.filter.mergefilter
 
 import de.maibornwolff.codecharta.model.*
 
-class ProjectMerger(private val projects: List<Project>, private val nodeMerger: NodeMergerStrategy) {
+class ProjectMerger(private val projects: List<Project>, private val nodeMerger: NodeMergerStrategy, private val projectName: String? = null) {
 
     fun extractProjectName(): String {
+        if(projectName != null) return projectName
         return projects.map { p -> p.projectName }.first()
     }
 

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
@@ -60,8 +60,9 @@ class ProjectMergerTest : Spek({
             )
 
             it("should throw a exception") {
-                val firstProjectName = ProjectMerger(projects, nodeMergerStrategy).extractProjectName()
-                assertThat(firstProjectName, CoreMatchers.`is`("test1"))
+                assertFailsWith(MergeException::class) {
+                    ProjectMerger(projects, nodeMergerStrategy).merge()
+                }
             }
         }
 

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
@@ -65,6 +65,20 @@ class ProjectMergerTest : Spek({
             }
         }
 
+        context("merging project providing a project name"){
+            val projectName = "arbitraryString"
+            val projects = listOf(
+                    Project("test1"),
+                    Project("test2")
+            )
+
+            it("project should have provided project name"){
+                val projectNameMerge = ProjectMerger(projects, nodeMergerStrategy, projectName).extractProjectName()
+                assertThat(projectNameMerge, CoreMatchers.`is`(projectName))
+            }
+
+        }
+
         context("merging project with same API major versions") {
             val projectName = "test"
             val projects = listOf(

--- a/analysis/filter/MergeFilter/src/test/resources/testEdges2.json
+++ b/analysis/filter/MergeFilter/src/test/resources/testEdges2.json
@@ -1,5 +1,5 @@
 {
-  "projectName": "Sample Project 2",
+  "projectName": "Sample Project 1",
   "apiVersion": "1.0",
   "nodes": [{
       "name": "root",


### PR DESCRIPTION
# Project name can be specified for Merge Filter

closes #394 
Merge permission: {CC-Member | @member}

## Description

- New option (-p) to specify project name of merged file in MergeFilter
- Fixed bug that no MergeException was thrown when project names did not match

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail
