### PR TITLE
Bug/498/filechooser-cancel-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 -	Prevent downloaded files from having multiple Timestamps #484
+-   Do not show loadingGif when cancelling the fileChooser #498
 
 ### Chore
 

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.spec.ts
@@ -8,7 +8,7 @@ import { FileStateService } from "../../state/fileState.service"
 import { DialogService } from "../dialog/dialog.service"
 import { FileChooserController } from "./fileChooser.component"
 import { TEST_FILE_CONTENT } from "../../util/dataMocks"
-import {CodeChartaController} from "../../codeCharta.component";
+import { CodeChartaController } from "../../codeCharta.component"
 import _ from "lodash"
 
 describe("fileChooserController", () => {
@@ -94,9 +94,9 @@ describe("fileChooserController", () => {
 			expect($scope.$apply).toHaveBeenCalled()
 		})
 
-		it("should broadcast the loading-status-changed event", () => {
+		it("should not broadcast the loading-status-changed event if no file loaded", () => {
 			fileChooserController.onImportNewFiles({ files: [] })
-			expect($rootScope.$broadcast).toHaveBeenCalledWith(CodeChartaController.LOADING_STATUS_EVENT, true)
+			expect($rootScope.$broadcast).not.toHaveBeenCalledWith(CodeChartaController.LOADING_STATUS_EVENT, true)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.ts
@@ -26,11 +26,13 @@ export class FileChooserController {
     }
 
     public onImportNewFiles(element) {
-        this.$rootScope.$broadcast(CodeChartaController.LOADING_STATUS_EVENT, true)
         this.$scope.$apply(() => {
             this.fileStateService.resetMaps()
             for(let file of element.files) {
                 let reader = new FileReader()
+                reader.onloadstart = () => {
+                    this.$rootScope.$broadcast(CodeChartaController.LOADING_STATUS_EVENT, true)
+                }
                 reader.onload = (event) => {
                     this.setNewData(file.name, (<any>event.target).result)
                 };


### PR DESCRIPTION
# Bug/498/filechooser-cancel-button

closes #498 
Merge permission: CC-Member

## Description

- Do not show loadingGif when cancelling the fileChooser (show loadingGif not before the FileReader actually starts to load files)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

* [x] **All** requirements mentioned in the issue are implemented
* [x] Does match the Code of Conduct and the Contribution file 
* [x] Task has its own **GitHub issue** (something it is solving)
  * [x] Issue number is **included in the commit messages** for traceability
* [x] **Update the README.md** with any changes/additions made
* [x] **Update the CHANGELOG.md** with any changes/additions made
* [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
* [x] **All tests pass**    
* [x] **Descriptive pull request text**, answering:
  + What problem/issue are you fixing?
  + What does this PR implement and how? 
* [x] **Assign your PR to someone** for a code review
  + This person _will be contacted **first**_ if a bug is introduced into `master`
* [x] **Manual testing** did not fail