### PR TITLE
Bug/542/Renaming breaks hierarchy in SVN log parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
 ### Added
+- SVN log parser keeps track of renaming of files for metric calculation #542
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+- Entries with renaming information in SVN logs are attributed to correct file #542
 
 ### Chore
 

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/Commit.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/Commit.kt
@@ -21,9 +21,11 @@ class Commit(val author: String, modifications: List<Modification>, val commitDa
                 .filter { !it.filename.isEmpty() }
     }
 
-    fun getModification(filename: String): List<Modification> {
-        // TODO: Probably only one Modification per file name, possibly refactor to return Modification
-        // we assume that in one commit there is only one modification for a file.
-        return modifications.filter { filename == it.filename }
+    fun getModification(filename: String): Modification {
+        val modifications = modifications.filter { filename == it.filename }
+        if (modifications.size != 1) {
+            throw IllegalStateException("No unique file name was found in commit for $filename, ${modifications.size} files were found")
+        }
+        return modifications.first()
     }
 }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/Commit.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/Commit.kt
@@ -22,6 +22,7 @@ class Commit(val author: String, modifications: List<Modification>, val commitDa
     }
 
     fun getModification(filename: String): List<Modification> {
+        // TODO: Probably only one Modification per file name, possibly refactor to return Modification
         // we assume that in one commit there is only one modification for a file.
         return modifications.filter { filename == it.filename }
     }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
@@ -38,13 +38,9 @@ class VersionControlledFile internal constructor(
      */
     fun registerCommit(commit: Commit) {
         val modification = commit.getModification(filename)
-
-        modification.forEach { mod ->
-            metrics.forEach { it.registerCommit(commit) }
-            authors.add(commit.author)
-
-            registerModification(mod)
-        }
+        metrics.forEach { it.registerCommit(commit) }
+        authors.add(commit.author)
+        registerModification(modification)
     }
 
     private fun registerModification(modification: Modification) {

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/git/GitLogNumstatRawParserStrategy.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/git/GitLogNumstatRawParserStrategy.kt
@@ -33,10 +33,10 @@ class GitLogNumstatRawParserStrategy: LogParserStrategy {
                 .filter { isFileLine(it) }
                 .map { parseModification(it) }
                 .groupingBy { it.filename }
-                .aggregate { _, mod1: Modification?, mod2, _ ->
-                    when (mod1) {
-                        null -> mergeModifications(mod2)
-                        else -> mergeModifications(mod1, mod2)
+                .aggregate { _, aggregatedModification: Modification?, currentModificatoin, _ ->
+                    when (aggregatedModification) {
+                        null -> mergeModifications(currentModificatoin)
+                        else -> mergeModifications(aggregatedModification, currentModificatoin)
                     }
                 }
                 .values
@@ -73,7 +73,7 @@ class GitLogNumstatRawParserStrategy: LogParserStrategy {
                     a.map { it.type }.firstOrNull { t -> t != Modification.Type.UNKNOWN } ?: Modification.Type.UNKNOWN
 
             if (type == Modification.Type.RENAME) {
-                val oldFilename = a.map { it.oldFilename }.firstOrNull { s -> !s.isEmpty() } ?: ""
+                val oldFilename = a.map { it.oldFilename }.firstOrNull { s -> s.isNotEmpty() } ?: ""
                 return Modification(filename, oldFilename, additions, deletions, type)
             }
 

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/git/GitLogNumstatRawParserStrategy.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/git/GitLogNumstatRawParserStrategy.kt
@@ -33,10 +33,10 @@ class GitLogNumstatRawParserStrategy: LogParserStrategy {
                 .filter { isFileLine(it) }
                 .map { parseModification(it) }
                 .groupingBy { it.filename }
-                .aggregate { _, aggregatedModification: Modification?, currentModificatoin, _ ->
+                .aggregate { _, aggregatedModification: Modification?, currentModification, _ ->
                     when (aggregatedModification) {
-                        null -> mergeModifications(currentModificatoin)
-                        else -> mergeModifications(aggregatedModification, currentModificatoin)
+                        null -> mergeModifications(currentModification)
+                        else -> mergeModifications(aggregatedModification, currentModification)
                     }
                 }
                 .values

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
@@ -79,9 +79,9 @@ class SVNLogParserStrategy: LogParserStrategy {
     }
 
     private fun parseRenameModification(filePathLine: String): Modification {
-        val fileNames = filePathLine.split(" (from")
+        val fileNames = filePathLine.split(RENAME_FILE_LINE_IDENTIFIER)
         val oldFileNameWithPrefix = fileNames.last().split(":").first()
-        val oldFileName = removeDefaultRepositoryFolderPrefix(oldFileNameWithPrefix.trim { it <= ' ' })
+        val oldFileName = removeDefaultRepositoryFolderPrefix(oldFileNameWithPrefix)
         val newFileName = fileNames.first()
 
         return ignoreIfRepresentsFolder(Modification(newFileName, oldFileName, Modification.Type.RENAME))
@@ -97,7 +97,7 @@ class SVNLogParserStrategy: LogParserStrategy {
 
     companion object {
 
-        private const val RENAME_FILE_LINE_IDENTIFIER =  " (from"
+        private const val RENAME_FILE_LINE_IDENTIFIER = " (from "
         private val SVN_COMMIT_SEPARATOR_TEST =
                 Predicate<String> { logLine -> logLine.isNotEmpty() && StringUtils.containsOnly(logLine, '-') }
         private val DEFAULT_REPOSITORY_FOLDER_PREFIXES = arrayOf("/branches/", "/tags/", "/trunk/", "/")

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
@@ -80,10 +80,9 @@ class SVNLogParserStrategy: LogParserStrategy {
 
     private fun parseRenameModification(filePathLine: String): Modification {
         val fileNames = filePathLine.split(" (from")
-        val oldFileName = removeDefaultRepositoryFolderPrefix(fileNames.last().split(":").first().trim { it <= ' ' })
+        val oldFileNameWithPrefix = fileNames.last().split(":").first()
+        val oldFileName = removeDefaultRepositoryFolderPrefix(oldFileNameWithPrefix.trim { it <= ' ' })
         val newFileName = fileNames.first()
-
-        println("Rename $oldFileName to $newFileName")
 
         return ignoreIfRepresentsFolder(Modification(newFileName, oldFileName, Modification.Type.RENAME))
     }
@@ -101,7 +100,7 @@ class SVNLogParserStrategy: LogParserStrategy {
         private const val RENAME_FILE_LINE_IDENTIFIER =  " (from"
         private val SVN_COMMIT_SEPARATOR_TEST =
                 Predicate<String> { logLine -> logLine.isNotEmpty() && StringUtils.containsOnly(logLine, '-') }
-        private val DEFAULT_REPOSITORY_FOLDER_PREFIXES = arrayOf("/branches/", "/tags/", "/trunk/")
+        private val DEFAULT_REPOSITORY_FOLDER_PREFIXES = arrayOf("/branches/", "/tags/", "/trunk/", "/")
         private val DATE_TIME_FORMATTER = DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
                 .append(DateTimeFormatter.ISO_LOCAL_DATE)

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
@@ -49,20 +49,6 @@ class SVNLogParserStrategy: LogParserStrategy {
         return commitLines
                 .filter { this.isFileLine(it) }
                 .map { this.parseModification(it) }
-        //.groupBy { it.filename }
-
-        /*
-        .groupingBy { it.filename }
-                .aggregate { _, mod1: Modification?, mod2, _ ->
-                    when (mod1) {
-                        null -> mergeModifications(mod2)
-                        else -> mergeModifications(mod1, mod2)
-                    }
-                }
-                .values
-                .filterNotNull()
-                .toList()
-         */
     }
 
     private fun isFileLine(commitLine: String): Boolean {
@@ -94,7 +80,7 @@ class SVNLogParserStrategy: LogParserStrategy {
 
     private fun parseRenameModification(filePathLine: String): Modification {
         val fileNames = filePathLine.split(" (from")
-        val oldFileName = fileNames.last().split(":").first()
+        val oldFileName = removeDefaultRepositoryFolderPrefix(fileNames.last().split(":").first().trim { it <= ' ' })
         val newFileName = fileNames.first()
 
         println("Rename $oldFileName to $newFileName")

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
@@ -3,6 +3,7 @@ package de.maibornwolff.codecharta.importer.scmlogparser
 import de.maibornwolff.codecharta.importer.scmlogparser.converter.ProjectConverter
 import de.maibornwolff.codecharta.importer.scmlogparser.input.metrics.MetricsFactory
 import de.maibornwolff.codecharta.importer.scmlogparser.parser.LogParserStrategy
+import de.maibornwolff.codecharta.importer.scmlogparser.parser.git.GitLogNumstatRawParserStrategy
 import de.maibornwolff.codecharta.importer.scmlogparser.parser.git.GitLogParserStrategy
 import de.maibornwolff.codecharta.importer.scmlogparser.parser.svn.SVNLogParserStrategy
 import de.maibornwolff.codecharta.model.Project
@@ -33,6 +34,7 @@ class SCMLogProjectCreatorGoldenMasterTest(
         fun data(): Collection<Array<Any>> {
             return Arrays.asList(
                     arrayOf("svn", SVNLogParserStrategy(), true, "example_svn.log", "expected_svn.json"),
+                    arrayOf("git_numstat", GitLogNumstatRawParserStrategy(), true, "example_git_numstat.log", "expected_git_numstat.json"),
                     arrayOf("git", GitLogParserStrategy(), false, "example_git.log", "expected_git.json"))
         }
     }

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverterTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverterTest.kt
@@ -45,7 +45,7 @@ class ProjectConverterTest {
         //given
         val projectConverter = ProjectConverter(true, "ProjectWithAuthors")
         val file1 = VersionControlledFile("File 1", metricsFactory)
-        file1.registerCommit(Commit("Author", modificationsByFilename("File 1, File 2"), OffsetDateTime.now()))
+        file1.registerCommit(Commit("Author", modificationsByFilename("File 1", "File 2"), OffsetDateTime.now()))
 
         //when
         val project = projectConverter.convert(Arrays.asList(file1))
@@ -59,7 +59,7 @@ class ProjectConverterTest {
         //given
         val projectConverter = ProjectConverter(false, "ProjectWithoutAuthors")
         val file1 = VersionControlledFile("File 1", metricsFactory)
-        file1.registerCommit(Commit("Author", modificationsByFilename("File 1, File 2"), OffsetDateTime.now()))
+        file1.registerCommit(Commit("Author", modificationsByFilename("File 1", "File 2"), OffsetDateTime.now()))
 
         //when
         val project = projectConverter.convert(Arrays.asList(file1))

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFileTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFileTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.jupiter.api.Assertions
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -54,24 +55,19 @@ class VersionControlledFileTest {
     }
 
     @Test
-    fun ignoresCommitsForDifferentFiles() {
-        // given
-        val modificationMetric = mockk<Metric>()
-
+    fun throwsExceptionIfFileIsNotInCommit() {
         val versionControlledFile = VersionControlledFile(
                 "filename",
-                Arrays.asList(modificationMetric)
+                listOf()
         )
 
-        // when
         val modification = Modification("anotherFilename")
         val commit = createCommit("An Author", modification)
-        versionControlledFile.registerCommit(commit)
 
-        // then
-        assertThat(versionControlledFile.authors).isEmpty()
+        Assertions.assertThrows(IllegalStateException::class.java) {
+            versionControlledFile.registerCommit(commit)
+        }
 
-        verify(exactly = 0) { modificationMetric.registerModification(any()) }
     }
 
     @Test
@@ -157,8 +153,7 @@ class VersionControlledFileTest {
         val modifications = Arrays.asList(
                 Modification(filename),
                 Modification(filename, oldFilename, Modification.Type.RENAME),
-                Modification(oldFilename),
-                Modification(filename)
+                Modification(oldFilename)
         )
         modifications
                 .forEach { mod -> versionControlledFile.registerCommit(createCommit("An Author", mod)) }

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/ParserStrategyContractTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/ParserStrategyContractTest.kt
@@ -47,7 +47,7 @@ abstract class ParserStrategyContractTest {
         val modifications = logParserStrategy.parseModifications(fullCommit)
         assertThat(modifications).hasSize(3)
         assertThat(modifications)
-                .extracting<String, RuntimeException>({ it.filename })
+                .extracting<String, RuntimeException> { it.filename }
                 .containsExactlyInAnyOrder("src/Added.java", "src/Modified.java", "src/Deleted.java")
     }
 

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategyTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategyTest.kt
@@ -90,7 +90,7 @@ class SVNLogParserStrategyTest: ParserStrategyContractTest() {
         val commitString = mutableListOf("------------------------------------------------------------------------",
                 "r156657 | dpagam05 | 2017-01-02 03:12:18 +0100 (Mo, 02 Jan 2017) | 1 line",
                 "Changed paths:",
-                "    M src/Modified.java",
+                "    M /src/Modified.java",
                 "Task | Increased automaticly build number | builduser01",
                 "------------------------------------------------------------------------")
         val commit = parser.parseCommit(commitString)

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategyTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategyTest.kt
@@ -33,28 +33,28 @@ class SVNLogParserStrategyTest: ParserStrategyContractTest() {
     @Test
     fun parsesFilenameFromFileMetadata() {
         val modification = parserStrategy.parseModification("   M /src/srcFolderTest.txt")
-        assertThat(modification.filename).isEqualTo("/src/srcFolderTest.txt")
+        assertThat(modification.filename).isEqualTo("src/srcFolderTest.txt")
         assertThat(modification.type).isEqualTo(Modification.Type.MODIFY)
     }
 
     @Test
     fun parsesFilenameFromAddedFile() {
         val modification = parserStrategy.parseModification("   A /src/srcFolderTest.txt")
-        assertThat(modification.filename).isEqualTo("/src/srcFolderTest.txt")
+        assertThat(modification.filename).isEqualTo("src/srcFolderTest.txt")
         assertThat(modification.type).isEqualTo(Modification.Type.ADD)
     }
 
     @Test
     fun parsesFilenameFromDeletedFile() {
         val modification = parserStrategy.parseModification("   D  /src/srcFolderTest.txt")
-        assertThat(modification.filename).isEqualTo("/src/srcFolderTest.txt")
+        assertThat(modification.filename).isEqualTo("src/srcFolderTest.txt")
         assertThat(modification.type).isEqualTo(Modification.Type.DELETE)
     }
 
     @Test
     fun parsesFilenameFromReplacedFile() {
         val modification = parserStrategy.parseModification("   R  /src/srcFolderTest.txt")
-        assertThat(modification.filename).isEqualTo("/src/srcFolderTest.txt")
+        assertThat(modification.filename).isEqualTo("src/srcFolderTest.txt")
         assertThat(modification.type).isEqualTo(Modification.Type.UNKNOWN)
     }
 

--- a/analysis/import/SCMLogParser/src/test/resources/example_git_numstat.log
+++ b/analysis/import/SCMLogParser/src/test/resources/example_git_numstat.log
@@ -1,0 +1,48 @@
+commit ca2b5e43cc5a5250e556a098f077b4d0a287107e (HEAD -> bug/renaming-breaks-hierarchy-svn-scmlogparser, origin/bug/renaming-breaks-hierarchy-svn-scmlogparser)
+Author: Alex Hunziker <alexhunziker91@gmail.com>
+Date:   Fri May 24 16:36:11 2019 +0200
+
+    Refactoring of SVNLogParserStrategy #542
+
+:100644 100644 5059d980 90e7c69d M      analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+15      21      analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+
+commit ca2b5e43cc5a5250e556a098f077b4d0a287107e (HEAD -> bug/renaming-breaks-hierarchy-svn-scmlogparser, origin/bug/renaming-breaks-hierarchy-svn-scmlogparser)
+Author: Alex Hunziker <alexhunziker91@gmail.com>
+Date:   Fri May 24 16:36:11 2019 +0200
+
+    Refactoring of SVNLogParserStrategy #542
+
+:100644 100644 5059d980 90e7c69d M      analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+15      21      analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+
+commit b8b392d90099aedde9583c546f8181aa5d119259
+Author: Alex Hunziker <alexhunziker91@gmail.com>
+Date:   Fri May 24 16:35:03 2019 +0200
+
+    Improved and updated SVN test log #542
+
+:100644 100644 3836af61 146503e3 M      analysis/import/SCMLogParser/src/test/resources/example_svn.log
+:100644 100644 17573e3d e26c38e9 M      analysis/import/SCMLogParser/src/test/resources/expected_svn.json
+1       1       analysis/import/SCMLogParser/src/test/resources/example_svn.log
+22      14      analysis/import/SCMLogParser/src/test/resources/expected_svn.json
+
+commit 84858d47edc72129b6a12c93e833191570088e21
+Author: anonymous <>
+Date:   Fri Dec 15 22:30:45 2017 +0100
+
+    rename test
+
+:100644 100644 e0fd40f... a55a55d... R092	analysis/import/SCMLogParser/src/test/resources/example_svn123.log	analysis/import/SCMLogParser/src/test/resources/example_svn.log
+3	3	analysis/import/SCMLogParser/src/test/resources/{example_svn123.log => example_svn.log}
+
+commit 2649528347cf50031d8c35458a59045dd69fd466
+Author: Alex Hunziker <alexhunziker91@gmail.com>
+Date:   Fri May 24 16:06:49 2019 +0200
+
+    Added renaming methods to SVNLogParser #542
+
+:100644 100644 2a465d9a 5059d980 M      analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+:100644 100644 a933e3fa 3836af61 M      analysis/import/SCMLogParser/src/test/resources/example_svn123.log
+24      1       analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/svn/SVNLogParserStrategy.kt
+20      0       analysis/import/SCMLogParser/src/test/resources/example_svn123.log

--- a/analysis/import/SCMLogParser/src/test/resources/example_svn.log
+++ b/analysis/import/SCMLogParser/src/test/resources/example_svn.log
@@ -41,7 +41,7 @@ Changed paths:
 Multiline commit message, this is long
 and even longer
 ------------------------------------------------------------------------
-r1 | MartinSc | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
+r1 | AlexH | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
 Changed paths:
    A /trunk/src
    A /trunk/src/innerFolder

--- a/analysis/import/SCMLogParser/src/test/resources/example_svn.log
+++ b/analysis/import/SCMLogParser/src/test/resources/example_svn.log
@@ -29,5 +29,25 @@ Changed paths:
    A /tags
    A /trunk
 
+Rename this
+------------------------------------------------------------------------
+r1 | MartinSc | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
+Changed paths:
+   A /trunk/src
+   A /trunk/src/innerFolder
+   A /trunk/src/innerFolder/BestClassEver.java
+   A /trunk/src/srcFolderTest.txt (from /trunk/src/srcFolderTest1.txt:123)
+
+Multiline commit message, this is long
+and even longer
+------------------------------------------------------------------------
+r1 | MartinSc | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
+Changed paths:
+   A /trunk/src
+   A /trunk/src/innerFolder
+   A /trunk/src/innerFolder/BestClassEver.java
+   A /trunk/src/srcFolderTest1.txt
+
+
 Imported folder structure
 ------------------------------------------------------------------------

--- a/analysis/import/SCMLogParser/src/test/resources/example_svn.log
+++ b/analysis/import/SCMLogParser/src/test/resources/example_svn.log
@@ -37,6 +37,7 @@ Changed paths:
    A /trunk/src/innerFolder
    A /trunk/src/innerFolder/BestClassEver.java
    A /trunk/src/srcFolderTest.txt (from /trunk/src/srcFolderTest_OLDNAME.txt:123)
+   D /trunk/src/srcFolderTest_OLDNAME.txt
 
 Multiline commit message, this is long
 and even longer

--- a/analysis/import/SCMLogParser/src/test/resources/example_svn.log
+++ b/analysis/import/SCMLogParser/src/test/resources/example_svn.log
@@ -31,22 +31,22 @@ Changed paths:
 
 Rename this
 ------------------------------------------------------------------------
-r1 | MartinSc | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
+r1 | MartinSc | 2016-06-10 14:12:47 +0200 (Fr, 10 Jun 2016) | 1 line
 Changed paths:
    A /trunk/src
    A /trunk/src/innerFolder
    A /trunk/src/innerFolder/BestClassEver.java
-   A /trunk/src/srcFolderTest.txt (from /trunk/src/srcFolderTest1.txt:123)
+   A /trunk/src/srcFolderTest.txt (from /trunk/src/srcFolderTest_OLDNAME.txt:123)
 
 Multiline commit message, this is long
 and even longer
 ------------------------------------------------------------------------
-r1 | AlexH | 2016-06-10 14:14:47 +0200 (Fr, 10 Jun 2016) | 1 line
+r1 | AlexH | 2016-06-10 14:10:47 +0200 (Fr, 10 Jun 2016) | 1 line
 Changed paths:
    A /trunk/src
    A /trunk/src/innerFolder
    A /trunk/src/innerFolder/BestClassEver.java
-   A /trunk/src/srcFolderTest1.txt
+   A /trunk/src/srcFolderTest_OLDNAME.txt
 
 
 Imported folder structure

--- a/analysis/import/SCMLogParser/src/test/resources/expected_git_numstat.json
+++ b/analysis/import/SCMLogParser/src/test/resources/expected_git_numstat.json
@@ -1,0 +1,181 @@
+{
+  "projectName": "SCMLogParser",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "attributes": {},
+      "link": "",
+      "children": [
+        {
+          "name": "analysis",
+          "type": "Folder",
+          "attributes": {},
+          "link": "",
+          "children": [
+            {
+              "name": "import",
+              "type": "Folder",
+              "attributes": {},
+              "link": "",
+              "children": [
+                {
+                  "name": "SCMLogParser",
+                  "type": "Folder",
+                  "attributes": {},
+                  "link": "",
+                  "children": [
+                    {
+                      "name": "src",
+                      "type": "Folder",
+                      "attributes": {},
+                      "link": "",
+                      "children": [
+                        {
+                          "name": "main",
+                          "type": "Folder",
+                          "attributes": {},
+                          "link": "",
+                          "children": [
+                            {
+                              "name": "kotlin",
+                              "type": "Folder",
+                              "attributes": {},
+                              "link": "",
+                              "children": [
+                                {
+                                  "name": "de",
+                                  "type": "Folder",
+                                  "attributes": {},
+                                  "link": "",
+                                  "children": [
+                                    {
+                                      "name": "maibornwolff",
+                                      "type": "Folder",
+                                      "attributes": {},
+                                      "link": "",
+                                      "children": [
+                                        {
+                                          "name": "codecharta",
+                                          "type": "Folder",
+                                          "attributes": {},
+                                          "link": "",
+                                          "children": [
+                                            {
+                                              "name": "importer",
+                                              "type": "Folder",
+                                              "attributes": {},
+                                              "link": "",
+                                              "children": [
+                                                {
+                                                  "name": "scmlogparser",
+                                                  "type": "Folder",
+                                                  "attributes": {},
+                                                  "link": "",
+                                                  "children": [
+                                                    {
+                                                      "name": "parser",
+                                                      "type": "Folder",
+                                                      "attributes": {},
+                                                      "link": "",
+                                                      "children": [
+                                                        {
+                                                          "name": "svn",
+                                                          "type": "Folder",
+                                                          "attributes": {},
+                                                          "link": "",
+                                                          "children": [
+                                                            {
+                                                              "name": "SVNLogParserStrategy.kt",
+                                                              "type": "File",
+                                                              "attributes": {
+                                                                "number_of_authors": 1,
+                                                                "number_of_commits": 3,
+                                                                "range_of_weeks_with_commits": 1,
+                                                                "successive_weeks_with_commits": 1,
+                                                                "weeks_with_commits": 1,
+                                                                "authors": [
+                                                                  "Alex Hunziker"
+                                                                ]
+                                                              },
+                                                              "link": "",
+                                                              "children": []
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "test",
+                          "type": "Folder",
+                          "attributes": {},
+                          "link": "",
+                          "children": [
+                            {
+                              "name": "resources",
+                              "type": "Folder",
+                              "attributes": {},
+                              "link": "",
+                              "children": [
+                                {
+                                  "name": "example_svn.log",
+                                  "type": "File",
+                                  "attributes": {
+                                    "number_of_authors": 2,
+                                    "number_of_commits": 3,
+                                    "range_of_weeks_with_commits": 76,
+                                    "successive_weeks_with_commits": 1,
+                                    "weeks_with_commits": 2,
+                                    "authors": ["Alex Hunziker", "anonymous"]
+                                  },
+                                  "link": "",
+                                  "children": []
+                                },
+                                {
+                                  "name": "expected_svn.json",
+                                  "type": "File",
+                                  "attributes": {
+                                    "number_of_authors": 1,
+                                    "number_of_commits": 1,
+                                    "range_of_weeks_with_commits": 1,
+                                    "successive_weeks_with_commits": 1,
+                                    "weeks_with_commits": 1,
+                                    "authors": ["Alex Hunziker"]
+                                  },
+                                  "link": "",
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiVersion": "1.1",
+  "edges": [],
+  "attributeTypes": {},
+  "blacklist": []
+}

--- a/analysis/import/SCMLogParser/src/test/resources/expected_svn.json
+++ b/analysis/import/SCMLogParser/src/test/resources/expected_svn.json
@@ -56,24 +56,10 @@
               "attributes": {
                 "weeks_with_commits": 1,
                 "range_of_weeks_with_commits": 1,
-                "number_of_commits": 3,
+                "number_of_commits": 4,
                 "successive_weeks_with_commits": 1,
-                "number_of_authors": 1,
-                "authors": ["MartinSc"]
-              },
-              "link": "",
-              "children": []
-            },
-            {
-              "name": "srcFolderTest1.txt",
-              "type": "File",
-              "attributes": {
-                "weeks_with_commits": 1,
-                "range_of_weeks_with_commits": 1,
-                "number_of_commits": 1,
-                "successive_weeks_with_commits": 1,
-                "number_of_authors": 1,
-                "authors": ["AlexH"]
+                "number_of_authors": 2,
+                "authors": ["MartinSc", "AlexH"]
               },
               "link": "",
               "children": []

--- a/analysis/import/SCMLogParser/src/test/resources/expected_svn.json
+++ b/analysis/import/SCMLogParser/src/test/resources/expected_svn.json
@@ -1,6 +1,6 @@
 {
   "projectName": "SCMLogParser",
-  "apiVersion": "1.0",
+  "apiVersion": "1.1",
   "nodes": [
     {
       "name": "root",
@@ -26,12 +26,10 @@
                   "attributes": {
                     "weeks_with_commits": 1,
                     "range_of_weeks_with_commits": 1,
-                    "number_of_commits": 3,
+                    "number_of_commits": 5,
                     "successive_weeks_with_commits": 1,
-                    "number_of_authors": 1,
-                    "authors": [
-                      "MartinSc"
-                    ]
+                    "number_of_authors": 2,
+                    "authors": ["MartinSc", "AlexH"]
                   },
                   "link": "",
                   "children": []
@@ -45,9 +43,7 @@
                     "number_of_commits": 2,
                     "successive_weeks_with_commits": 1,
                     "number_of_authors": 1,
-                    "authors": [
-                      "MartinSc"
-                    ]
+                    "authors": ["MartinSc"]
                   },
                   "link": "",
                   "children": []
@@ -60,12 +56,24 @@
               "attributes": {
                 "weeks_with_commits": 1,
                 "range_of_weeks_with_commits": 1,
-                "number_of_commits": 2,
+                "number_of_commits": 3,
                 "successive_weeks_with_commits": 1,
                 "number_of_authors": 1,
-                "authors": [
-                  "MartinSc"
-                ]
+                "authors": ["MartinSc"]
+              },
+              "link": "",
+              "children": []
+            },
+            {
+              "name": "srcFolderTest1.txt",
+              "type": "File",
+              "attributes": {
+                "weeks_with_commits": 1,
+                "range_of_weeks_with_commits": 1,
+                "number_of_commits": 1,
+                "successive_weeks_with_commits": 1,
+                "number_of_authors": 1,
+                "authors": ["AlexH"]
               },
               "link": "",
               "children": []


### PR DESCRIPTION
# Renaming information in SVN log leads to wrong file attribution

closes #542 

## Description

- SVN Entries that contain renaming information are now attributed to the correct file
- SVNLogParser now keeps track of renaming, in order to correctly calculate metrics for renamed files
- Some refactoring of SVNLogParser and VersionControlled File. Exception is now thrown if file path+name are ambiguous in a commit
- Test cases (e2e) for svn + git parser to check correct renaming

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
