### PR TITLE
Bugfix: Changing Margin and then file or mode results in endless loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
+
 ### Added
+
 - SVN log parser keeps track of renaming of files for metric calculation #542
 
 ### Changed
@@ -14,7 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed
 
 ### Fixed
+
 - Entries with renaming information in SVN logs are attributed to correct file #542
+- Changing margin and then file or mode will no longer freeze the application #524
 
 ### Chore
 

--- a/visualization/app/codeCharta/ui/areaSettingsPanel/areaSettingsPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/areaSettingsPanel/areaSettingsPanel.component.spec.ts
@@ -72,6 +72,12 @@ describe("AreaSettingsPanelController", () => {
 
 			expect(CodeMapPreRenderService.subscribe).toHaveBeenCalledWith($rootScope, areaSettingsPanelController)
 		})
+
+		it("should subscribe to FileStateService", () => {
+			rebuildController()
+
+			expect(FileStateService.subscribe).toHaveBeenCalledWith($rootScope, areaSettingsPanelController)
+		})
 	})
 
 	describe("onSettingsChanged", () => {
@@ -148,6 +154,40 @@ describe("AreaSettingsPanelController", () => {
 			areaSettingsPanelController.onRenderFileChanged(file, undefined)
 
 			expect(areaSettingsPanelController.applySettings).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("onFileSelectionStatesChanged", () => {
+		it("should set dynamicMargin in viewModel to true", () => {
+			areaSettingsPanelController.onFileSelectionStatesChanged(undefined, undefined)
+
+			expect(areaSettingsPanelController["_viewModel"].dynamicMargin).toBeTruthy()
+		})
+
+		it("should update margin and dynamicMargin in settingsService", () => {
+			areaSettingsPanelController.onFileSelectionStatesChanged(undefined, undefined)
+
+			expect(settingsService.updateSettings).toHaveBeenCalledWith({
+				dynamicSettings: { margin: 28 },
+				appSettings: { dynamicMargin: true }
+			})
+		})
+	})
+
+	describe("onImportedFilesChanged", () => {
+		it("should set dynamicMargin in viewModel to true", () => {
+			areaSettingsPanelController.onImportedFilesChanged(undefined, undefined)
+
+			expect(areaSettingsPanelController["_viewModel"].dynamicMargin).toBeTruthy()
+		})
+
+		it("should update margin and dynamicMargin in settingsService", () => {
+			areaSettingsPanelController.onImportedFilesChanged(undefined, undefined)
+
+			expect(settingsService.updateSettings).toHaveBeenCalledWith({
+				dynamicSettings: { margin: 28 },
+				appSettings: { dynamicMargin: true }
+			})
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/areaSettingsPanel/areaSettingsPanel.component.ts
+++ b/visualization/app/codeCharta/ui/areaSettingsPanel/areaSettingsPanel.component.ts
@@ -1,11 +1,13 @@
 import "./areaSettingsPanel.component.scss"
 import { IRootScopeService } from "angular"
 import { SettingsService, SettingsServiceSubscriber } from "../../state/settings.service"
-import { CCFile, CodeMapNode, RecursivePartial, Settings } from "../../codeCharta.model"
+import { CCFile, CodeMapNode, FileState, RecursivePartial, Settings } from "../../codeCharta.model"
 import { hierarchy, HierarchyNode } from "d3-hierarchy"
 import { CodeMapPreRenderService, CodeMapPreRenderServiceSubscriber } from "../codeMap/codeMap.preRender.service"
+import { FileStateService, FileStateServiceSubscriber } from "../../state/fileState.service"
 
-export class AreaSettingsPanelController implements SettingsServiceSubscriber, CodeMapPreRenderServiceSubscriber {
+export class AreaSettingsPanelController
+	implements SettingsServiceSubscriber, CodeMapPreRenderServiceSubscriber, FileStateServiceSubscriber {
 	private static MIN_MARGIN = 15
 	private static MAX_MARGIN = 100
 	private static MARGIN_FACTOR = 4
@@ -26,6 +28,7 @@ export class AreaSettingsPanelController implements SettingsServiceSubscriber, C
 	) {
 		SettingsService.subscribe(this.$rootScope, this)
 		CodeMapPreRenderService.subscribe(this.$rootScope, this)
+		FileStateService.subscribe(this.$rootScope, this)
 	}
 
 	public onSettingsChanged(settings: Settings, update: RecursivePartial<Settings>, event: angular.IAngularEvent) {
@@ -37,6 +40,21 @@ export class AreaSettingsPanelController implements SettingsServiceSubscriber, C
 	public onRenderFileChanged(renderFile: CCFile, event: angular.IAngularEvent) {
 		this._viewModel.dynamicMargin = this.settingsService.getSettings().appSettings.dynamicMargin
 		this.potentiallyUpdateMargin(renderFile, this.settingsService.getSettings())
+	}
+
+	public onFileSelectionStatesChanged(fileStates: FileState[], event: angular.IAngularEvent) {
+		this.resetDynamicMargin()
+		this.potentiallyUpdateMargin(this.codeMapPreRenderService.getRenderFile(), this.settingsService.getSettings())
+	}
+
+	public onImportedFilesChanged(fileStates: FileState[], event: angular.IAngularEvent) {
+		this.resetDynamicMargin()
+		this.potentiallyUpdateMargin(this.codeMapPreRenderService.getRenderFile(), this.settingsService.getSettings())
+	}
+
+	private resetDynamicMargin() {
+		this._viewModel.dynamicMargin = true
+		this.applySettingsDynamicMargin()
 	}
 
 	public onChangeMarginSlider() {


### PR DESCRIPTION
# Changing margin and then file or mode will no longer freeze the application

closes #524

## Description
- when mode or file is changed, we set dynamicMargin in the viewModel to true again and update the settings so that the margin can be calculated correctly again

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
