### PR TITLE
Bugfix: Unary metric no longer vanishes when a folder is excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased]
+
 ### Added
+
 - SVN log parser keeps track of renaming of files for metric calculation #542
 
 ### Changed
@@ -14,7 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed
 
 ### Fixed
+
 - Entries with renaming information in SVN logs are attributed to correct file #542
+- Unary metric will no longer be removed from the MetricChooser-Dropdown when a folder was excluded or hidden #548
 
 ### Chore
 

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -46,6 +46,7 @@ export class MetricService implements FileStateServiceSubscriber, SettingsServic
 				FileStateHelper.getVisibleFileStates(fileStates),
 				update.fileSettings.blacklist
 			)
+			this.addUnaryMetric()
 			this.notifyMetricDataAdded()
 		}
 	}


### PR DESCRIPTION
# Unary metric no longer vanishes when a folder is excluded

closes #548 

## Description
- unary metric is added to metricData again after settings change

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
