### PR TITLE
Fix set default colorRange onClickResetButton #560

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Fix set default ColorRange when resetting color section #560
+
 ### Chore
 
 ## [1.25.1] - 2019-05-30

--- a/visualization/app/codeCharta/ui/colorSettingsPanel/colorSettingsPanel.component.html
+++ b/visualization/app/codeCharta/ui/colorSettingsPanel/colorSettingsPanel.component.html
@@ -19,5 +19,5 @@
 </md-input-container>
 
 <reset-settings-button-component
-        settings-names="appSettings.invertColorRange, appSettings.invertDeltaColors, appSettings.whiteColorBuildings"
+        settings-names="dynamicSettings.colorRange, appSettings.invertColorRange, appSettings.invertDeltaColors, appSettings.whiteColorBuildings"
 ></reset-settings-button-component>


### PR DESCRIPTION
# Fix set default colorRange onClickResetButton #560

closes #560 

## Description

- ColorRange resets to default when pressing the reset button in the *color*-section

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail