### PR TITLE
Fix/sigma icon not displayed

### DIFF
--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeProjectBuilder.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeProjectBuilder.kt
@@ -153,7 +153,7 @@ class EdgeProjectBuilder(private val project: Project, private val pathSeparator
 
             if (attributeType == AttributeType.relative) aggregatedAttributeValue /= filteredAttribute.size
 
-            aggregatedAttributes[key + "_" + attributeType] = aggregatedAttributeValue
+            aggregatedAttributes[key] = aggregatedAttributeValue
         }
         return aggregatedAttributes
     }

--- a/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ProjectMergerTest.kt
+++ b/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ProjectMergerTest.kt
@@ -68,37 +68,37 @@ class ProjectMergerTest: Spek({
         }
 
         it("leaf1 should have correct pairingRate_relative value") {
-            val value: Int = getAttributeValue(leaf1.attributes, "pairingRate_relative")
+            val value: Int = getAttributeValue(leaf1.attributes, "pairingRate")
             val expectedValue = (90 + 30 + 70) / 3 // see testfile
             MatcherAssert.assertThat(value, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf1 should have correct avgCommits_absolute value") {
-            val value: Int = getAttributeValue(leaf1.attributes, "avgCommits_absolute")
+            val value: Int = getAttributeValue(leaf1.attributes, "avgCommits")
             val expectedValue = 30 + 10 + 30 // see testfile
             MatcherAssert.assertThat(value, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf3 should have correct pairingRate_relative value") {
-            val number: Int = getAttributeValue(leaf3.attributes, "pairingRate_relative")
+            val number: Int = getAttributeValue(leaf3.attributes, "pairingRate")
             val expectedValue = (90 + 60 + 70) / 3 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf3 should have correct avgCommits_absolute value") {
-            val number: Int = getAttributeValue(leaf3.attributes, "avgCommits_absolute")
+            val number: Int = getAttributeValue(leaf3.attributes, "avgCommits")
             val expectedValue = 30 + 40 + 30 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf4 should have correct pairingRate_relative value") {
-            val number: Int = getAttributeValue(leaf4.attributes, "pairingRate_relative")
+            val number: Int = getAttributeValue(leaf4.attributes, "pairingRate")
             val expectedValue = (60 + 80 + 60) / 3 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf4 should have correct avgCommits_absolute value") {
-            val number: Int = getAttributeValue(leaf4.attributes, "avgCommits_absolute")
+            val number: Int = getAttributeValue(leaf4.attributes, "avgCommits")
             val expectedValue = 20 + 30 + 40 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
@@ -127,37 +127,37 @@ class ProjectMergerTest: Spek({
         }
 
         it("leaf1 should have correct pairingRate_relative value") {
-            val value: Int = getAttributeValue(leaf1.attributes, "pairingRate_relative")
+            val value: Int = getAttributeValue(leaf1.attributes, "pairingRate")
             val expectedValue = (90 + 30 + 70) / 3 // see testfile
             MatcherAssert.assertThat(value, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf1 should have correct avgCommits_absolute value") {
-            val value: Int = getAttributeValue(leaf1.attributes, "avgCommits_absolute")
+            val value: Int = getAttributeValue(leaf1.attributes, "avgCommits")
             val expectedValue = 30 + 10 + 30 // see testfile
             MatcherAssert.assertThat(value, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf3 should have correct pairingRate_relative value") {
-            val number: Int = getAttributeValue(leaf3.attributes, "pairingRate_relative")
+            val number: Int = getAttributeValue(leaf3.attributes, "pairingRate")
             val expectedValue = (90 + 60 + 70) / 3 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf3 should have correct avgCommits_absolute value") {
-            val number: Int = getAttributeValue(leaf3.attributes, "avgCommits_absolute")
+            val number: Int = getAttributeValue(leaf3.attributes, "avgCommits")
             val expectedValue = 30 + 40 + 30 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf4 should have correct pairingRate_relative value") {
-            val number: Int = getAttributeValue(leaf4.attributes, "pairingRate_relative")
+            val number: Int = getAttributeValue(leaf4.attributes, "pairingRate")
             val expectedValue = (60 + 80 + 60) / 3 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }
 
         it("leaf4 should have correct avgCommits_absolute value") {
-            val number: Int = getAttributeValue(leaf4.attributes, "avgCommits_absolute")
+            val number: Int = getAttributeValue(leaf4.attributes, "avgCommits")
             val expectedValue = 20 + 30 + 40 // see testfile
             MatcherAssert.assertThat(number, CoreMatchers.`is`(expectedValue))
         }

--- a/visualization/app/codeCharta/assets/sample1.cc.json
+++ b/visualization/app/codeCharta/assets/sample1.cc.json
@@ -14,8 +14,8 @@
 						"rloc": 400,
 						"functions": 10,
 						"mcc": 100,
-						"pairingRate_relative": 32,
-						"avgCommits_absolute": 17
+						"pairingRate": 32,
+						"avgCommits": 17
 					},
 					"link": "http://www.google.de"
 				},
@@ -26,8 +26,8 @@
 						"rloc": 100,
 						"functions": 10,
 						"mcc": 1,
-						"pairingRate_relative": 77,
-						"avgCommits_absolute": 56
+						"pairingRate": 77,
+						"avgCommits": 56
 					},
 					"link": "http://www.google.de"
 				},
@@ -43,8 +43,8 @@
 								"rloc": 30,
 								"functions": 100,
 								"mcc": 100,
-								"pairingRate_relative": 60,
-								"avgCommits_absolute": 51
+								"pairingRate": 60,
+								"avgCommits": 51
 							}
 						},
 						{
@@ -54,8 +54,8 @@
 								"rloc": 70,
 								"functions": 1000,
 								"mcc": 10,
-								"pairingRate_relative": 65,
-								"avgCommits_absolute": 22
+								"pairingRate": 65,
+								"avgCommits": 22
 							}
 						}
 					]

--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -123,15 +123,15 @@ export interface ColorRange {
 }
 
 export interface AttributeTypes {
-	nodes: Array<{
-		[key: string]: AttributeType
-	}>
-	edges: Array<{
-		[key: string]: AttributeType
-	}>
+	nodes: AttributeType[]
+	edges: AttributeType[]
 }
 
-export enum AttributeType {
+export interface AttributeType {
+	[key: string]: AttributeTypeValue
+}
+
+export enum AttributeTypeValue {
 	absolute = "absolute",
 	relative = "relative"
 }

--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -1,7 +1,7 @@
 import "./state.module"
 import { getService, instantiateModule } from "../../../mocks/ng.mockhelper"
 import { IRootScopeService } from "angular"
-import { CCFile, FileState, FileSelectionState, MetricData, Settings, AttributeType } from "../codeCharta.model"
+import { CCFile, FileState, FileSelectionState, MetricData, Settings, AttributeTypeValue } from "../codeCharta.model"
 import { TEST_DELTA_MAP_A, TEST_DELTA_MAP_B, SETTINGS } from "../util/dataMocks"
 import { MetricService } from "./metric.service"
 import { FileStateService } from "./fileState.service"
@@ -137,13 +137,13 @@ describe("MetricService", () => {
 		it("should return absolute", () => {
 			const actual = metricService.getAttributeTypeByMetric("rloc", settings)
 
-			expect(actual).toBe(AttributeType.absolute)
+			expect(actual).toBe(AttributeTypeValue.absolute)
 		})
 
 		it("should return relative", () => {
 			const actual = metricService.getAttributeTypeByMetric("coverage", settings)
 
-			expect(actual).toBe(AttributeType.relative)
+			expect(actual).toBe(AttributeTypeValue.relative)
 		})
 
 		it("should return null", () => {

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -1,5 +1,6 @@
 import {
-	AttributeType,
+	AttributeTypes,
+	AttributeTypeValue,
 	BlacklistItem,
 	BlacklistType,
 	CodeMapNode,
@@ -75,10 +76,10 @@ export class MetricService implements FileStateServiceSubscriber, SettingsServic
 		return metric ? metric.maxValue : undefined
 	}
 
-	public getAttributeTypeByMetric(metricName: string, settings: Settings): AttributeType {
+	public getAttributeTypeByMetric(metricName: string, settings: Settings): AttributeTypeValue {
 		const attributeTypes = settings.fileSettings.attributeTypes
 
-		const attributeType = this.getMergedAttributeTypes(attributeTypes.nodes, attributeTypes.edges).find(x => {
+		const attributeType = this.getMergedAttributeTypes(attributeTypes).find(x => {
 			return _.findKey(x) === metricName
 		})
 
@@ -88,17 +89,11 @@ export class MetricService implements FileStateServiceSubscriber, SettingsServic
 		return null
 	}
 
-	private getMergedAttributeTypes(nodeAttributes: Array<{
-		[key: string]: AttributeType
-	}>, edgeAttributes: Array<{
-		[key: string]: AttributeType
-	}>): Array<{
-		[key: string]: AttributeType
-	}> {
-		const mergedAttributeTypes = [...nodeAttributes]
+	private getMergedAttributeTypes(attributeTypes : AttributeTypes) {
+		const mergedAttributeTypes = [...attributeTypes.nodes]
 
 		mergedAttributeTypes.forEach(nodeAttribute => {
-			edgeAttributes.forEach(edgeAttribute => {
+			attributeTypes.edges.forEach(edgeAttribute => {
 				if (Object.keys(nodeAttribute)[0] !== Object.keys(edgeAttribute)[0]) {
 					mergedAttributeTypes.push(edgeAttribute)
 				}

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -1,4 +1,5 @@
 import {
+	AttributeType,
 	AttributeTypes,
 	AttributeTypeValue,
 	BlacklistItem,
@@ -89,7 +90,7 @@ export class MetricService implements FileStateServiceSubscriber, SettingsServic
 		return null
 	}
 
-	private getMergedAttributeTypes(attributeTypes : AttributeTypes) {
+	private getMergedAttributeTypes(attributeTypes : AttributeTypes) : AttributeType[] {
 		const mergedAttributeTypes = [...attributeTypes.nodes]
 
 		mergedAttributeTypes.forEach(nodeAttribute => {

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -76,12 +76,36 @@ export class MetricService implements FileStateServiceSubscriber, SettingsServic
 	}
 
 	public getAttributeTypeByMetric(metricName: string, settings: Settings): AttributeType {
-		const attributeType = settings.fileSettings.attributeTypes.nodes.find(x => _.findKey(x) === metricName)
+		const attributeTypes = settings.fileSettings.attributeTypes
+
+		const attributeType = this.getMergedAttributeTypes(attributeTypes.nodes, attributeTypes.edges).find(x => {
+			return _.findKey(x) === metricName
+		})
 
 		if (attributeType) {
 			return attributeType[metricName]
 		}
 		return null
+	}
+
+	private getMergedAttributeTypes(nodeAttributes: Array<{
+		[key: string]: AttributeType
+	}>, edgeAttributes: Array<{
+		[key: string]: AttributeType
+	}>): Array<{
+		[key: string]: AttributeType
+	}> {
+		const mergedAttributeTypes = [...nodeAttributes]
+
+		mergedAttributeTypes.forEach(nodeAttribute => {
+			edgeAttributes.forEach(edgeAttribute => {
+				if (Object.keys(nodeAttribute)[0] !== Object.keys(edgeAttribute)[0]) {
+					mergedAttributeTypes.push(edgeAttribute)
+				}
+			})
+		})
+
+		return mergedAttributeTypes
 	}
 
 	private calculateMetrics(fileStates: FileState[], visibleFileStates: FileState[], blacklist: BlacklistItem[]): MetricData[] {

--- a/visualization/app/codeCharta/state/settings.service.spec.ts
+++ b/visualization/app/codeCharta/state/settings.service.spec.ts
@@ -3,7 +3,7 @@ import { SettingsService } from "./settings.service"
 import { IRootScopeService, ITimeoutService } from "angular"
 import { getService, instantiateModule } from "../../../mocks/ng.mockhelper"
 import { DEFAULT_SETTINGS, TEST_DELTA_MAP_A, TEST_DELTA_MAP_B } from "../util/dataMocks"
-import { AttributeType, FileSelectionState, FileState, RecursivePartial, Settings } from "../codeCharta.model"
+import { AttributeTypeValue, FileSelectionState, FileState, RecursivePartial, Settings } from "../codeCharta.model"
 import { FileStateService } from "./fileState.service"
 import { FileStateHelper } from "../util/fileStateHelper"
 import { SettingsMerger } from "../util/settingsMerger"
@@ -126,9 +126,9 @@ describe("settingService", () => {
 
 		it("should set attributeTypes", () => {
 			const nodeAttributeTypes = [
-				{ rloc: AttributeType.absolute },
-				{ mcc: AttributeType.absolute },
-				{ coverage: AttributeType.relative }
+				{ rloc: AttributeTypeValue.absolute },
+				{ mcc: AttributeTypeValue.absolute },
+				{ coverage: AttributeTypeValue.relative }
 			]
 
 			settingsService.updateSettings({

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
@@ -8,8 +8,11 @@
 		</md-option>
 	</md-select>
 
+	<div>
+		<area-metric-type-component></area-metric-type-component>
 	<span class="metric-value"
 		>{{ ($ctrl.hoveredAreaValue | number) || "-" }}
 		<span ng-hide="!$ctrl.hoveredAreaDelta">(&Delta;{{ $ctrl.hoveredAreaDelta | number }})</span>
 	</span>
+	</div>
 </md-input-container>

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
@@ -1,15 +1,19 @@
 <md-input-container class="md-block">
-	<i class="fa fa-paint-brush"></i>
+    <i class="fa fa-paint-brush"></i>
 
-	<md-select ng-model="$ctrl._viewModel.colorMetric" ng-change="$ctrl.applySettingsColorMetric()">
-		<md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
-			{{::metric.name}}
-			<span class="metric-max-value">({{::metric.maxValue}})</span>
-		</md-option>
-	</md-select>
+    <md-select ng-model="$ctrl._viewModel.colorMetric" ng-change="$ctrl.applySettingsColorMetric()">
+        <md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
+            {{::metric.name}}
+            <span class="metric-max-value">({{::metric.maxValue}})</span>
+        </md-option>
+    </md-select>
 
-	<span class="metric-value"
-		>{{ ($ctrl.hoveredColorValue | number) || "-" }}
+    <div>
+        <color-metric-type-component></color-metric-type-component>
+        <span class="metric-value"
+        >{{ ($ctrl.hoveredColorValue | number) || "-" }}
 		<span ng-hide="!$ctrl.hoveredHeightDelta">(&Delta;{{ $ctrl.hoveredColorDelta | number }})</span>
 	</span>
+    </div>
+
 </md-input-container>

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
@@ -8,10 +8,13 @@
 		</md-option>
 	</md-select>
 
+	<div>
+		<height-metric-type-component></height-metric-type-component>
 	<span class="metric-value"
 		>{{ ($ctrl.hoveredHeightValue | number) || "-" }}
 		<span style="color: {{ $ctrl.hoveredDeltaColor }};" ng-hide="!$ctrl.hoveredHeightDelta"
 			>(&Delta;{{ $ctrl.hoveredHeightDelta | number }})</span
 		>
 	</span>
+	</div>
 </md-input-container>

--- a/visualization/app/codeCharta/ui/metricType/metricType.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricType/metricType.component.spec.ts
@@ -4,7 +4,7 @@ import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { MetricService } from "../../state/metric.service"
 import { IRootScopeService } from "angular"
 import { SettingsService } from "../../state/settings.service"
-import { AttributeType, Settings } from "../../codeCharta.model"
+import { AttributeTypeValue, Settings } from "../../codeCharta.model"
 import { SETTINGS } from "../../util/dataMocks"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 import { CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service"
@@ -67,25 +67,25 @@ describe("MetricTypeController", () => {
 		it("should set the areaMetricType to absolute", () => {
 			metricTypeController.onSettingsChanged(settings, { dynamicSettings: { areaMetric: "rloc" } }, undefined)
 
-			expect(metricTypeController["_viewModel"].areaMetricType).toBe(AttributeType.absolute)
+			expect(metricTypeController["_viewModel"].areaMetricType).toBe(AttributeTypeValue.absolute)
 		})
 
 		it("should set the heightMetricType to absolute", () => {
 			metricTypeController.onSettingsChanged(settings, { dynamicSettings: { heightMetric: "mcc" } }, undefined)
 
-			expect(metricTypeController["_viewModel"].heightMetricType).toBe(AttributeType.absolute)
+			expect(metricTypeController["_viewModel"].heightMetricType).toBe(AttributeTypeValue.absolute)
 		})
 
 		it("should set the colorMetricType to relative", () => {
 			metricTypeController.onSettingsChanged(settings, { dynamicSettings: { colorMetric: "coverage" } }, undefined)
 
-			expect(metricTypeController["_viewModel"].colorMetricType).toBe(AttributeType.relative)
+			expect(metricTypeController["_viewModel"].colorMetricType).toBe(AttributeTypeValue.relative)
 		})
 	})
 
 	describe("isAreaMetricAbsolute", () => {
 		it("should return true if areaMetric is absolute", () => {
-			metricTypeController["_viewModel"].areaMetricType = AttributeType.absolute
+			metricTypeController["_viewModel"].areaMetricType = AttributeTypeValue.absolute
 
 			const actual = metricTypeController.isAreaMetricAbsolute()
 
@@ -101,7 +101,7 @@ describe("MetricTypeController", () => {
 		})
 
 		it("should return false if areaMetric is relative", () => {
-			metricTypeController["_viewModel"].areaMetricType = AttributeType.relative
+			metricTypeController["_viewModel"].areaMetricType = AttributeTypeValue.relative
 
 			const actual = metricTypeController.isAreaMetricAbsolute()
 
@@ -111,7 +111,7 @@ describe("MetricTypeController", () => {
 
 	describe("isHeightMetricAbsolute", () => {
 		it("should return true if areaMetric is absolute", () => {
-			metricTypeController["_viewModel"].heightMetricType = AttributeType.absolute
+			metricTypeController["_viewModel"].heightMetricType = AttributeTypeValue.absolute
 
 			const actual = metricTypeController.isHeightMetricAbsolute()
 
@@ -127,7 +127,7 @@ describe("MetricTypeController", () => {
 		})
 
 		it("should return false if heightMetric is relative", () => {
-			metricTypeController["_viewModel"].heightMetricType = AttributeType.relative
+			metricTypeController["_viewModel"].heightMetricType = AttributeTypeValue.relative
 
 			const actual = metricTypeController.isHeightMetricAbsolute()
 
@@ -137,7 +137,7 @@ describe("MetricTypeController", () => {
 
 	describe("isColorMetricAbsolute", () => {
 		it("should return true if colorMetric is absolute", () => {
-			metricTypeController["_viewModel"].colorMetricType = AttributeType.absolute
+			metricTypeController["_viewModel"].colorMetricType = AttributeTypeValue.absolute
 
 			const actual = metricTypeController.isColorMetricAbsolute()
 
@@ -153,7 +153,7 @@ describe("MetricTypeController", () => {
 		})
 
 		it("should return false if colorMetric is relative", () => {
-			metricTypeController["_viewModel"].colorMetricType = AttributeType.relative
+			metricTypeController["_viewModel"].colorMetricType = AttributeTypeValue.relative
 
 			const actual = metricTypeController.isColorMetricAbsolute()
 

--- a/visualization/app/codeCharta/ui/metricType/metricType.component.ts
+++ b/visualization/app/codeCharta/ui/metricType/metricType.component.ts
@@ -1,6 +1,6 @@
 import "./metricType.component.scss"
 import { MetricService } from "../../state/metric.service"
-import { AttributeType, RecursivePartial, Settings } from "../../codeCharta.model"
+import { AttributeTypeValue, RecursivePartial, Settings } from "../../codeCharta.model"
 import { IRootScopeService } from "angular"
 import { SettingsService, SettingsServiceSubscriber } from "../../state/settings.service"
 import {
@@ -12,9 +12,9 @@ import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 
 export class MetricTypeController implements SettingsServiceSubscriber, CodeMapMouseEventServiceSubscriber {
 	private _viewModel: {
-		areaMetricType: AttributeType
-		heightMetricType: AttributeType
-		colorMetricType: AttributeType
+		areaMetricType: AttributeTypeValue
+		heightMetricType: AttributeTypeValue
+		colorMetricType: AttributeTypeValue
 		isBuildingHovered: boolean
 	} = {
 		areaMetricType: null,
@@ -60,15 +60,15 @@ export class MetricTypeController implements SettingsServiceSubscriber, CodeMapM
 	public onBuildingSelected(data: CodeMapBuildingTransition, event: angular.IAngularEvent) {}
 
 	public isAreaMetricAbsolute(): boolean {
-		return this._viewModel.areaMetricType === AttributeType.absolute || !this._viewModel.areaMetricType
+		return this._viewModel.areaMetricType === AttributeTypeValue.absolute || !this._viewModel.areaMetricType
 	}
 
 	public isHeightMetricAbsolute(): boolean {
-		return this._viewModel.heightMetricType === AttributeType.absolute || !this._viewModel.heightMetricType
+		return this._viewModel.heightMetricType === AttributeTypeValue.absolute || !this._viewModel.heightMetricType
 	}
 
 	public isColorMetricAbsolute(): boolean {
-		return this._viewModel.colorMetricType === AttributeType.absolute || !this._viewModel.colorMetricType
+		return this._viewModel.colorMetricType === AttributeTypeValue.absolute || !this._viewModel.colorMetricType
 	}
 }
 

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -1,4 +1,4 @@
-import { AttributeType, CCFile, CodeMapNode, Edge, MetricData, Node, Settings } from "../codeCharta.model"
+import { AttributeTypeValue, CCFile, CodeMapNode, Edge, MetricData, Node, Settings } from "../codeCharta.model"
 import { CodeMapBuilding } from "../ui/codeMap/rendering/codeMapBuilding"
 import * as THREE from "three"
 import { MetricDistribution } from "./fileExtensionCalculator"
@@ -442,13 +442,13 @@ export const SETTINGS: Settings = {
 		attributeTypes: {
 			nodes: [
 				{
-					rloc: AttributeType.absolute
+					rloc: AttributeTypeValue.absolute
 				},
 				{
-					mcc: AttributeType.absolute
+					mcc: AttributeTypeValue.absolute
 				},
 				{
-					coverage: AttributeType.relative
+					coverage: AttributeTypeValue.relative
 				}
 			],
 			edges: []

--- a/visualization/app/codeCharta/util/settingsMerger.spec.ts
+++ b/visualization/app/codeCharta/util/settingsMerger.spec.ts
@@ -1,4 +1,4 @@
-import { AttributeType, BlacklistItem, BlacklistType, CCFile, Edge, FileSettings, MarkedPackage, AttributeTypes } from "../codeCharta.model"
+import { AttributeTypeValue, BlacklistItem, BlacklistType, CCFile, Edge, FileSettings, MarkedPackage, AttributeTypes } from "../codeCharta.model"
 import { SettingsMerger } from "./settingsMerger"
 
 describe("SettingsMerger", () => {
@@ -211,12 +211,12 @@ describe("SettingsMerger", () => {
 			attributes1 = {
 				nodes: [
 					{
-						attribute1: AttributeType.absolute
+						attribute1: AttributeTypeValue.absolute
 					}
 				],
 				edges: [
 					{
-						attribute2: AttributeType.relative
+						attribute2: AttributeTypeValue.relative
 					}
 				]
 			}
@@ -224,12 +224,12 @@ describe("SettingsMerger", () => {
 			attributes2 = {
 				nodes: [
 					{
-						attribute3: AttributeType.absolute
+						attribute3: AttributeTypeValue.absolute
 					}
 				],
 				edges: [
 					{
-						attribute4: AttributeType.relative
+						attribute4: AttributeTypeValue.relative
 					}
 				]
 			}
@@ -237,7 +237,7 @@ describe("SettingsMerger", () => {
 			attributes3 = {
 				nodes: [
 					{
-						attribute1: AttributeType.relative
+						attribute1: AttributeTypeValue.relative
 					}
 				],
 				edges: []

--- a/visualization/app/codeCharta/util/settingsMerger.ts
+++ b/visualization/app/codeCharta/util/settingsMerger.ts
@@ -1,4 +1,4 @@
-import { AttributeType, Edge, BlacklistItem, CCFile, FileSettings, MarkedPackage } from "../codeCharta.model"
+import { AttributeTypeValue, Edge, BlacklistItem, CCFile, FileSettings, MarkedPackage } from "../codeCharta.model"
 import { CodeChartaService } from "../codeCharta.service"
 import _ from "lodash"
 
@@ -6,8 +6,8 @@ export class SettingsMerger {
 	private static edges: Edge[] = []
 	private static markedPackages: MarkedPackage[] = []
 	private static blacklist: BlacklistItem[] = []
-	private static attributeTypesEdge: Array<{ [key: string]: AttributeType }> = []
-	private static attributeTypesNode: Array<{ [key: string]: AttributeType }> = []
+	private static attributeTypesEdge: Array<{ [key: string]: AttributeTypeValue }> = []
+	private static attributeTypesNode: Array<{ [key: string]: AttributeTypeValue }> = []
 
 	public static getMergedFileSettings(inputFiles: CCFile[], withUpdatedPath: boolean = false): FileSettings {
 		if (inputFiles.length == 1) {

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -76,7 +76,7 @@
 		"lint": "tslint -c \"tslint.json\" \"app/**/*.ts\" --project tsconfig.json",
 		"lint:fix": "tslint -c \"tslint.json\" \"app/**/*.ts\" --fix --project tsconfig.json",
 		"format": "prettier --write \"./**/*\"",
-		"format:quick" : "pretty-quick --pattern \"./**/*\" --staged"
+		"format:quick": "pretty-quick --pattern \"./**/*\" --staged"
 	},
 	"bin": {
 		"codecharta-visualization": "cli.js"


### PR DESCRIPTION
# Hotfix: Sigma Icon no longer displayed correctly

## Description
- Merge removed some parts of html so that the sigma icon was no longer displayed
- Fixed that only the node-attribute-types were used to determine the metricType
- EdgeFilter will no longer add _relative or _absolute to attributes aggregated to nodes

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
