### PR TITLE
bug/602/margin-null-after-area-metric-change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Margin will now be set correctly depending on whether dynamicMargin is enabled or not #602
+
+
 ### Chore
 
 ## [1.27.0] - 2019-06-25

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
@@ -10,24 +10,25 @@ import { DEFAULT_SETTINGS, SETTINGS } from "../../util/dataMocks"
 
 describe("MetricChooserController", () => {
 	let metricChooserController: MetricChooserController
-	let services
+	let settingsService: SettingsService
+	let $rootScope: IRootScopeService
 	let dataDelta, dataNotDelta
 
 	function rebuildController() {
-		metricChooserController = new MetricChooserController(services.SettingsService, services.$rootScope)
+		metricChooserController = new MetricChooserController(settingsService, $rootScope)
 	}
 
 	function restartSystem() {
 		instantiateModule("app.codeCharta.ui.metricChooser")
 
-		services = {
-			settingsService: getService<SettingsService>("settingsService"),
-			$rootScope: getService<IRootScopeService>("$rootScope")
-		}
+
+		settingsService = getService<SettingsService>("settingsService")
+		$rootScope = getService<IRootScopeService>("$rootScope")
+
 	}
 
 	function withMockedSettingsService() {
-		services.settingsService = metricChooserController["settingsService"] = jest.fn(() => {
+		settingsService = metricChooserController["settingsService"] = jest.fn(() => {
 			return {
 				subscribe: jest.fn(),
 				updateSettings: jest.fn(),
@@ -62,183 +63,231 @@ describe("MetricChooserController", () => {
 		withMockedSettingsService()
 	})
 
-	it("should uptate height/area/color metric on settings changed", () => {
-		let settings = { dynamicSettings: { areaMetric: "foo", heightMetric: "bar", colorMetric: "foobar" } } as Settings
+	describe("onSettingsChanged", () => {
+		it("should update height/area/color metric on settings changed", () => {
+			let settings = {
+				dynamicSettings: {
+					areaMetric: "foo",
+					heightMetric: "bar",
+					colorMetric: "foobar"
+				}
+			} as Settings
 
-		metricChooserController.onSettingsChanged(settings, undefined, null)
+			metricChooserController.onSettingsChanged(settings, undefined, null)
 
-		expect(metricChooserController["_viewModel"].areaMetric).toEqual("foo")
-		expect(metricChooserController["_viewModel"].heightMetric).toEqual("bar")
-		expect(metricChooserController["_viewModel"].colorMetric).toEqual("foobar")
-	})
-
-	it("metric data should be updated", () => {
-		let metricData = [
-			{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-			{ name: "b", maxValue: 2, availableInVisibleMaps: false }
-		]
-
-		metricChooserController.onMetricDataAdded(metricData, null)
-
-		expect(metricChooserController["_viewModel"].metricData).toEqual(metricData)
-	})
-
-	it("settings are updated if selected metrics are not available", () => {
-		let metricData = [
-			{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-			{ name: "b", maxValue: 2, availableInVisibleMaps: true },
-			{ name: "c", maxValue: 2, availableInVisibleMaps: true },
-			{ name: "d", maxValue: 2, availableInVisibleMaps: true }
-		]
-
-		metricChooserController.onMetricDataAdded(metricData, null)
-
-		expect(services.settingsService.updateSettings).toHaveBeenCalledWith({
-			dynamicSettings: { areaMetric: "a", colorMetric: "c", heightMetric: "b", distributionMetric: "d" }
+			expect(metricChooserController["_viewModel"].areaMetric).toEqual("foo")
+			expect(metricChooserController["_viewModel"].heightMetric).toEqual("bar")
+			expect(metricChooserController["_viewModel"].colorMetric).toEqual("foobar")
 		})
 	})
 
-	it("same metric is selected multiple times if less than 3 metrics available", () => {
-		let metricData = [
-			{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-			{ name: "b", maxValue: 1, availableInVisibleMaps: false }
-		]
+	describe("onMetricDataAdded", () => {
+		it("metric data should be updated", () => {
+			let metricData = [
+				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
+				{ name: "b", maxValue: 2, availableInVisibleMaps: false }
+			]
 
-		metricChooserController.onMetricDataAdded(metricData, null)
+			metricChooserController.onMetricDataAdded(metricData, null)
 
-		expect(services.settingsService.updateSettings).toHaveBeenCalledWith({
-			dynamicSettings: { areaMetric: "a", colorMetric: "a", heightMetric: "a", distributionMetric: "a" }
+			expect(metricChooserController["_viewModel"].metricData).toEqual(metricData)
+		})
+
+		it("settings are updated if selected metrics are not available", () => {
+			let metricData = [
+				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
+				{ name: "b", maxValue: 2, availableInVisibleMaps: true },
+				{ name: "c", maxValue: 2, availableInVisibleMaps: true },
+				{ name: "d", maxValue: 2, availableInVisibleMaps: true }
+			]
+
+			metricChooserController.onMetricDataAdded(metricData, null)
+
+			expect(settingsService.updateSettings).toHaveBeenCalledWith({
+				dynamicSettings: { areaMetric: "a", colorMetric: "c", heightMetric: "b", distributionMetric: "d" }
+			})
+		})
+
+		it("same metric is selected multiple times if less than 3 metrics available", () => {
+			let metricData = [
+				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
+				{ name: "b", maxValue: 1, availableInVisibleMaps: false }
+			]
+
+			metricChooserController.onMetricDataAdded(metricData, null)
+
+			expect(settingsService.updateSettings).toHaveBeenCalledWith({
+				dynamicSettings: { areaMetric: "a", colorMetric: "a", heightMetric: "a", distributionMetric: "a" }
+			})
+		})
+
+		it("settings are not updated if selected metrics are available", () => {
+			let metricData = [
+				{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
+				{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
+			]
+
+			metricChooserController.onMetricDataAdded(metricData, null)
+
+			expect(settingsService.updateSettings).not.toBeCalled()
+		})
+
+		it("no metrics available, should not update settings", () => {
+			let metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
+
+			metricChooserController.onMetricDataAdded(metricData, null)
+
+			expect(settingsService.updateSettings).not.toBeCalled()
+		})
+
+	})
+
+
+	describe("applySettingsAreaMetric", () => {
+		it("should updateSettings with areaMetric and margin null, when dynamicMargin is enabled", () => {
+			settingsService.getSettings = jest.fn().mockReturnValue({ appSettings: { dynamicMargin: true } })
+
+			metricChooserController["_viewModel"].areaMetric = "mcc"
+
+			metricChooserController.applySettingsAreaMetric()
+
+			expect(settingsService.updateSettings).toBeCalledWith({
+				dynamicSettings: {
+					areaMetric: "mcc",
+					margin: null
+				}
+			})
+		})
+
+		it("should updateSettings with areaMetric and margin from settings, when dynamicMargin is disabled", () => {
+			settingsService.getSettings = jest.fn().mockReturnValue({
+				appSettings: { dynamicMargin: false },
+				dynamicSettings: { margin: 20 }
+			})
+
+			metricChooserController["_viewModel"].areaMetric = "mcc"
+
+			metricChooserController.applySettingsAreaMetric()
+
+			expect(settingsService.updateSettings).toBeCalledWith({
+				dynamicSettings: {
+					areaMetric: "mcc",
+					margin: 20
+				}
+			})
 		})
 	})
 
-	it("settings are not updated if selected metrics are available", () => {
-		let metricData = [
-			{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-			{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-		]
+	describe("applySettingsColorMetric", () => {
+		it("should update color metric settings", () => {
+			metricChooserController["_viewModel"].colorMetric = "c"
 
-		metricChooserController.onMetricDataAdded(metricData, null)
+			metricChooserController.applySettingsColorMetric()
 
-		expect(services.settingsService.updateSettings).not.toBeCalled()
-	})
-
-	it("no metrics available, should not update settings", () => {
-		let metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
-
-		metricChooserController.onMetricDataAdded(metricData, null)
-
-		expect(services.settingsService.updateSettings).not.toBeCalled()
-	})
-
-	it("apply settings area metric updates settings", () => {
-		metricChooserController["_viewModel"].areaMetric = "a"
-
-		metricChooserController.applySettingsAreaMetric()
-
-		expect(services.settingsService.updateSettings).toBeCalledWith({ dynamicSettings: { areaMetric: "a", margin: null } })
-	})
-
-	it("apply settings color metric updates settings", () => {
-		metricChooserController["_viewModel"].colorMetric = "c"
-
-		metricChooserController.applySettingsColorMetric()
-
-		expect(services.settingsService.updateSettings).toBeCalledWith({
-			dynamicSettings: { colorMetric: "c", colorRange: { from: null, to: null } }
+			expect(settingsService.updateSettings).toBeCalledWith({
+				dynamicSettings: { colorMetric: "c", colorRange: { from: null, to: null } }
+			})
 		})
 	})
 
-	it("apply settings height metric updates settings", () => {
-		metricChooserController["_viewModel"].heightMetric = "b"
 
-		metricChooserController.applySettingsHeightMetric()
+	describe("applySettingsHeightMetric", () => {
+		it("should update height metric settings", () => {
+			metricChooserController["_viewModel"].heightMetric = "b"
 
-		expect(services.settingsService.updateSettings).toBeCalledWith({ dynamicSettings: { heightMetric: "b" } })
+			metricChooserController.applySettingsHeightMetric()
+
+			expect(settingsService.updateSettings).toBeCalledWith({ dynamicSettings: { heightMetric: "b" } })
+		})
 	})
 
-	it("should set values and deltas to null if data incomplete", () => {
-		let data = { from: {}, to: {} } as CodeMapBuildingTransition
+	describe("onBuildingHovered", () => {
+		it("should set values and deltas to null if data incomplete", () => {
+			let data = { from: {}, to: {} } as CodeMapBuildingTransition
 
-		metricChooserController.onBuildingHovered(data, null)
+			metricChooserController.onBuildingHovered(data, null)
 
-		expect(metricChooserController.hoveredAreaDelta).toBe(null)
-		expect(metricChooserController.hoveredAreaValue).toBe(null)
-		expect(metricChooserController.hoveredColorDelta).toBe(null)
-		expect(metricChooserController.hoveredColorValue).toBe(null)
-		expect(metricChooserController.hoveredHeightValue).toBe(null)
-		expect(metricChooserController.hoveredHeightDelta).toBe(null)
-	})
-
-	it("should set hovered values and set hovered deltas to null if not delta", () => {
-		withMockedBuildingTransitions()
-		metricChooserController["_viewModel"].areaMetric = "area"
-		metricChooserController["_viewModel"].heightMetric = "height"
-		metricChooserController["_viewModel"].colorMetric = "color"
-
-		metricChooserController.onBuildingHovered(dataNotDelta, null)
-
-		expect(metricChooserController.hoveredAreaDelta).toBe(null)
-		expect(metricChooserController.hoveredAreaValue).toBe(10)
-		expect(metricChooserController.hoveredColorDelta).toBe(null)
-		expect(metricChooserController.hoveredColorValue).toBe(30)
-		expect(metricChooserController.hoveredHeightValue).toBe(20)
-		expect(metricChooserController.hoveredHeightDelta).toBe(null)
-	})
-
-	it("should set hovered values and deltas if delta", () => {
-		withMockedBuildingTransitions()
-		metricChooserController["_viewModel"].areaMetric = "area"
-		metricChooserController["_viewModel"].heightMetric = "height"
-		metricChooserController["_viewModel"].colorMetric = "color"
-
-		metricChooserController.onBuildingHovered(dataDelta, null)
-
-		expect(metricChooserController.hoveredAreaDelta).toBe(40)
-		expect(metricChooserController.hoveredAreaValue).toBe(10)
-		expect(metricChooserController.hoveredColorDelta).toBe(60)
-		expect(metricChooserController.hoveredColorValue).toBe(30)
-		expect(metricChooserController.hoveredHeightValue).toBe(20)
-		expect(metricChooserController.hoveredHeightDelta).toBe(50)
-	})
-
-	it("hovered delta color should be null if not delta", () => {
-		withMockedBuildingTransitions()
-		metricChooserController.hoveredDeltaColor = "foo"
-
-		metricChooserController.onBuildingHovered(dataNotDelta, null)
-
-		expect(metricChooserController.hoveredDeltaColor).toBe(null)
-	})
-
-	it("hovered delta color should be inherited if hoveredHeigtDelta is 0", () => {
-		withMockedBuildingTransitions()
-		metricChooserController.hoveredHeightDelta = 0
-
-		metricChooserController.onBuildingHovered(dataDelta, null)
-
-		expect(metricChooserController.hoveredDeltaColor).toBe("inherit")
-	})
-
-	it("hovered delta color should be set correctly", () => {
-		withMockedBuildingTransitions()
-		metricChooserController["_viewModel"].heightMetric = "height"
-		metricChooserController.hoveredHeightDelta = 2
-
-		metricChooserController.onBuildingHovered(dataDelta, null)
-
-		expect(metricChooserController.hoveredDeltaColor).toBe("green")
-	})
-
-	it("hovered delta color should be set correctly if reversed colors", () => {
-		withMockedBuildingTransitions()
-		metricChooserController["_viewModel"].heightMetric = "height"
-		metricChooserController.hoveredHeightDelta = 2
-		services.settingsService.getSettings = jest.fn(() => {
-			return { appSettings: { invertDeltaColors: true } }
+			expect(metricChooserController.hoveredAreaDelta).toBe(null)
+			expect(metricChooserController.hoveredAreaValue).toBe(null)
+			expect(metricChooserController.hoveredColorDelta).toBe(null)
+			expect(metricChooserController.hoveredColorValue).toBe(null)
+			expect(metricChooserController.hoveredHeightValue).toBe(null)
+			expect(metricChooserController.hoveredHeightDelta).toBe(null)
 		})
 
-		metricChooserController.onBuildingHovered(dataDelta, null)
+		it("should set hovered values and set hovered deltas to null if not delta", () => {
+			withMockedBuildingTransitions()
+			metricChooserController["_viewModel"].areaMetric = "area"
+			metricChooserController["_viewModel"].heightMetric = "height"
+			metricChooserController["_viewModel"].colorMetric = "color"
 
-		expect(metricChooserController.hoveredDeltaColor).toBe("red")
+			metricChooserController.onBuildingHovered(dataNotDelta, null)
+
+			expect(metricChooserController.hoveredAreaDelta).toBe(null)
+			expect(metricChooserController.hoveredAreaValue).toBe(10)
+			expect(metricChooserController.hoveredColorDelta).toBe(null)
+			expect(metricChooserController.hoveredColorValue).toBe(30)
+			expect(metricChooserController.hoveredHeightValue).toBe(20)
+			expect(metricChooserController.hoveredHeightDelta).toBe(null)
+		})
+
+		it("should set hovered values and deltas if delta", () => {
+			withMockedBuildingTransitions()
+			metricChooserController["_viewModel"].areaMetric = "area"
+			metricChooserController["_viewModel"].heightMetric = "height"
+			metricChooserController["_viewModel"].colorMetric = "color"
+
+			metricChooserController.onBuildingHovered(dataDelta, null)
+
+			expect(metricChooserController.hoveredAreaDelta).toBe(40)
+			expect(metricChooserController.hoveredAreaValue).toBe(10)
+			expect(metricChooserController.hoveredColorDelta).toBe(60)
+			expect(metricChooserController.hoveredColorValue).toBe(30)
+			expect(metricChooserController.hoveredHeightValue).toBe(20)
+			expect(metricChooserController.hoveredHeightDelta).toBe(50)
+		})
+
+		it("hovered delta color should be null if not delta", () => {
+			withMockedBuildingTransitions()
+			metricChooserController.hoveredDeltaColor = "foo"
+
+			metricChooserController.onBuildingHovered(dataNotDelta, null)
+
+			expect(metricChooserController.hoveredDeltaColor).toBe(null)
+		})
+
+		it("hovered delta color should be inherited if hoveredHeigtDelta is 0", () => {
+			withMockedBuildingTransitions()
+			metricChooserController.hoveredHeightDelta = 0
+
+			metricChooserController.onBuildingHovered(dataDelta, null)
+
+			expect(metricChooserController.hoveredDeltaColor).toBe("inherit")
+		})
+
+		it("hovered delta color should be set correctly", () => {
+			withMockedBuildingTransitions()
+			metricChooserController["_viewModel"].heightMetric = "height"
+			metricChooserController.hoveredHeightDelta = 2
+
+			metricChooserController.onBuildingHovered(dataDelta, null)
+
+			expect(metricChooserController.hoveredDeltaColor).toBe("green")
+		})
+
+		it("hovered delta color should be set correctly if reversed colors", () => {
+			withMockedBuildingTransitions()
+			metricChooserController["_viewModel"].heightMetric = "height"
+			metricChooserController.hoveredHeightDelta = 2
+			settingsService.getSettings = jest.fn(() => {
+				return { appSettings: { invertDeltaColors: true } }
+			})
+
+			metricChooserController.onBuildingHovered(dataDelta, null)
+
+			expect(metricChooserController.hoveredDeltaColor).toBe("red")
+		})
+
 	})
+
 })

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.ts
@@ -49,7 +49,8 @@ export class MetricChooserController implements MetricServiceSubscriber, CodeMap
 		this.potentiallyUpdateChosenMetrics(metricData)
 	}
 
-	public onMetricDataRemoved(event: angular.IAngularEvent) {}
+	public onMetricDataRemoved(event: angular.IAngularEvent) {
+	}
 
 	private potentiallyUpdateChosenMetrics(metricData: MetricData[]) {
 		const metricKeys: Partial<DynamicSettings> = {
@@ -90,22 +91,15 @@ export class MetricChooserController implements MetricServiceSubscriber, CodeMap
 	}
 
 	public applySettingsAreaMetric() {
-		if(this.settingsService.getSettings().appSettings.dynamicMargin) {
-			this.settingsService.updateSettings({
-				dynamicSettings: {
-					areaMetric: this._viewModel.areaMetric,
-					margin: this.settingsService.getDefaultSettings().dynamicSettings.margin
-				}
-			})
-		} else {
-			this.settingsService.updateSettings({
-				dynamicSettings: {
-					areaMetric: this._viewModel.areaMetric,
-					margin: this.settingsService.getSettings().dynamicSettings.margin
-				}
-			})
-		}
+		const settings = this.settingsService.getSettings()
+		const margin = settings.appSettings.dynamicMargin ? null : settings.dynamicSettings.margin
 
+		this.settingsService.updateSettings({
+			dynamicSettings: {
+				areaMetric: this._viewModel.areaMetric,
+				margin
+			}
+		})
 	}
 
 	public applySettingsColorMetric() {
@@ -133,7 +127,8 @@ export class MetricChooserController implements MetricServiceSubscriber, CodeMap
 		})
 	}
 
-	public onBuildingRightClicked(building: CodeMapBuilding, x: number, y: number, event: IAngularEvent) {}
+	public onBuildingRightClicked(building: CodeMapBuilding, x: number, y: number, event: IAngularEvent) {
+	}
 
 	public onBuildingHovered(data: CodeMapBuildingTransition, event: angular.IAngularEvent) {
 		if (data && data.to && data.to.node && data.to.node.attributes) {
@@ -163,7 +158,8 @@ export class MetricChooserController implements MetricServiceSubscriber, CodeMap
 		}
 	}
 
-	public onBuildingSelected(data: CodeMapBuildingTransition, event: angular.IAngularEvent) {}
+	public onBuildingSelected(data: CodeMapBuildingTransition, event: angular.IAngularEvent) {
+	}
 
 	private getHoveredDeltaColor() {
 		let colors = {

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.ts
@@ -90,12 +90,22 @@ export class MetricChooserController implements MetricServiceSubscriber, CodeMap
 	}
 
 	public applySettingsAreaMetric() {
-		this.settingsService.updateSettings({
-			dynamicSettings: {
-				areaMetric: this._viewModel.areaMetric,
-				margin: this.settingsService.getDefaultSettings().dynamicSettings.margin
-			}
-		})
+		if(this.settingsService.getSettings().appSettings.dynamicMargin) {
+			this.settingsService.updateSettings({
+				dynamicSettings: {
+					areaMetric: this._viewModel.areaMetric,
+					margin: this.settingsService.getDefaultSettings().dynamicSettings.margin
+				}
+			})
+		} else {
+			this.settingsService.updateSettings({
+				dynamicSettings: {
+					areaMetric: this._viewModel.areaMetric,
+					margin: this.settingsService.getSettings().dynamicSettings.margin
+				}
+			})
+		}
+
 	}
 
 	public applySettingsColorMetric() {


### PR DESCRIPTION
# Set Margin based on dynamicMargin enabled

closes #602 

## Description
- If dymamicMargin is `enabled`, margin will be reset to `null` and dynamically calculated again for the new metric
- If dynamicMargin is `disabled`, margin will be the same as before
- Refactored the structure of the test

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
