### PR TITLE
Bug/584/file extension bar color missing in standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Colors in File-Extension-Bar will be displayed in MS Edge and Standlone now #584
+
 ### Chore
 
 ## [1.28.0] - 2019-06-28

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -5,7 +5,6 @@ import { SettingsService } from "../../state/settings.service"
 import { TEST_FILE_WITH_PATHS, SETTINGS, METRIC_DISTRIBUTION, NONE_METRIC_DISTRIBUTION } from "../../util/dataMocks"
 import { MetricDistribution, FileExtensionCalculator } from "../../util/fileExtensionCalculator"
 import { FileExtensionBarController } from "./fileExtensionBar.component"
-import { CodeMapMesh } from "../codeMap/rendering/codeMapMesh"
 
 describe("FileExtensionBarController", () => {
 	let fileExtensionBarController: FileExtensionBarController

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -56,7 +56,7 @@ describe("FileExtensionBarController", () => {
 		it("should set the color of given extension attribute", () => {
 			fileExtensionBarController.onRenderMapChanged(TEST_FILE_WITH_PATHS.map, undefined)
 
-			expect(distribution[0].color).toEqual("hsla(58, 40%, 50%)")
+			expect(distribution[0].color).toEqual("hsl(58, 40%, 50%)")
 		})
 
 		it("should remain the color property of the extension, if it already has one", () => {

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
@@ -56,7 +56,7 @@ export class FileExtensionBarController implements CodeMapPreRenderServiceSubscr
 
 	private numberToHsl(hashCode: number): string {
 		let shortened = hashCode % 360
-		return "hsla(" + shortened + ", 40%, 50%)"
+		return "hsl(" + shortened + ", 40%, 50%)"
 	}
 
 	private getNoneExtension(): MetricDistribution {


### PR DESCRIPTION
# Color in File-Extension-Bar will be displayed in Standalone and MS Edge now

requires #616 
closes #584 

## Description
- MS Edge and NWJS can't display `hslA` values. `hsl` works

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
