### PR TITLE
Feature/adapt-center-map-button

### DIFF
--- a/visualization/app/codeCharta/ui/centerMapButton/centerMapButton.component.html
+++ b/visualization/app/codeCharta/ui/centerMapButton/centerMapButton.component.html
@@ -1,5 +1,10 @@
-<div id="centerMap" ng-show="!$ctrl._viewModel.isMapCentered" ng-class="$ctrl._viewModel.isMapCentered ? 'invisible' : 'visible'">
+<div
+	id="centerMap"
+	class="small-action-button"
+	ng-show="!$ctrl._viewModel.isMapCentered"
+	ng-class="$ctrl._viewModel.isMapCentered ? 'invisible' : 'visible'"
+>
 	<md-button class="md-fab md-primary dark_shadow_opacity" aria-label="Fit Map to View" ng-click="$ctrl.fitMapToView()">
-		<i class="fa fa-compass fa-2x"></i>
+		<i class="fa fa-compass"></i>
 	</md-button>
 </div>

--- a/visualization/app/codeCharta/ui/centerMapButton/centerMapButton.component.scss
+++ b/visualization/app/codeCharta/ui/centerMapButton/centerMapButton.component.scss
@@ -1,25 +1,22 @@
 center-map-button-component {
-	.md-fab {
-		i {
-			position: absolute;
-			top: 4px;
-			left: 6px;
-			color: white;
+	#centerMap {
+		transition: opacity 0.3s linear;
 
-			&:hover {
-				cursor: pointer;
-				color: #eee;
+		.md-fab {
+			font-size: 14pt;
+
+			i {
+				top: 3px;
+				left: 4px;
 			}
 		}
 	}
 
 	.visible {
-		transition: opacity 0.3s linear;
 		opacity: 1;
 	}
 
 	.invisible {
-		transition: opacity 0.3s linear;
 		opacity: 0;
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -8,13 +8,7 @@ code-map-component {
 
 	#centerMap {
 		position: absolute;
-		top: 10px;
-		right: 15px;
-		float: right;
-
-		.md-fab {
-			width: 36px;
-			height: 36px;
-		}
+		top: 20px;
+		right: 20px;
 	}
 }


### PR DESCRIPTION
# Feature/adapt-center-map-button

## Description

- Make centreMap button smaller and adapt to other buttons (use of same CSS class)

### Question

Do you think the button is too small now?

### Before and After

<img width="31%" src="https://user-images.githubusercontent.com/23529226/61550990-e56e7000-aa4b-11e9-8c1f-2625d9fe858a.jpeg"> <img width="30%" src="https://user-images.githubusercontent.com/23529226/61551023-f7e8a980-aa4b-11e9-9047-660fffb82bc7.jpeg">



## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail