### PR TITLE
Feature/adapt-file-extension-bar-height

### DIFF
--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
@@ -23,7 +23,7 @@ file-extension-bar-component {
 
 			.bar-section-text {
 				font-size: 10px;
-				margin-top: 0;
+				margin-top: 2px;
 			}
 		}
 	}
@@ -52,7 +52,7 @@ file-extension-bar-component {
 				color: black;
 				font-size: 15px;
 				margin-left: 30px;
-				margin-top: 4px;
+				margin-top: 3px;
 
 				.dot {
 					height: 10px;

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
@@ -10,11 +10,12 @@ file-extension-bar-component {
 
 		.bar-section {
 			width: 100%;
-			height: 15px;
+			height: 17px;
 			float: left;
 			color: white;
 			text-align: center;
 			cursor: pointer;
+			outline: none;
 
 			&:not(:last-child) {
 				border-right: 1px solid white;
@@ -51,7 +52,7 @@ file-extension-bar-component {
 				color: black;
 				font-size: 15px;
 				margin-left: 30px;
-				margin-top: 5px;
+				margin-top: 4px;
 
 				.dot {
 					height: 10px;


### PR DESCRIPTION
# Feature/adapt-file-extension-bar-height

## Description

When using the Chrome Browser, then the fileExtensionBar had a small unwanted white margin-bottom. This PR:
- Adjust fileExtensionBar height
- Remove the blue outline when focusing a fileExtensionBar-section
- Move the fileExtensionBar-detailsText up by 1px

Before
![image](https://user-images.githubusercontent.com/23529226/61551282-a2f96300-aa4c-11e9-992e-70f64a7cc930.jpeg)

After
![image](https://user-images.githubusercontent.com/23529226/61551441-18653380-aa4d-11e9-8865-13fcca0a8432.jpeg)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail