### PR TITLE
Feature/621/number of renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added
 
 - New Search Bar #526
+- Number of Renames Metric to SCMLogParser #621
 
 ### Changed
 

--- a/analysis/import/SCMLogParser/README.md
+++ b/analysis/import/SCMLogParser/README.md
@@ -2,33 +2,31 @@
 
 Generates visualisation data from repository (Git or SVN) logs. It supports the following metrics per file:
 
-| Metric               | Description |
-| ---                  | --- |
-| `number_of_commits`  | total number of commits |
-| `weeks_with_commits` | weeks with commits |
-| `number_of_authors`  | number of authors with commits |
+| Metric               | Description                                                 |
+| -------------------- | ----------------------------------------------------------- |
+| `number_of_commits`  | total number of commits                                     |
+| `number_of_renames`  | total number of renames                                     |
+| `weeks_with_commits` | weeks with commits                                          |
+| `number_of_authors`  | number of authors with commits                              |
 | `code_churn`         | code churn, i.e. number of additions plus deletions to file |
 
 Additionally it saves the names of authors when the --add-author flag is set.
 
 ## Usage
 
-### Creating the repository log for metric generation  
+### Creating the repository log for metric generation
 
-
-| SCM | Log format | Command for log creation                   | tracks renames | ignores deleted files | supports code churn | 
-| --- | ---        | ---                                        | ---            | ---                   | --- |
-| git | GIT_LOG    | `git log --name-status --topo-order`       | yes            | yes                   | no  |
-| git | GIT_LOG_NUMSTAT | `git log --numstat --topo-order`      | yes            | no                    | yes |
-| git | GIT_LOG_NUMSTAT_RAW | `git log --numstat --raw --topo-order`  | yes      | yes                   | yes |
-| git | GIT_LOG_RAW | `git log --raw --topo-order`              | yes            | yes                   | no  |
-| SVN | SVN_LOG    | `svn log --verbose`                        | no             | yes                   | no  |
-
+| SCM | Log format          | Command for log creation               | tracks renames | ignores deleted files | supports code churn |
+| --- | ------------------- | -------------------------------------- | -------------- | --------------------- | ------------------- |
+| git | GIT_LOG             | `git log --name-status --topo-order`   | yes            | yes                   | no                  |
+| git | GIT_LOG_NUMSTAT     | `git log --numstat --topo-order`       | yes            | no                    | yes                 |
+| git | GIT_LOG_NUMSTAT_RAW | `git log --numstat --raw --topo-order` | yes            | yes                   | yes                 |
+| git | GIT_LOG_RAW         | `git log --raw --topo-order`           | yes            | yes                   | no                  |
+| SVN | SVN_LOG             | `svn log --verbose`                    | no             | yes                   | no                  |
 
 The generated logs must be in UTF-8 encoding.
 
 You can also use the bash script anongit which generates an anonymous git log with log format GIT_LOG_NUMSTAT_RAW for usage with CodeCharta.
-
 
 ### Executing the SCMLogParser
 
@@ -40,15 +38,14 @@ The result is written as JSON to standard out or into an output file (if specifi
 
 ### Example using Git
 
-* `cd <my_git_project>`
-* `git log --numstat --raw --topo-order > git.log` (or `anongit > git.log`)
-* `./ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o output.cc.json`
-* load `output.cc.json` in visualization
+- `cd <my_git_project>`
+- `git log --numstat --raw --topo-order > git.log` (or `anongit > git.log`)
+- `./ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o output.cc.json`
+- load `output.cc.json` in visualization
 
 ### Example using SVN
 
-* `cd <my_svn_project>`
-* `svn log --verbose > svn.log`
-* `./ccsh scmlogparser svn.log --input-format SVN_LOG -o output.cc.json`
-* load `output.cc.json` in visualization
-
+- `cd <my_svn_project>`
+- `svn log --verbose > svn.log`
+- `./ccsh scmlogparser svn.log --input-format SVN_LOG -o output.cc.json`
+- load `output.cc.json` in visualization

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
@@ -61,6 +61,7 @@ class SCMLogParser: Callable<Void> {
             val nonChurnMetrics = Arrays.asList(
                     "number_of_authors",
                     "number_of_commits",
+                    "number_of_renames",
                     "range_of_weeks_with_commits",
                     "successive_weeks_of_commits",
                     "weeks_with_commits"

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/MetricsFactory.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/MetricsFactory.kt
@@ -40,7 +40,8 @@ class MetricsFactory {
                 HighlyCoupledFiles(),
                 MedianCoupledFiles(),
                 AbsoluteCoupledChurn(),
-                AverageCodeChurnPerCommit()
+                AverageCodeChurnPerCommit(),
+                NumberOfRenames()
         )
     }
 

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/NumberOfRenames.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/NumberOfRenames.kt
@@ -1,0 +1,25 @@
+package de.maibornwolff.codecharta.importer.scmlogparser.input.metrics
+
+import de.maibornwolff.codecharta.importer.scmlogparser.input.Modification
+
+class NumberOfRenames : Metric {
+    private var numberOfRenames = 0
+
+    override fun description(): String {
+        return "Number of Renames: The number of times a file was renamed"
+    }
+
+    override fun metricName(): String {
+        return "number_of_renames"
+    }
+
+    override fun registerModification(modification: Modification) {
+        if (modification.type == Modification.Type.RENAME) {
+            numberOfRenames++
+        }
+    }
+
+    override fun value(): Number {
+        return numberOfRenames
+    }
+}

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/MetricsFactoryTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/MetricsFactoryTest.kt
@@ -28,6 +28,6 @@ class MetricsFactoryTest {
     fun defaultConstructorShouldCreateAllMetrics() {
         val factory = MetricsFactory()
 
-        assertThat(factory.createMetrics()).hasSize(12)
+        assertThat(factory.createMetrics()).hasSize(14)
     }
 }

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/NumberOfRenamesTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/metrics/NumberOfRenamesTest.kt
@@ -1,0 +1,37 @@
+package de.maibornwolff.codecharta.importer.scmlogparser.input.metrics
+
+import de.maibornwolff.codecharta.importer.scmlogparser.input.Modification
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class NumberOfRenamesTest {
+
+    @Test
+    fun `initial value should be zero`() {
+        val metric = NumberOfRenames()
+
+        Assertions.assertThat(metric.value()).isEqualTo(0)
+    }
+
+    @Test
+    fun `metric should not be incremented if not a rename`() {
+        val modification = Modification("foo", Modification.Type.ADD)
+
+        val metric = NumberOfRenames()
+        metric.registerModification(modification)
+
+        Assertions.assertThat(metric.value()).isEqualTo(0)
+    }
+
+    @Test
+    fun `metric should be incremented on rename`() {
+        val modification = Modification("foo", Modification.Type.RENAME)
+
+        val metric = NumberOfRenames()
+        metric.registerModification(modification)
+        metric.registerModification(modification)
+
+        Assertions.assertThat(metric.value()).isEqualTo(2)
+    }
+
+}


### PR DESCRIPTION
# Number of Renames Metric for SCMLogParser

closes #621

## Description

New Metric for SCMLogParser: Number of Renames

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
