### PR TITLE
Bug/631/out of memory scm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Reduced memory usage of SCMLogParser to avoid OutOfMemory Exception #631
+
 ### Chore
 
 - [Security] Bump lodash.mergewith from 4.6.1 to 4.6.2 in /visualization

--- a/analysis/import/SCMLogParser/README.md
+++ b/analysis/import/SCMLogParser/README.md
@@ -2,33 +2,30 @@
 
 Generates visualisation data from repository (Git or SVN) logs. It supports the following metrics per file:
 
-| Metric               | Description |
-| ---                  | --- |
-| `number_of_commits`  | total number of commits |
-| `weeks_with_commits` | weeks with commits |
-| `number_of_authors`  | number of authors with commits |
+| Metric               | Description                                                 |
+| -------------------- | ----------------------------------------------------------- |
+| `number_of_commits`  | total number of commits                                     |
+| `weeks_with_commits` | weeks with commits                                          |
+| `number_of_authors`  | number of authors with commits                              |
 | `code_churn`         | code churn, i.e. number of additions plus deletions to file |
 
 Additionally it saves the names of authors when the --add-author flag is set.
 
 ## Usage
 
-### Creating the repository log for metric generation  
+### Creating the repository log for metric generation
 
-
-| SCM | Log format | Command for log creation                   | tracks renames | ignores deleted files | supports code churn | 
-| --- | ---        | ---                                        | ---            | ---                   | --- |
-| git | GIT_LOG    | `git log --name-status --topo-order`       | yes            | yes                   | no  |
-| git | GIT_LOG_NUMSTAT | `git log --numstat --topo-order`      | yes            | no                    | yes |
-| git | GIT_LOG_NUMSTAT_RAW | `git log --numstat --raw --topo-order`  | yes      | yes                   | yes |
-| git | GIT_LOG_RAW | `git log --raw --topo-order`              | yes            | yes                   | no  |
-| SVN | SVN_LOG    | `svn log --verbose`                        | no             | yes                   | no  |
-
+| SCM | Log format          | Command for log creation               | tracks renames | ignores deleted files | supports code churn |
+| --- | ------------------- | -------------------------------------- | -------------- | --------------------- | ------------------- |
+| git | GIT_LOG             | `git log --name-status --topo-order`   | yes            | yes                   | no                  |
+| git | GIT_LOG_NUMSTAT     | `git log --numstat --topo-order`       | yes            | no                    | yes                 |
+| git | GIT_LOG_NUMSTAT_RAW | `git log --numstat --raw --topo-order` | yes            | yes                   | yes                 |
+| git | GIT_LOG_RAW         | `git log --raw --topo-order`           | yes            | yes                   | no                  |
+| SVN | SVN_LOG             | `svn log --verbose`                    | yes            | yes                   | no                  |
 
 The generated logs must be in UTF-8 encoding.
 
 You can also use the bash script anongit which generates an anonymous git log with log format GIT_LOG_NUMSTAT_RAW for usage with CodeCharta.
-
 
 ### Executing the SCMLogParser
 
@@ -40,15 +37,14 @@ The result is written as JSON to standard out or into an output file (if specifi
 
 ### Example using Git
 
-* `cd <my_git_project>`
-* `git log --numstat --raw --topo-order > git.log` (or `anongit > git.log`)
-* `./ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o output.cc.json`
-* load `output.cc.json` in visualization
+- `cd <my_git_project>`
+- `git log --numstat --raw --topo-order > git.log` (or `anongit > git.log`)
+- `./ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o output.cc.json`
+- load `output.cc.json` in visualization
 
 ### Example using SVN
 
-* `cd <my_svn_project>`
-* `svn log --verbose > svn.log`
-* `./ccsh scmlogparser svn.log --input-format SVN_LOG -o output.cc.json`
-* load `output.cc.json` in visualization
-
+- `cd <my_svn_project>`
+- `svn log --verbose > svn.log`
+- `./ccsh scmlogparser svn.log --input-format SVN_LOG -o output.cc.json`
+- load `output.cc.json` in visualization

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
@@ -47,6 +47,9 @@ class SCMLogParser: Callable<Void> {
             description = ["analysis of svn log, equivalent --input-format SVN_LOG"])
     private var svnLog = false
 
+    @CommandLine.Option(names = ["--silent"], description = ["suppress command line output during process"])
+    private var silent = false
+
     @CommandLine.Option(names = ["--input-format"], description = ["input format for parsing"])
     private var inputFormatNames: InputFormatNames = GIT_LOG
 
@@ -83,7 +86,8 @@ class SCMLogParser: Callable<Void> {
                 logParserStrategy,
                 metricsFactory,
                 projectName,
-                addAuthor)
+                addAuthor,
+                silent)
         if (!outputFile.isEmpty()) {
             ProjectSerializer.serializeProjectAndWriteToFile(project, outputFile)
         } else {
@@ -160,12 +164,13 @@ class SCMLogParser: Callable<Void> {
                 parserStrategy: LogParserStrategy,
                 metricsFactory: MetricsFactory,
                 projectName: String,
-                containsAuthors: Boolean
+                containsAuthors: Boolean,
+                silent: Boolean = false
         ): Project {
 
             val lines = pathToLog.readLines().stream()
             val projectConverter = ProjectConverter(containsAuthors, projectName)
-            return SCMLogProjectCreator(parserStrategy, metricsFactory, projectConverter).parse(lines)
+            return SCMLogProjectCreator(parserStrategy, metricsFactory, projectConverter, silent).parse(lines)
         }
     }
 }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
@@ -88,7 +88,7 @@ class SCMLogParser: Callable<Void> {
                 projectName,
                 addAuthor,
                 silent)
-        if (!outputFile.isEmpty()) {
+        if (outputFile.isNotEmpty()) {
             ProjectSerializer.serializeProjectAndWriteToFile(project, outputFile)
         } else {
             ProjectSerializer.serializeProject(project, OutputStreamWriter(System.out))

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreator.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreator.kt
@@ -13,10 +13,11 @@ import java.util.stream.Stream
 class SCMLogProjectCreator(
         parserStrategy: LogParserStrategy,
         metricsFactory: MetricsFactory,
-        private val projectConverter: ProjectConverter
+        private val projectConverter: ProjectConverter,
+        private val silent: Boolean = false
 ) {
 
-    private val logLineParser: LogLineParser = LogLineParser(parserStrategy, metricsFactory)
+    private val logLineParser: LogLineParser = LogLineParser(parserStrategy, metricsFactory, silent)
 
     fun parse(lines: Stream<String>): Project {
         val versionControlledFiles = logLineParser.parse(lines)

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
@@ -28,7 +28,7 @@ class LogLineParser(private val parserStrategy: LogParserStrategy, private val m
     }
 
     private fun showProgress(date: OffsetDateTime) {
-        print("\r$numberOfCommitsParsed commits parsed. (Latest commit from $date)       ")
+        System.err.print("\r$numberOfCommitsParsed commits parsed. (Latest commit from $date)       ")
         numberOfCommitsParsed++
     }
 }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
@@ -28,7 +28,7 @@ class LogLineParser(private val parserStrategy: LogParserStrategy, private val m
     }
 
     private fun showProgress(date: OffsetDateTime) {
-        print("\r$numberOfCommitsParsed commits parsed. (Latest commit from $date)")
+        print("\r$numberOfCommitsParsed commits parsed. (Latest commit from $date)       ")
         numberOfCommitsParsed++
     }
 }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/parser/LogLineParser.kt
@@ -3,12 +3,15 @@ package de.maibornwolff.codecharta.importer.scmlogparser.parser
 import de.maibornwolff.codecharta.importer.scmlogparser.input.Commit
 import de.maibornwolff.codecharta.importer.scmlogparser.input.VersionControlledFile
 import de.maibornwolff.codecharta.importer.scmlogparser.input.metrics.MetricsFactory
+import java.time.OffsetDateTime
 import java.util.stream.Stream
 
 /**
  * Parses log lines and generates VersionControlledFiles from them using specific parserStrategy and metricsFactory
  */
-class LogLineParser(private val parserStrategy: LogParserStrategy, private val metricsFactory: MetricsFactory) {
+class LogLineParser(private val parserStrategy: LogParserStrategy, private val metricsFactory: MetricsFactory, private val silent: Boolean = false) {
+
+    private var numberOfCommitsParsed = 0
 
     fun parse(logLines: Stream<String>): List<VersionControlledFile> {
         return logLines.collect(parserStrategy.createLogLineCollector())
@@ -20,6 +23,12 @@ class LogLineParser(private val parserStrategy: LogParserStrategy, private val m
         val author = parserStrategy.parseAuthor(commitLines)
         val commitDate = parserStrategy.parseDate(commitLines)
         val modifications = parserStrategy.parseModifications(commitLines)
+        if (!silent) showProgress(commitDate)
         return Commit(author, modifications, commitDate)
+    }
+
+    private fun showProgress(date: OffsetDateTime) {
+        print("\r$numberOfCommitsParsed commits parsed. (Latest commit from $date)")
+        numberOfCommitsParsed++
     }
 }

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
@@ -55,8 +55,8 @@ class SCMLogProjectCreatorGoldenMasterTest(
         // given
         val projectConverter = ProjectConverter(containsAuthors, PROJECT_NAME)
 
-        val svnSCMLogProjectCreator = SCMLogProjectCreator(strategy, metricsFactory, projectConverter)
-        val ccjsonReader = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(expectedProjectFilename))
+        val svnSCMLogProjectCreator = SCMLogProjectCreator(strategy, metricsFactory, projectConverter, silent = true)
+        val ccjsonReader = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(expectedProjectFilename)!!)
         val expectedProject = ProjectDeserializer.deserializeProject(ccjsonReader)
         val resource = this.javaClass.classLoader.getResource(logFilename)
         val logStream = Files.lines(Paths.get(resource!!.toURI()))

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorTest.kt
@@ -45,7 +45,8 @@ class SCMLogProjectCreatorTest(
         val gitSCMLogProjectCreator = SCMLogProjectCreator(
                 strategy,
                 metricsFactory,
-                projectConverter
+                projectConverter,
+                silent = true
         )
         val logStream = Files.lines(Paths.get(this.javaClass.classLoader.getResource(logFilename)!!.toURI()))
 

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/ProjectBuilder.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/ProjectBuilder.kt
@@ -100,6 +100,7 @@ open class ProjectBuilder(
                 blacklist = blacklist.toList()
         )
 
+        System.err.println()
         logger.info { "Created Project with ${project.size} leaves." }
 
         return project

--- a/analysis/test/golden_test.sh
+++ b/analysis/test/golden_test.sh
@@ -72,7 +72,7 @@ check_jasome() {
 check_scmlog() {
   echo " -- expect SCMLogParser gives valid cc.json"
   ACTUAL_SCMLOG_JSON="${INSTALL_DIR}/actual_scmlog.json"
-  "${CCSH}" scmlogparser --svn data/codecharta/SVNTestLog.txt > "${ACTUAL_SCMLOG_JSON}"
+  "${CCSH}" scmlogparser --svn data/codecharta/SVNTestLog.txt --silent > "${ACTUAL_SCMLOG_JSON}"
   validate "${ACTUAL_SCMLOG_JSON}"
 }
 


### PR DESCRIPTION
# Fixing OutOfMemory exception for large log files in SCMLogParser

closes #631

## Description

- Added Progress indicator for SCMLogParser
- The highly coupled files metric is now calculated only after all commits have been parsed, this allows for a less memory intensive computation of the metric

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
