### PR TITLE
Feature/659/metric max nesting level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added
 
+- New Metric in SourceCodeParser: Maximum-Nesting-Level #659
+
 ### Changed
 
 ### Removed

--- a/analysis/import/SourceCodeParser/README.md
+++ b/analysis/import/SourceCodeParser/README.md
@@ -6,6 +6,23 @@ A parser to generate code metrics from a source code file or a project folder. I
 
 - Java
 
+## Supported Metrics
+
+- rloc: Real lines of code
+- classes
+- functions
+- statements
+- comment_lines
+- mcc: McCabe Complexity / Cyclomatic complexity
+- cognitive_complexity
+- commented_out_code_blocks
+- max_nesting_level
+- code_smell
+- security_hotspot
+- vulnerability
+- bug
+- sonar_issue_other
+
 ## Run
 
 The SourceCodeParser can analyze either a single file or a project folder; here are some sample commands:

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sonaranalyzers/JavaSonarAnalyzer.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sonaranalyzers/JavaSonarAnalyzer.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.codecharta.importer.sourcecodeparser.sonaranalyzers
 
 import de.maibornwolff.codecharta.importer.sourcecodeparser.NullFileLinesContextFactory
 import de.maibornwolff.codecharta.importer.sourcecodeparser.metrics.ProjectMetrics
+import de.maibornwolff.codecharta.importer.sourcecodeparser.visitors.MaxNestingLevelVisitor
 import org.sonar.api.SonarQubeSide
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
@@ -19,11 +20,16 @@ import org.sonar.java.DefaultJavaResourceLocator
 import org.sonar.java.JavaClasspath
 import org.sonar.java.JavaTestClasspath
 import org.sonar.java.SonarComponents
+import org.sonar.java.ast.parser.JavaParser
 import org.sonar.java.checks.CheckList
+import org.sonar.java.model.DefaultJavaFileScannerContext
+import org.sonar.java.model.JavaVersionImpl
 import org.sonar.plugins.java.Java
 import org.sonar.plugins.java.JavaRulesDefinition
 import org.sonar.plugins.java.JavaSonarWayProfile
 import org.sonar.plugins.java.JavaSquidSensor
+import org.sonar.plugins.java.api.tree.CompilationUnitTree
+import org.sonar.plugins.java.api.tree.Tree
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -96,7 +102,7 @@ class JavaSonarAnalyzer(verbose: Boolean = false, searchIssues: Boolean = true) 
             addFileToContext(file)
             executeScan()
             val fileMetrics = retrieveMetrics(file)
-            retrieveAdditionalMetrics().forEach { fileMetrics.add(it.key, it.value) }
+            retrieveAdditionalMetrics(file).forEach { fileMetrics.add(it.key, it.value) }
             retrieveIssues().forEach { fileMetrics.add(it.key, it.value) }
             projectMetrics.addFileMetricMap(file, fileMetrics)
         }
@@ -121,14 +127,17 @@ class JavaSonarAnalyzer(verbose: Boolean = false, searchIssues: Boolean = true) 
 
 
     override fun addFileToContext(fileName: String) {
-        val inputFile = TestInputFileBuilder.create("moduleKey", fileName)
+        sensorContext.fileSystem().add(getInputFile(fileName))
+    }
+
+    private fun getInputFile(fileName: String) : InputFile {
+        return TestInputFileBuilder.create("moduleKey", fileName)
                 .setModuleBaseDir(baseDir.toPath())
                 .setCharset(StandardCharsets.UTF_8)
                 .setType(InputFile.Type.MAIN)
                 .setLanguage(Java.KEY)
                 .initMetadata(fileContent(File("$baseDir/$fileName"), StandardCharsets.UTF_8))
                 .build()
-        sensorContext.fileSystem().add(inputFile)
     }
 
     override fun executeScan() {
@@ -164,13 +173,28 @@ class JavaSonarAnalyzer(verbose: Boolean = false, searchIssues: Boolean = true) 
         return issues
     }
 
-    private fun retrieveAdditionalMetrics(): HashMap<String, Int> {
+    private fun retrieveAdditionalMetrics(fileName: String): HashMap<String, Int> {
         val additionalMetrics: HashMap<String, Int> = hashMapOf()
+
+        val tree = buildTree(fileName)
 
         val commentedOutBlocks = sensorContext.allIssues().filter { it.ruleKey().rule() == "CommentedOutCodeLine" }
         additionalMetrics["commented_out_code_blocks"] = commentedOutBlocks.size
+        addMetricsFromVisitors(tree, additionalMetrics)
 
         return additionalMetrics
+    }
+
+    private fun buildTree(fileName: String): Tree {
+        val compilationUnitTree = JavaParser.createParser().parse(File("$baseDir/$fileName")) as CompilationUnitTree
+        val defaultJavaFileScannerContext = DefaultJavaFileScannerContext(
+                compilationUnitTree, getInputFile(fileName), null, null, JavaVersionImpl(), true)
+
+        return defaultJavaFileScannerContext.tree
+    }
+
+    private fun addMetricsFromVisitors(tree: Tree, additionalMetrics: HashMap<String, Int>) {
+        additionalMetrics["max_nesting_level"] = MaxNestingLevelVisitor().getMaxNestingLevel(tree)
     }
 
     private fun printProgressBar(fileName: String) {

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -34,13 +34,22 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
         forwardNesting--
     }
 
-
     override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
         forwardNesting++
 
         checkForChildrenAndUpdateMax()
 
         super.visitDoWhileStatement(tree)
+
+        forwardNesting--
+    }
+
+    override fun visitLambdaExpression(lambdaExpressionTree: LambdaExpressionTree) {
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax()
+
+        super.visitLambdaExpression(lambdaExpressionTree)
 
         forwardNesting--
     }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -1,0 +1,69 @@
+package de.maibornwolff.codecharta.importer.sourcecodeparser.visitors
+
+import org.sonar.java.ast.visitors.ComplexityVisitor
+import org.sonar.plugins.java.api.tree.*
+
+class MaxNestingLevelVisitor : ComplexityVisitor() {
+    private var maxNestingLevel = 0
+    private var currentMaxNestingLevel = 0
+
+    fun getMaxNestingLevel(tree: Tree): Int {
+        scan(tree)
+        return maxNestingLevel
+    }
+
+    override fun visitMethod(tree: MethodTree) {
+        println("visit method")
+        if(maxNestingLevel < currentMaxNestingLevel) {
+            maxNestingLevel = currentMaxNestingLevel
+        }
+        currentMaxNestingLevel = 0
+        super.visitMethod(tree)
+    }
+
+    override fun visitBlock(tree: BlockTree) {
+        currentMaxNestingLevel = 0
+        println("this is a new block")
+        super.visitBlock(tree)
+    }
+
+    override fun visitIfStatement(tree: IfStatementTree) {
+        currentMaxNestingLevel++
+        super.visitIfStatement(tree)
+    }
+
+    override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
+        currentMaxNestingLevel++
+        super.visitDoWhileStatement(tree)
+    }
+
+    override fun visitConditionalExpression(tree: ConditionalExpressionTree) {
+        currentMaxNestingLevel++
+        super.visitConditionalExpression(tree)
+    }
+
+    override fun visitForEachStatement(tree: ForEachStatement) {
+        currentMaxNestingLevel++
+        super.visitForEachStatement(tree)
+    }
+
+    override fun visitForStatement(tree: ForStatementTree) {
+        currentMaxNestingLevel++
+        super.visitForStatement(tree)
+    }
+
+    override fun visitWhileStatement(tree: WhileStatementTree) {
+        currentMaxNestingLevel++
+        super.visitWhileStatement(tree)
+    }
+
+    override fun visitSwitchExpression(tree: SwitchExpressionTree) {
+        currentMaxNestingLevel++
+        super.visitSwitchExpression(tree)
+    }
+
+    override fun visitTryStatement(tree: TryStatementTree) {
+        currentMaxNestingLevel++
+        super.visitTryStatement(tree)
+    }
+}

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -5,7 +5,7 @@ import org.sonar.plugins.java.api.tree.*
 
 class MaxNestingLevelVisitor: ComplexityVisitor() {
     private var maxNestingLevel = 0
-    private var forwardNesting = 0
+    private var currentNestingLevel = 0
 
     fun getMaxNestingLevel(tree: Tree): Int {
         super.getNodes(tree)
@@ -14,103 +14,103 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     }
 
     private fun potentiallyUpdateMaxNestingLevel() {
-        if (maxNestingLevel < forwardNesting) {
-            maxNestingLevel = forwardNesting
+        if (maxNestingLevel < currentNestingLevel) {
+            maxNestingLevel = currentNestingLevel
         }
     }
 
     override fun visitMethod(tree: MethodTree) {
-        forwardNesting = 0
+        currentNestingLevel = 0
         super.visitMethod(tree)
     }
 
     override fun visitIfStatement(tree: IfStatementTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitIfStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitDoWhileStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitLambdaExpression(lambdaExpressionTree: LambdaExpressionTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitLambdaExpression(lambdaExpressionTree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitConditionalExpression(tree: ConditionalExpressionTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitConditionalExpression(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitForEachStatement(tree: ForEachStatement) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitForEachStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitForStatement(tree: ForStatementTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitForStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitWhileStatement(tree: WhileStatementTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitWhileStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitSwitchExpression(tree: SwitchExpressionTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitSwitchExpression(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 
     override fun visitTryStatement(tree: TryStatementTree) {
-        forwardNesting++
+        currentNestingLevel++
 
         potentiallyUpdateMaxNestingLevel()
 
         super.visitTryStatement(tree)
 
-        forwardNesting--
+        currentNestingLevel--
     }
 }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -3,69 +3,92 @@ package de.maibornwolff.codecharta.importer.sourcecodeparser.visitors
 import org.sonar.java.ast.visitors.ComplexityVisitor
 import org.sonar.plugins.java.api.tree.*
 
-class MaxNestingLevelVisitor : ComplexityVisitor() {
+class MaxNestingLevelVisitor: ComplexityVisitor() {
     private var maxNestingLevel = 0
-    private var currentMaxNestingLevel = 0
+    private var forwardNesting = 0
+
 
     fun getMaxNestingLevel(tree: Tree): Int {
         super.getNodes(tree)
+
         return maxNestingLevel
     }
 
-    override fun visitMethod(tree: MethodTree) {
-        println("visit method")
-        currentMaxNestingLevel = 0
-        super.visitMethod(tree)
-        if (maxNestingLevel < currentMaxNestingLevel) {
-            println(currentMaxNestingLevel)
-            maxNestingLevel = currentMaxNestingLevel
+    private fun checkForChildrenAndUpdateMax(tree: Tree) {
+        if(super.getNodes(tree).isEmpty()) {
+            if(maxNestingLevel < forwardNesting) {
+                maxNestingLevel = forwardNesting
+            }
+            forwardNesting = 0
         }
     }
 
-    override fun visitBlock(tree: BlockTree) {
-        //currentMaxNestingLevel = 0
-        println("this is a new block")
-        super.visitBlock(tree)
+    override fun visitMethod(tree: MethodTree) {
+        forwardNesting = 0
+        super.visitMethod(tree)
     }
 
     override fun visitIfStatement(tree: IfStatementTree) {
-        currentMaxNestingLevel++
-        println("if_statement")
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitIfStatement(tree)
     }
 
     override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitDoWhileStatement(tree)
     }
 
     override fun visitConditionalExpression(tree: ConditionalExpressionTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitConditionalExpression(tree)
     }
 
     override fun visitForEachStatement(tree: ForEachStatement) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitForEachStatement(tree)
     }
 
     override fun visitForStatement(tree: ForStatementTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitForStatement(tree)
     }
 
     override fun visitWhileStatement(tree: WhileStatementTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitWhileStatement(tree)
     }
 
     override fun visitSwitchExpression(tree: SwitchExpressionTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitSwitchExpression(tree)
     }
 
     override fun visitTryStatement(tree: TryStatementTree) {
-        currentMaxNestingLevel++
+        forwardNesting++
+
+        checkForChildrenAndUpdateMax(tree)
+
         super.visitTryStatement(tree)
     }
 }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -7,19 +7,15 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     private var maxNestingLevel = 0
     private var forwardNesting = 0
 
-
     fun getMaxNestingLevel(tree: Tree): Int {
         super.getNodes(tree)
 
         return maxNestingLevel
     }
 
-    private fun checkForChildrenAndUpdateMax(tree: Tree) {
-        if(super.getNodes(tree).isEmpty()) {
-            if(maxNestingLevel < forwardNesting) {
-                maxNestingLevel = forwardNesting
-            }
-            forwardNesting = 0
+    private fun checkForChildrenAndUpdateMax() {
+        if (maxNestingLevel < forwardNesting) {
+            maxNestingLevel = forwardNesting
         }
     }
 
@@ -31,64 +27,81 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitIfStatement(tree: IfStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitIfStatement(tree)
+
+        forwardNesting--
     }
+
 
     override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitDoWhileStatement(tree)
+
+        forwardNesting--
     }
 
     override fun visitConditionalExpression(tree: ConditionalExpressionTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitConditionalExpression(tree)
+
+        forwardNesting--
     }
 
     override fun visitForEachStatement(tree: ForEachStatement) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitForEachStatement(tree)
+
+        forwardNesting--
     }
 
     override fun visitForStatement(tree: ForStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitForStatement(tree)
+
+        forwardNesting--
     }
 
     override fun visitWhileStatement(tree: WhileStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitWhileStatement(tree)
+
+        forwardNesting--
     }
 
     override fun visitSwitchExpression(tree: SwitchExpressionTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitSwitchExpression(tree)
+
+        forwardNesting--
     }
 
     override fun visitTryStatement(tree: TryStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax(tree)
+        checkForChildrenAndUpdateMax()
 
         super.visitTryStatement(tree)
+
+        forwardNesting--
     }
 }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -8,27 +8,29 @@ class MaxNestingLevelVisitor : ComplexityVisitor() {
     private var currentMaxNestingLevel = 0
 
     fun getMaxNestingLevel(tree: Tree): Int {
-        scan(tree)
+        super.getNodes(tree)
         return maxNestingLevel
     }
 
     override fun visitMethod(tree: MethodTree) {
         println("visit method")
-        if(maxNestingLevel < currentMaxNestingLevel) {
-            maxNestingLevel = currentMaxNestingLevel
-        }
         currentMaxNestingLevel = 0
         super.visitMethod(tree)
+        if (maxNestingLevel < currentMaxNestingLevel) {
+            println(currentMaxNestingLevel)
+            maxNestingLevel = currentMaxNestingLevel
+        }
     }
 
     override fun visitBlock(tree: BlockTree) {
-        currentMaxNestingLevel = 0
+        //currentMaxNestingLevel = 0
         println("this is a new block")
         super.visitBlock(tree)
     }
 
     override fun visitIfStatement(tree: IfStatementTree) {
         currentMaxNestingLevel++
+        println("if_statement")
         super.visitIfStatement(tree)
     }
 

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitor.kt
@@ -13,7 +13,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
         return maxNestingLevel
     }
 
-    private fun checkForChildrenAndUpdateMax() {
+    private fun potentiallyUpdateMaxNestingLevel() {
         if (maxNestingLevel < forwardNesting) {
             maxNestingLevel = forwardNesting
         }
@@ -27,7 +27,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitIfStatement(tree: IfStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitIfStatement(tree)
 
@@ -37,7 +37,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitDoWhileStatement(tree: DoWhileStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitDoWhileStatement(tree)
 
@@ -47,7 +47,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitLambdaExpression(lambdaExpressionTree: LambdaExpressionTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitLambdaExpression(lambdaExpressionTree)
 
@@ -57,7 +57,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitConditionalExpression(tree: ConditionalExpressionTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitConditionalExpression(tree)
 
@@ -67,7 +67,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitForEachStatement(tree: ForEachStatement) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitForEachStatement(tree)
 
@@ -77,7 +77,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitForStatement(tree: ForStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitForStatement(tree)
 
@@ -87,7 +87,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitWhileStatement(tree: WhileStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitWhileStatement(tree)
 
@@ -97,7 +97,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitSwitchExpression(tree: SwitchExpressionTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitSwitchExpression(tree)
 
@@ -107,7 +107,7 @@ class MaxNestingLevelVisitor: ComplexityVisitor() {
     override fun visitTryStatement(tree: TryStatementTree) {
         forwardNesting++
 
-        checkForChildrenAndUpdateMax()
+        potentiallyUpdateMaxNestingLevel()
 
         super.visitTryStatement(tree)
 

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sourcecodeparser/JavaSonarAnalyzerTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sourcecodeparser/JavaSonarAnalyzerTest.kt
@@ -61,6 +61,7 @@ class JavaSonarAnalyzerTest {
         assertThat(metrics.getFileMetricMap("foo.java")?.getMetricValue("classes")).isEqualTo(1)
         assertThat(metrics.getFileMetricMap("foo.java")?.getMetricValue("mcc")).isEqualTo(6)
         assertThat(metrics.getFileMetricMap("foo.java")?.getMetricValue("comment_lines")).isEqualTo(3)
+        assertThat(metrics.getFileMetricMap("foo.java")?.getMetricValue("max_nesting_level")).isEqualTo(2)
     }
 
     @Test

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
@@ -1,0 +1,39 @@
+package de.maibornwolff.codecharta.importer.sourcecodeparser.visitors
+
+import junit.framework.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.sonar.api.batch.fs.InputFile
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder
+
+import org.sonar.java.ast.parser.JavaParser
+import org.sonar.java.model.DefaultJavaFileScannerContext
+import org.sonar.java.model.JavaVersionImpl
+import org.sonar.plugins.java.Java
+import org.sonar.plugins.java.api.tree.CompilationUnitTree
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+internal class MaxNestingLevelVisitorTest {
+    private val baseDir = File("src/test/resources/sampleproject").absoluteFile
+
+    @Test
+    fun getMaxNestingLevel() {
+        val file = File("src/test/resources/sampleproject/foo.java")
+        val inputFile = TestInputFileBuilder.create("moduleKey", "foo.java")
+                .setModuleBaseDir(baseDir.toPath())
+                .setCharset(StandardCharsets.UTF_8)
+                .setType(InputFile.Type.MAIN)
+                .setLanguage(Java.KEY)
+                .initMetadata(String(Files.readAllBytes(File("$baseDir/foo.java").toPath()), StandardCharsets.UTF_8))
+                .build()
+
+        val compilationUnitTree = JavaParser.createParser().parse(file) as CompilationUnitTree
+        val defaultJavaFileScannerContext = DefaultJavaFileScannerContext(
+                compilationUnitTree, inputFile, null, null, JavaVersionImpl(), true)
+
+        val maxNestingLevel = MaxNestingLevelVisitor().getMaxNestingLevel(defaultJavaFileScannerContext.tree)
+
+        assertEquals(maxNestingLevel, 1)
+    }
+}

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
@@ -50,9 +50,16 @@ class MaxNestingLevelVisitorTest {
     }
 
     @Test
-    fun getMaxNestingLevelGoldenTest() {
+    fun getMaxNestingLevelOfGoldenTest() {
         val maxNestingLevel = MaxNestingLevelVisitor().getMaxNestingLevel(getTree("golden_test.java"))
 
         assertEquals(7, maxNestingLevel)
+    }
+
+    @Test
+    fun getMaxNestingLevelOfLambdaFunctions() {
+        val maxNestingLevel = MaxNestingLevelVisitor().getMaxNestingLevel(getTree("lambda_function.java"))
+
+        assertEquals(2, maxNestingLevel)
     }
 }

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
@@ -20,7 +20,7 @@ internal class MaxNestingLevelVisitorTest {
     @Test
     fun getMaxNestingLevel() {
         val file = File("src/test/resources/sampleproject/foo.java")
-        val inputFile = TestInputFileBuilder.create("moduleKey", "foo.java")
+        val inputFile: InputFile = TestInputFileBuilder.create("moduleKey", "foo.java")
                 .setModuleBaseDir(baseDir.toPath())
                 .setCharset(StandardCharsets.UTF_8)
                 .setType(InputFile.Type.MAIN)

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/visitors/MaxNestingLevelVisitorTest.kt
@@ -15,7 +15,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-internal class MaxNestingLevelVisitorTest {
+class MaxNestingLevelVisitorTest {
     private val baseDir = File("src/test/resources/max-nesting-level").absoluteFile
 
     private fun getTree(fileName: String) : Tree {

--- a/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/golden_test.java
+++ b/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/golden_test.java
@@ -1,0 +1,32 @@
+import java.awt.*;
+
+class GoldenTest {
+
+    public void goldenTest() {
+        if (1 < 2) {
+            for (i = 0; i < 2; i++) {
+                System.out.println("ABC");
+                System.out.println("ABC");
+                if (1 < 2) {
+                    System.out.println("ABC");
+                } else if (1 < 2) {
+                    System.out.println("ABC");
+                    for (i = 0; i < 2; i++) {
+                        if (1 < 2) {
+                            System.out.println("ABC");
+                            if (2 < 3) {
+                                System.out.println("ABC");
+                            }
+                        } else if (1 < 2) {
+                            System.out.println("ABC");
+                        }
+                    }
+                }
+            }
+        } else {
+            if (1 < 2) {
+                System.out.println("ABC");
+            }
+        }
+    }
+}

--- a/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/if_else.java
+++ b/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/if_else.java
@@ -1,0 +1,13 @@
+public class Foo {
+
+    public void setStuff(int stuff){
+        this.wasReset = false;
+        if(stuff < 0){
+            reset(5);
+            wasReset = true;
+        } else {
+            this.stuff = stuff;
+        }
+        System.out.println("SetStuff was called");
+    }
+}

--- a/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/lambda_function.java
+++ b/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/lambda_function.java
@@ -1,0 +1,12 @@
+class LambdaFunction {
+
+    public void lamba() {
+        FuncInterface fobj = (int x) -> {
+            if(a<b) {
+                System.out.println(2 * x);
+            }
+        };
+
+        fobj.abstractFunction(5);
+    }
+}

--- a/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/nested_ifs.java
+++ b/analysis/import/SourceCodeParser/src/test/resources/max-nesting-level/nested_ifs.java
@@ -1,0 +1,18 @@
+public class Foo {
+    public void setStuff(int stuff){
+        this.wasReset = false;
+        if(stuff < 0){
+            reset(5);
+            wasReset = true;
+        } else if(reset(-1)){
+            this.stuff = stuff;
+        }
+
+        if(0 < 1) {
+            if(1 < 0) {
+                System.out.println("ABC");
+            }
+        }
+        System.out.println("SetStuff was called");
+    }
+}


### PR DESCRIPTION
# Added Metric for Maximum Nesting Level

closes #659

## Description
- Added a max_nesting_level metric to the SourceCodeParser
- Metric is calculated with the use of Visitors
- Refactored some functions in JavaAnalyzer and made it easier to add future metrics from visitors

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
