### PR TITLE
SourceCodeParser handling of files w. invalid syntax tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- SourceCodeParser now skips custom metrics for files, if the syntax tree cannot be created
+
 ### Chore
 
 ## [1.32.0] - 2019-08-09

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sonaranalyzers/JavaSonarAnalyzer.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/sonaranalyzers/JavaSonarAnalyzer.kt
@@ -1,5 +1,6 @@
 package de.maibornwolff.codecharta.importer.sourcecodeparser.sonaranalyzers
 
+import com.sonar.sslr.api.RecognitionException
 import de.maibornwolff.codecharta.importer.sourcecodeparser.NullFileLinesContextFactory
 import de.maibornwolff.codecharta.importer.sourcecodeparser.metrics.ProjectMetrics
 import de.maibornwolff.codecharta.importer.sourcecodeparser.visitors.MaxNestingLevelVisitor
@@ -176,7 +177,13 @@ class JavaSonarAnalyzer(verbose: Boolean = false, searchIssues: Boolean = true) 
     private fun retrieveAdditionalMetrics(fileName: String): HashMap<String, Int> {
         val additionalMetrics: HashMap<String, Int> = hashMapOf()
 
-        val tree = buildTree(fileName)
+        var tree: Tree
+        try {
+            tree = buildTree(fileName)
+        } catch (e: RecognitionException) {
+            System.err.println("Syntax error in file $fileName, therefore some metrics are not calculated")
+            return hashMapOf()
+        }
 
         val commentedOutBlocks = sensorContext.allIssues().filter { it.ruleKey().rule() == "CommentedOutCodeLine" }
         additionalMetrics["commented_out_code_blocks"] = commentedOutBlocks.size


### PR DESCRIPTION
# SourceCodeParser handling of files w. invalid syntax tree

## Description

The SourceCodeParser used to throw an exception if for a file the syntax tree could not be created. This is inpractical if we want to scan a large project and have to exclude the file manually and restart the process again for each invalid file. Therefore i changed the behaviour, that the exception is catched, a warning given, and the custom metrics not calculated for those files.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
