### PR TITLE
Bug/707/search does not work

### DIFF
--- a/visualization/app/codeCharta/state/settingsService/settings.service.ts
+++ b/visualization/app/codeCharta/state/settingsService/settings.service.ts
@@ -242,7 +242,6 @@ export class SettingsService implements FileStateServiceSubscriber {
 	private notify(eventName: string, data: object, debounceTime: number = SettingsService.DEBOUNCE_TIME) {
 		this.debounceBroadcast = _.debounce(() => {
 			this.$rootScope.$broadcast(eventName, data)
-			this.update = {}
 		}, debounceTime)
 		this.debounceBroadcast()
 	}


### PR DESCRIPTION
# Bug/707/search does not work

closes #707 

## Description

- The update object inside the settingsService is set empty too early. It only has to be emptied at its last broadcast call.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
