### PR TITLE
Bug/654/disable adding pattern when search is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
-- Exclude and Hide options are disabled for empty search Pattern String #654
+- Exclude and Hide options are disabled for empty and already existing search patterns #654
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Exclude and Hide options are disabled for empty search Pattern String #654
+
 ### Chore
 
 ## [1.34.0] - 2019-09-20

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
@@ -11,7 +11,7 @@
 
 <md-menu>
 	<div class="small-action-button transparent">
-		<md-button class="md-fab" ng-click="$mdMenu.open($event)" title="Add to Blacklist...">
+		<md-button class="md-fab" ng-click="$mdMenu.open($event); $ctrl.isPatternInBlackList()" title="Add to Blacklist...">
 			<i class="fa fa-ellipsis-h"></i>
 		</md-button>
 	</div>

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
@@ -23,16 +23,12 @@
 		</md-menu-item>
 		<md-divider></md-divider>
 		<md-menu-item>
-			<md-button
-				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternHidden"
-				ng-click="$ctrl.onClickBlacklistPattern('hide')"
+			<md-button ng-disabled="$ctrl.disableHiddenOption()" ng-click="$ctrl.onClickBlacklistPattern('hide')"
 				><i class="fa fa-eye-slash"></i> Hide</md-button
 			>
 		</md-menu-item>
 		<md-menu-item>
-			<md-button
-				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternExcluded"
-				ng-click="$ctrl.onClickBlacklistPattern('exclude')"
+			<md-button ng-disabled="$ctrl.disableExcludeOption()" ng-click="$ctrl.onClickBlacklistPattern('exclude')"
 				><i class="fa fa-ban"></i> Exclude</md-button
 			>
 		</md-menu-item>

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
@@ -5,13 +5,13 @@
 		type="text"
 		placeholder="gitignore style: *.js, **/app/*"
 		ng-model="$ctrl._viewModel.searchPattern"
-		ng-change="$ctrl.applySettingsSearchPattern()"
+		ng-change="$ctrl.onSearchPatternChanged()"
 	/>
 </md-input-container>
 
 <md-menu>
 	<div class="small-action-button transparent">
-		<md-button class="md-fab" ng-click="$mdMenu.open($event); $ctrl.isPatternInBlackList()" title="Add to Blacklist...">
+		<md-button class="md-fab" ng-click="$mdMenu.open($event)" title="Add to Blacklist...">
 			<i class="fa fa-ellipsis-h"></i>
 		</md-button>
 	</div>

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
@@ -24,14 +24,14 @@
 		<md-divider></md-divider>
 		<md-menu-item>
 			<md-button
-				ng-disabled="$ctrl._viewModel.folderCount + $ctrl._viewModel.fileCount == 0 || $ctrl._viewModel.isPatternHidden"
+				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternHidden"
 				ng-click="$ctrl.onClickBlacklistPattern('hide')"
 				><i class="fa fa-eye-slash"></i> Hide</md-button
 			>
 		</md-menu-item>
 		<md-menu-item>
 			<md-button
-				ng-disabled="$ctrl._viewModel.folderCount + $ctrl._viewModel.fileCount == 0 || $ctrl._viewModel.isPatternExcluded"
+				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternExcluded"
 				ng-click="$ctrl.onClickBlacklistPattern('exclude')"
 				><i class="fa fa-ban"></i> Exclude</md-button
 			>

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.html
@@ -23,12 +23,16 @@
 		</md-menu-item>
 		<md-divider></md-divider>
 		<md-menu-item>
-			<md-button ng-disabled="$ctrl.disableHiddenOption()" ng-click="$ctrl.onClickBlacklistPattern('hide')"
+			<md-button
+				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternHidden"
+				ng-click="$ctrl.onClickBlacklistPattern('hide')"
 				><i class="fa fa-eye-slash"></i> Hide</md-button
 			>
 		</md-menu-item>
 		<md-menu-item>
-			<md-button ng-disabled="$ctrl.disableExcludeOption()" ng-click="$ctrl.onClickBlacklistPattern('exclude')"
+			<md-button
+				ng-disabled="$ctrl.isSearchPatternEmpty() || $ctrl._viewModel.isPatternExcluded"
+				ng-click="$ctrl.onClickBlacklistPattern('exclude')"
 				><i class="fa fa-ban"></i> Exclude</md-button
 			>
 		</md-menu-item>

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -71,7 +71,7 @@ describe("SearchBarController", () => {
 	describe("applySettingsSearchPattern", () => {
 		it("should set searchPattern in settings", () => {
 			searchBarController["_viewModel"].searchPattern = "*fileSettings"
-			searchBarController.applySettingsSearchPattern()
+			searchBarController["applySettingsSearchPattern"]()
 			expect(settingsService.getSettings().dynamicSettings.searchPattern).toBe(searchBarController["_viewModel"].searchPattern)
 		})
 	})
@@ -143,19 +143,19 @@ describe("SearchBarController", () => {
 
 	describe("onSearchPatternChanged", () => {
 		it("call applySettingsSearchPattern", () => {
-			searchBarController.applySettingsSearchPattern = jest.fn()
+			searchBarController["applySettingsSearchPattern"] = jest.fn()
 
 			searchBarController.onSearchPatternChanged()
 
-			expect(searchBarController.applySettingsSearchPattern).toHaveBeenCalled()
+			expect(searchBarController["applySettingsSearchPattern"]).toHaveBeenCalled()
 		})
 
 		it("call updateViewModel", () => {
-			searchBarController.updateViewModel = jest.fn()
+			searchBarController["updateViewModel"] = jest.fn()
 
 			searchBarController.onSearchPatternChanged()
 
-			expect(searchBarController.updateViewModel).toHaveBeenCalled()
+			expect(searchBarController["updateViewModel"]).toHaveBeenCalled()
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -1,10 +1,10 @@
 import "./searchBar.module"
-import { SearchBarController } from "./searchBar.component"
-import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
-import { IRootScopeService } from "angular"
-import { SettingsService } from "../../state/settingsService/settings.service"
-import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
-import { BlacklistType, BlacklistItem } from "../../codeCharta.model"
+import {SearchBarController} from "./searchBar.component"
+import {getService, instantiateModule} from "../../../../mocks/ng.mockhelper"
+import {IRootScopeService} from "angular"
+import {SettingsService} from "../../state/settingsService/settings.service"
+import {CodeMapActionsService} from "../codeMap/codeMap.actions.service"
+import {BlacklistItem, BlacklistType} from "../../codeCharta.model"
 
 describe("SearchBarController", () => {
 	let searchBarController: SearchBarController
@@ -119,4 +119,59 @@ describe("SearchBarController", () => {
 			expect(searchBarController.isSearchPatternEmpty()).toBeFalsy()
 		})
 	})
+
+    describe("isPatternInBlackList", ()=>{
+        beforeEach(() => {
+            searchBarController["_viewModel"].searchPattern = "/root/node/path"
+
+            settingsService.getSettings().fileSettings.blacklist = [
+                { path: "/root/another/node/path", type: BlacklistType.exclude }
+            ]
+        })
+        it("should set the isPatternHidden to true, when the pattern is already in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternHidden = false
+            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.hide})
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
+
+        })
+        it("should set the isPatternHidden to false, when the pattern is not in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternHidden = true
+
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
+
+        })
+        it("should set the isPatternExcluded to true, when the pattern is in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternExcluded = false
+            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.exclude})
+
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
+
+        })
+        it("should set the isPatternExcluded to false, when the pattern is not in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternExcluded = true
+
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
+
+        })
+    })
 })

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -30,6 +30,16 @@ describe("SearchBarController", () => {
 		searchBarController = new SearchBarController($rootScope, settingsService, codeMapActionsService)
 	}
 
+	function withMockedSettingsService(blacklist: BlacklistItem[]) {
+		settingsService = searchBarController["settingsService"] = jest.fn().mockReturnValue({
+			getSettings: jest.fn().mockReturnValue({
+				fileSettings: {
+					blacklist: blacklist
+				}
+			})()
+		})()
+	}
+
 	describe("constructor", () => {
 		SettingsService.subscribeToBlacklist = jest.fn()
 
@@ -120,39 +130,40 @@ describe("SearchBarController", () => {
 		})
 	})
 
-	describe("isPatternInBlackList", () => {
-		beforeEach(() => {
-			searchBarController["_viewModel"].searchPattern = "/root/node/path"
+	describe("updateViewModel", () => {
+		let blacklist: BlacklistItem[]
 
-			settingsService.getSettings().fileSettings.blacklist = [{ path: "/root/another/node/path", type: BlacklistType.exclude }]
+		beforeEach(() => {
+			blacklist = [{ path: "/root/another/node/path", type: BlacklistType.exclude }]
+			searchBarController["_viewModel"].searchPattern = "/root/node/path"
 		})
 		it("should set the isPatternHidden to true, when the pattern is already in Blacklist", () => {
+			blacklist.push({ path: "/root/node/path", type: BlacklistType.hide })
 			searchBarController["_viewModel"].isPatternHidden = false
-			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.hide })
 
-			searchBarController.isPatternInBlackList()
+			searchBarController["updateViewModel"](blacklist)
 
 			expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
 		})
 		it("should set the isPatternHidden to false, when the pattern is not in Blacklist", () => {
 			searchBarController["_viewModel"].isPatternHidden = true
 
-			searchBarController.isPatternInBlackList()
+			searchBarController["updateViewModel"](blacklist)
 
 			expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
 		})
 		it("should set the isPatternExcluded to true, when the pattern is in Blacklist", () => {
+			blacklist.push({ path: "/root/node/path", type: BlacklistType.exclude })
 			searchBarController["_viewModel"].isPatternExcluded = false
-			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.exclude })
 
-			searchBarController.isPatternInBlackList()
+			searchBarController["updateViewModel"](blacklist)
 
 			expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
 		})
 		it("should set the isPatternExcluded to false, when the pattern is not in Blacklist", () => {
 			searchBarController["_viewModel"].isPatternExcluded = true
 
-			searchBarController.isPatternInBlackList()
+			searchBarController["updateViewModel"](blacklist)
 
 			expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
 		})

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -31,16 +31,6 @@ describe("SearchBarController", () => {
 		searchBarController = new SearchBarController($rootScope, settingsService, codeMapActionsService)
 	}
 
-	function withMockedSettingsService(blacklist: BlacklistItem[]) {
-		settingsService = searchBarController["settingsService"] = jest.fn().mockReturnValue({
-			getSettings: jest.fn().mockReturnValue({
-				fileSettings: {
-					blacklist: blacklist
-				}
-			})()
-		})()
-	}
-
 	function withMockedEventMethods() {
 		$rootScope.$on = searchBarController["$rootScope"].$on = jest.fn()
 		$rootScope.$broadcast = searchBarController["$rootScope"].$broadcast = jest.fn()

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -106,4 +106,17 @@ describe("SearchBarController", () => {
 			expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
 		})
 	})
+
+	describe("isSearchPatternEmpty", ()=>{
+		it("should return true, if SearchPattern is empty", () =>{
+			searchBarController["_viewModel"].searchPattern = ""
+
+			expect(searchBarController.isSearchPatternEmpty()).toBeTruthy()
+		})
+		it("should return false, if SearchPattern is empty", () =>{
+			searchBarController["_viewModel"].searchPattern = "test"
+
+			expect(searchBarController.isSearchPatternEmpty()).toBeFalsy()
+		})
+	})
 })

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -1,10 +1,10 @@
 import "./searchBar.module"
-import { SearchBarController } from "./searchBar.component"
-import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
-import { IRootScopeService } from "angular"
-import { SettingsService } from "../../state/settingsService/settings.service"
-import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
-import { BlacklistItem, BlacklistType } from "../../codeCharta.model"
+import {SearchBarController} from "./searchBar.component"
+import {getService, instantiateModule} from "../../../../mocks/ng.mockhelper"
+import {IRootScopeService} from "angular"
+import {SettingsService} from "../../state/settingsService/settings.service"
+import {CodeMapActionsService} from "../codeMap/codeMap.actions.service"
+import {BlacklistItem, BlacklistType} from "../../codeCharta.model"
 
 describe("SearchBarController", () => {
 	let searchBarController: SearchBarController
@@ -107,54 +107,71 @@ describe("SearchBarController", () => {
 		})
 	})
 
-	describe("isSearchPatternEmpty", () => {
-		it("should return true, if SearchPattern is empty", () => {
+	describe("isSearchPatternEmpty", ()=>{
+		it("should return true, if SearchPattern is empty", () =>{
 			searchBarController["_viewModel"].searchPattern = ""
 
 			expect(searchBarController.isSearchPatternEmpty()).toBeTruthy()
 		})
-		it("should return false, if SearchPattern is empty", () => {
+		it("should return false, if SearchPattern is empty", () =>{
 			searchBarController["_viewModel"].searchPattern = "test"
 
 			expect(searchBarController.isSearchPatternEmpty()).toBeFalsy()
 		})
 	})
 
-	describe("isPatternInBlackList", () => {
-		beforeEach(() => {
-			searchBarController["_viewModel"].searchPattern = "/root/node/path"
+    describe("isPatternInBlackList", ()=>{
+        beforeEach(() => {
+            searchBarController["_viewModel"].searchPattern = "/root/node/path"
 
-			settingsService.getSettings().fileSettings.blacklist = [{ path: "/root/another/node/path", type: BlacklistType.exclude }]
-		})
-		it("should set the isPatternHidden to true, when the pattern is already in Blacklist", () => {
-			searchBarController["_viewModel"].isPatternHidden = false
-			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.hide })
+            settingsService.getSettings().fileSettings.blacklist = [
+                { path: "/root/another/node/path", type: BlacklistType.exclude }
+            ]
+        })
+        it("should set the isPatternHidden to true, when the pattern is already in Blacklist",() =>{
 
-			searchBarController.isPatternInBlackList()
+            searchBarController["_viewModel"].isPatternHidden = false
+            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.hide})
 
-			expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
-		})
-		it("should set the isPatternHidden to false, when the pattern is not in Blacklist", () => {
-			searchBarController["_viewModel"].isPatternHidden = true
+            searchBarController.isPatternInBlackList()
 
-			searchBarController.isPatternInBlackList()
 
-			expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
-		})
-		it("should set the isPatternExcluded to true, when the pattern is in Blacklist", () => {
-			searchBarController["_viewModel"].isPatternExcluded = false
-			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.exclude })
+            expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
 
-			searchBarController.isPatternInBlackList()
+        })
+        it("should set the isPatternHidden to false, when the pattern is not in Blacklist",() =>{
 
-			expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
-		})
-		it("should set the isPatternExcluded to false, when the pattern is not in Blacklist", () => {
-			searchBarController["_viewModel"].isPatternExcluded = true
+            searchBarController["_viewModel"].isPatternHidden = true
 
-			searchBarController.isPatternInBlackList()
 
-			expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
-		})
-	})
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
+
+        })
+        it("should set the isPatternExcluded to true, when the pattern is in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternExcluded = false
+            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.exclude})
+
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
+
+        })
+        it("should set the isPatternExcluded to false, when the pattern is not in Blacklist",() =>{
+
+            searchBarController["_viewModel"].isPatternExcluded = true
+
+
+            searchBarController.isPatternInBlackList()
+
+
+            expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
+
+        })
+    })
 })

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -1,10 +1,10 @@
 import "./searchBar.module"
-import {SearchBarController} from "./searchBar.component"
-import {getService, instantiateModule} from "../../../../mocks/ng.mockhelper"
-import {IRootScopeService} from "angular"
-import {SettingsService} from "../../state/settingsService/settings.service"
-import {CodeMapActionsService} from "../codeMap/codeMap.actions.service"
-import {BlacklistItem, BlacklistType} from "../../codeCharta.model"
+import { SearchBarController } from "./searchBar.component"
+import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
+import { IRootScopeService } from "angular"
+import { SettingsService } from "../../state/settingsService/settings.service"
+import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
+import { BlacklistItem, BlacklistType } from "../../codeCharta.model"
 
 describe("SearchBarController", () => {
 	let searchBarController: SearchBarController
@@ -107,71 +107,54 @@ describe("SearchBarController", () => {
 		})
 	})
 
-	describe("isSearchPatternEmpty", ()=>{
-		it("should return true, if SearchPattern is empty", () =>{
+	describe("isSearchPatternEmpty", () => {
+		it("should return true, if SearchPattern is empty", () => {
 			searchBarController["_viewModel"].searchPattern = ""
 
 			expect(searchBarController.isSearchPatternEmpty()).toBeTruthy()
 		})
-		it("should return false, if SearchPattern is empty", () =>{
+		it("should return false, if SearchPattern is empty", () => {
 			searchBarController["_viewModel"].searchPattern = "test"
 
 			expect(searchBarController.isSearchPatternEmpty()).toBeFalsy()
 		})
 	})
 
-    describe("isPatternInBlackList", ()=>{
-        beforeEach(() => {
-            searchBarController["_viewModel"].searchPattern = "/root/node/path"
+	describe("isPatternInBlackList", () => {
+		beforeEach(() => {
+			searchBarController["_viewModel"].searchPattern = "/root/node/path"
 
-            settingsService.getSettings().fileSettings.blacklist = [
-                { path: "/root/another/node/path", type: BlacklistType.exclude }
-            ]
-        })
-        it("should set the isPatternHidden to true, when the pattern is already in Blacklist",() =>{
+			settingsService.getSettings().fileSettings.blacklist = [{ path: "/root/another/node/path", type: BlacklistType.exclude }]
+		})
+		it("should set the isPatternHidden to true, when the pattern is already in Blacklist", () => {
+			searchBarController["_viewModel"].isPatternHidden = false
+			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.hide })
 
-            searchBarController["_viewModel"].isPatternHidden = false
-            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.hide})
+			searchBarController.isPatternInBlackList()
 
-            searchBarController.isPatternInBlackList()
+			expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
+		})
+		it("should set the isPatternHidden to false, when the pattern is not in Blacklist", () => {
+			searchBarController["_viewModel"].isPatternHidden = true
 
+			searchBarController.isPatternInBlackList()
 
-            expect(searchBarController["_viewModel"].isPatternHidden).toBeTruthy()
+			expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
+		})
+		it("should set the isPatternExcluded to true, when the pattern is in Blacklist", () => {
+			searchBarController["_viewModel"].isPatternExcluded = false
+			settingsService.getSettings().fileSettings.blacklist.push({ path: "/root/node/path", type: BlacklistType.exclude })
 
-        })
-        it("should set the isPatternHidden to false, when the pattern is not in Blacklist",() =>{
+			searchBarController.isPatternInBlackList()
 
-            searchBarController["_viewModel"].isPatternHidden = true
+			expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
+		})
+		it("should set the isPatternExcluded to false, when the pattern is not in Blacklist", () => {
+			searchBarController["_viewModel"].isPatternExcluded = true
 
+			searchBarController.isPatternInBlackList()
 
-            searchBarController.isPatternInBlackList()
-
-
-            expect(searchBarController["_viewModel"].isPatternHidden).toBeFalsy()
-
-        })
-        it("should set the isPatternExcluded to true, when the pattern is in Blacklist",() =>{
-
-            searchBarController["_viewModel"].isPatternExcluded = false
-            settingsService.getSettings().fileSettings.blacklist.push({path:"/root/node/path", type:BlacklistType.exclude})
-
-
-            searchBarController.isPatternInBlackList()
-
-
-            expect(searchBarController["_viewModel"].isPatternExcluded).toBeTruthy()
-
-        })
-        it("should set the isPatternExcluded to false, when the pattern is not in Blacklist",() =>{
-
-            searchBarController["_viewModel"].isPatternExcluded = true
-
-
-            searchBarController.isPatternInBlackList()
-
-
-            expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
-
-        })
-    })
+			expect(searchBarController["_viewModel"].isPatternExcluded).toBeFalsy()
+		})
+	})
 })

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -31,7 +31,6 @@ export class SearchBarController implements BlacklistSubscriber {
 				searchPattern: this._viewModel.searchPattern
 			}
 		})
-
 	}
 
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
@@ -51,7 +50,7 @@ export class SearchBarController implements BlacklistSubscriber {
 		return this._viewModel.searchPattern === ""
 	}
 
-	public isPatternInBlackList(){
+	public isPatternInBlackList() {
 		this.updateViewModel(this.settingsService.getSettings().fileSettings.blacklist)
 	}
 

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -46,6 +46,11 @@ export class SearchBarController implements BlacklistSubscriber {
 		this.resetSearchPattern()
 	}
 
+	public isSearchPatternEmpty(){
+		console.log(this.settingsService.getSettings().dynamicSettings.searchedNodePaths)
+		return this._viewModel.searchPattern === ""
+	}
+
 	private updateViewModel(blacklist: BlacklistItem[]) {
 		this._viewModel.isPatternExcluded = this.isPatternBlacklisted(blacklist, BlacklistType.exclude)
 		this._viewModel.isPatternHidden = this.isPatternBlacklisted(blacklist, BlacklistType.hide)

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -25,14 +25,6 @@ export class SearchBarController implements BlacklistSubscriber {
 		SettingsService.subscribeToBlacklist(this.$rootScope, this)
 	}
 
-	public applySettingsSearchPattern() {
-		this.settingsService.updateSettings({
-			dynamicSettings: {
-				searchPattern: this._viewModel.searchPattern
-			}
-		})
-	}
-
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
 		this.resetSearchPattern()
 	}
@@ -50,7 +42,8 @@ export class SearchBarController implements BlacklistSubscriber {
 		return this._viewModel.searchPattern === ""
 	}
 
-	public isPatternInBlackList() {
+	public onSearchPatternChanged() {
+		this.applySettingsSearchPattern()
 		this.updateViewModel(this.settingsService.getSettings().fileSettings.blacklist)
 	}
 
@@ -66,6 +59,14 @@ export class SearchBarController implements BlacklistSubscriber {
 	private resetSearchPattern() {
 		this._viewModel.searchPattern = ""
 		this.applySettingsSearchPattern()
+	}
+
+	private applySettingsSearchPattern() {
+		this.settingsService.updateSettings({
+			dynamicSettings: {
+				searchPattern: this._viewModel.searchPattern
+			}
+		})
 	}
 }
 

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -31,6 +31,7 @@ export class SearchBarController implements BlacklistSubscriber {
 				searchPattern: this._viewModel.searchPattern
 			}
 		})
+
 	}
 
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
@@ -48,6 +49,10 @@ export class SearchBarController implements BlacklistSubscriber {
 
 	public isSearchPatternEmpty() {
 		return this._viewModel.searchPattern === ""
+	}
+
+	public isPatternInBlackList(){
+		this.updateViewModel(this.settingsService.getSettings().fileSettings.blacklist)
 	}
 
 	private updateViewModel(blacklist: BlacklistItem[]) {

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -46,8 +46,7 @@ export class SearchBarController implements BlacklistSubscriber {
 		this.resetSearchPattern()
 	}
 
-	public isSearchPatternEmpty(){
-		console.log(this.settingsService.getSettings().dynamicSettings.searchedNodePaths)
+	public isSearchPatternEmpty() {
 		return this._viewModel.searchPattern === ""
 	}
 

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -28,10 +28,10 @@ export class SearchBarController implements BlacklistSubscriber {
 	public applySettingsSearchPattern() {
 		this.settingsService.updateSettings({
 			dynamicSettings: {
-				searchPattern: this._viewModel.searchPattern,
-				searchedNodePaths: []
+				searchPattern: this._viewModel.searchPattern
 			}
 		})
+
 	}
 
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
@@ -47,32 +47,12 @@ export class SearchBarController implements BlacklistSubscriber {
 		this.resetSearchPattern()
 	}
 
-	public disableHiddenOption() {
-		if (this.isSearchPatternEmpty() || this._viewModel.isPatternHidden || !this.isSearchPatternExisting()) {
-			return true
-		} else {
-			return false
-		}
-	}
-
-	public disableExcludeOption() {
-		if (this.isSearchPatternEmpty() || this._viewModel.isPatternExcluded || !this.isSearchPatternExisting()) {
-			return true
-		} else {
-			return false
-		}
-	}
-
 	public isSearchPatternEmpty() {
 		return this._viewModel.searchPattern === ""
 	}
 
-	public isPatternInBlackList() {
+	public isPatternInBlackList(){
 		this.updateViewModel(this.settingsService.getSettings().fileSettings.blacklist)
-	}
-
-	public isSearchPatternExisting() {
-		return this.settingsService.getSettings().dynamicSettings.searchedNodePaths.length > 0
 	}
 
 	private updateViewModel(blacklist: BlacklistItem[]) {

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -28,10 +28,10 @@ export class SearchBarController implements BlacklistSubscriber {
 	public applySettingsSearchPattern() {
 		this.settingsService.updateSettings({
 			dynamicSettings: {
-				searchPattern: this._viewModel.searchPattern
+				searchPattern: this._viewModel.searchPattern,
+				searchedNodePaths: []
 			}
 		})
-
 	}
 
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
@@ -47,12 +47,32 @@ export class SearchBarController implements BlacklistSubscriber {
 		this.resetSearchPattern()
 	}
 
+	public disableHiddenOption() {
+		if (this.isSearchPatternEmpty() || this._viewModel.isPatternHidden || !this.isSearchPatternExisting()) {
+			return true
+		} else {
+			return false
+		}
+	}
+
+	public disableExcludeOption() {
+		if (this.isSearchPatternEmpty() || this._viewModel.isPatternExcluded || !this.isSearchPatternExisting()) {
+			return true
+		} else {
+			return false
+		}
+	}
+
 	public isSearchPatternEmpty() {
 		return this._viewModel.searchPattern === ""
 	}
 
-	public isPatternInBlackList(){
+	public isPatternInBlackList() {
 		this.updateViewModel(this.settingsService.getSettings().fileSettings.blacklist)
+	}
+
+	public isSearchPatternExisting() {
+		return this.settingsService.getSettings().dynamicSettings.searchedNodePaths.length > 0
 	}
 
 	private updateViewModel(blacklist: BlacklistItem[]) {

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -4,8 +4,9 @@ import { BlacklistType, BlacklistItem, FileState } from "../../codeCharta.model"
 import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
 import { IRootScopeService } from "angular"
 import { BlacklistSubscriber } from "../../state/settingsService/settings.service.events"
+import { FileStateService, FileStateServiceSubscriber } from "../../state/fileState.service"
 
-export class SearchBarController implements BlacklistSubscriber {
+export class SearchBarController implements BlacklistSubscriber, FileStateServiceSubscriber {
 	private _viewModel: {
 		searchPattern: string
 		isPatternHidden: boolean
@@ -23,11 +24,14 @@ export class SearchBarController implements BlacklistSubscriber {
 		private codeMapActionsService: CodeMapActionsService
 	) {
 		SettingsService.subscribeToBlacklist(this.$rootScope, this)
+		FileStateService.subscribe(this.$rootScope, this)
 	}
 
 	public onFileSelectionStatesChanged(fileStates: FileState[]) {
 		this.resetSearchPattern()
 	}
+
+	public onImportedFilesChanged(fileStates: FileState[]) {}
 
 	public onBlacklistChanged(blacklist: BlacklistItem[]) {
 		this.updateViewModel(blacklist)


### PR DESCRIPTION
# Disable adding pattern when search is empty

closes #654 

## Description

When the search pattern is empty, the options to exclude or hide the empty string is disabled. 

![empty_string](https://user-images.githubusercontent.com/50145538/65316063-84712e80-db99-11e9-8ea1-252dd0062e78.PNG)


If the search pattern is already in the exclude or hide list, then that option is disabled. 

![already_excluded](https://user-images.githubusercontent.com/50145538/65316089-90f58700-db99-11e9-94bf-e4f66a23b43e.gif)


If the pattern won't match any building, the options are not disabled.

![no_matching](https://user-images.githubusercontent.com/50145538/65316105-98b52b80-db99-11e9-932b-2973ea6cda28.PNG)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
