### PR TITLE
Bug/600/shelljs sanitize input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed
 
 - Increased size of ribbonBar for big screens #644
+- Sanitize input for shelljs #600
 
 ### Chore
 

--- a/visualization/cli.js
+++ b/visualization/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 
 const shell = require("shelljs")
-shell.exec(`npm run --prefix ${__dirname} start`)
+const sanitized_dir = __dirname.replace('"', "")
+shell.exec(`npm run --prefix "${sanitized_dir}" start`)


### PR DESCRIPTION
# Sanitizing input for shelljs

closes #600 

## Description

- cli.js can now execute codecharta from within a folder that contains blanks and $ signs.
- quotation marks are removed from the path, which aims at avoiding arbitrary code execution. however this also means that quotation marks are still (as before) not supported within the installation dir of codeCharta.

![shelljs_bash](https://user-images.githubusercontent.com/20796577/66409753-42e1df80-e9f1-11e9-9acf-ce0822859bb3.JPG)
![shelljs_win](https://user-images.githubusercontent.com/20796577/66409754-42e1df80-e9f1-11e9-9842-9647474840fc.JPG)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
