### PR TITLE
Debounce for colorRange Inputs #676

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Inputs of Color Range Slider now waits a second before it commits its values #676
 - Fixed root folder name in TreeView after new map after loading new map #649
 - Increased size of ribbonBar for big screens #644
 - Sanitize input for shelljs #600

--- a/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.html
+++ b/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.html
@@ -6,6 +6,7 @@
 		min="0"
 		step="1"
 		ng-change="$ctrl._viewModel.sliderOptions.onFromChange()"
+		ng-model-options="{debounce: 1000}"
 	/>
 </md-input-container>
 
@@ -26,5 +27,6 @@
 		min="0"
 		step="1"
 		ng-change="$ctrl._viewModel.sliderOptions.onToChange()"
+		ng-model-options="{debounce: 1000}"
 	/>
 </md-input-container>


### PR DESCRIPTION
# Debounce for colorRange Inputs

closes #676

## Description

The inputs of the Color Range Slider now waits one Second before the value is comitted. 


![color_reset_debounce](https://user-images.githubusercontent.com/50145538/66753130-61355880-ee93-11e9-864c-9143a36c3b91.gif)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
