### PR TITLE
Feature/607/move path panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Changed
 
 - Animation to show or hide the legend panel #527
+- Moved nodePathPanel to toolBar and updated style #607
 
 ### Removed
 

--- a/visualization/app/codeCharta/codeCharta.component.html
+++ b/visualization/app/codeCharta/codeCharta.component.html
@@ -20,8 +20,6 @@
 
 <legend-panel-component></legend-panel-component>
 
-<node-path-panel-component></node-path-panel-component>
-
 <loading-gif-file-component></loading-gif-file-component>
 
 <div id="mw-logo">

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,3 +1,9 @@
 <div id="node-path">
-	{{ $ctrl._viewModel.hoveredNodePath }}
+	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath track by $index">
+		<span role="img" class="fa fa-folder"></span>
+		{{ folder }} >
+	</span>
+
+	<span role="img" class="fa fa-file-o"></span>
+	{{ $ctrl._viewModel.hoveredNodeName }}
 </div>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -4,6 +4,7 @@
 		{{ folder }} >
 	</span>
 
-	<span role="img" class="fa fa-file-o"></span>
+	<span role="img" class="fa fa-file-o" ng-if="$ctrl._viewModel.hoveredNodeIsFile"></span>
+	<span role="img" class="fa fa-folder" ng-if="!$ctrl._viewModel.hoveredNodeIsFile"></span>
 	{{ $ctrl._viewModel.hoveredNodeName }}
 </div>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,10 +1,7 @@
 <div id="node-path">
-	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath track by $index">
-		<span role="img" class="fa fa-folder"></span>
-		{{ folder }} >
-	</span>
+	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath"> {{ folder }} > </span>
 
 	<span role="img" class="fa fa-file-o" ng-if="$ctrl._viewModel.hoveredNodeIsFile"></span>
 	<span role="img" class="fa fa-folder" ng-if="!$ctrl._viewModel.hoveredNodeIsFile"></span>
-	{{ $ctrl._viewModel.hoveredNodeName }}
+	<span class="hovered-node-name">{{ $ctrl._viewModel.hoveredNodeName }}</span>
 </div>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,5 +1,5 @@
 <div id="node-path">
-	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath"> {{ folder }} > </span>
+	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath"> {{ folder }} <i class="fa fa-angle-right"></i> </span>
 
 	<span role="img" class="fa fa-file-o" ng-if="$ctrl._viewModel.hoveredNodeIsFile"></span>
 	<span role="img" class="fa fa-folder" ng-if="!$ctrl._viewModel.hoveredNodeIsFile"></span>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,3 +1,3 @@
-<div id="node-path" class="cc-shadow" ng-show="$ctrl._viewModel.hoveredNodePath">
+<div id="node-path">
 	{{ $ctrl._viewModel.hoveredNodePath }}
 </div>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,5 +1,5 @@
 <div id="node-path">
-	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath"> {{ folder }} <i class="fa fa-angle-right"></i> </span>
+	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath track by $index"> {{ folder }} <i class="fa fa-angle-right"></i> </span>
 
 	<span role="img" class="fa fa-file-o" ng-if="$ctrl._viewModel.hoveredNodeIsFile"></span>
 	<span role="img" class="fa fa-folder" ng-if="!$ctrl._viewModel.hoveredNodeIsFile"></span>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.html
@@ -1,7 +1,8 @@
 <div id="node-path">
-	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath track by $index"> {{ folder }} <i class="fa fa-angle-right"></i> </span>
-
-	<span role="img" class="fa fa-file-o" ng-if="$ctrl._viewModel.hoveredNodeIsFile"></span>
-	<span role="img" class="fa fa-folder" ng-if="!$ctrl._viewModel.hoveredNodeIsFile"></span>
-	<span class="hovered-node-name">{{ $ctrl._viewModel.hoveredNodeName }}</span>
+	<span ng-repeat="folder in $ctrl._viewModel.hoveredNodePath track by $index">
+		<i role="img" class="fa fa-file-o" ng-if="$last && $ctrl._viewModel.hoveredNodeIsFile"></i>
+		<i role="img" class="fa fa-folder" ng-if="$last && !$ctrl._viewModel.hoveredNodeIsFile"></i>
+		<span ng-class="{bold: $last}">{{ folder }}</span>
+		<i ng-if="!$last" class="fa fa-angle-right"></i>
+	</span>
 </div>

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
@@ -1,13 +1,9 @@
 node-path-panel-component {
 	#node-path {
-		margin-top: 10px;
-		margin-left: 10px;
+		margin: 10px;
 		font-weight: bold;
 		float: left;
-		vertical-align: middle;
 		font-size: 10pt;
-		max-width: calc(100% - 150px);
-		-ms-word-break: break-all;
-		word-break: break-all;
+		max-width: calc(100% - 250px);
 	}
 }

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
@@ -1,15 +1,12 @@
 node-path-panel-component {
 	#node-path {
-		position: fixed;
-		z-index: 40;
-		bottom: 0.5em;
-		left: 0.5em;
-		background-color: #fff;
-		color: #5a585a;
-		font-size: 10pt;
+		margin-top: 10px;
+		margin-left: 10px;
 		font-weight: bold;
-		padding: 4px;
-		max-width: 60%;
+		float: left;
+		vertical-align: middle;
+		font-size: 10pt;
+		max-width: calc(100% - 150px);
 		-ms-word-break: break-all;
 		word-break: break-all;
 	}

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
@@ -9,7 +9,7 @@ node-path-panel-component {
 		white-space: nowrap;
 	}
 
-	.hovered-node-name {
+	.bold {
 		font-weight: 600;
 	}
 }

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
@@ -1,9 +1,12 @@
 node-path-panel-component {
 	#node-path {
-		margin: 10px;
-		font-weight: bold;
+		margin: 10px 10px 0 10px;
 		float: left;
 		font-size: 10pt;
 		max-width: calc(100% - 250px);
+	}
+
+	.hovered-node-name {
+		font-weight: 600;
 	}
 }

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.scss
@@ -4,6 +4,9 @@ node-path-panel-component {
 		float: left;
 		font-size: 10pt;
 		max-width: calc(100% - 250px);
+		direction: rtl;
+		overflow: hidden;
+		white-space: nowrap;
 	}
 
 	.hovered-node-name {

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
@@ -34,28 +34,25 @@ describe("NodePathPanelController", () => {
 	})
 
 	describe("onBuildingHovered", () => {
-		it("should update the viewModel when hovering", () => {
-			const dataHovered = {
-				to: {
-					node: {
-						path: "/root/my/path"
-					}
+		const dataHovered = {
+			to: {
+				node: {
+					path: "/root/my/path"
 				}
-			} as CodeMapBuildingTransition
+			}
+		} as CodeMapBuildingTransition
 
+		it("should update the hoveredNodeName when hovering", () => {
 			nodePathPanelController.onBuildingHovered(dataHovered)
 
-			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual("/root/my/path")
+			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my"])
+			expect(nodePathPanelController["_viewModel"].hoveredNodeName).toEqual("path")
 		})
 
-		it("should update the viewModel when unhovering", () => {
-			const dataUnhovered = {
-				to: {}
-			} as CodeMapBuildingTransition
+		it("should update the hoveredNodePath when hovering", () => {
+			nodePathPanelController.onBuildingHovered(dataHovered)
 
-			nodePathPanelController.onBuildingHovered(dataUnhovered)
-
-			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(null)
+			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my"])
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
@@ -43,16 +43,10 @@ describe("NodePathPanelController", () => {
 			}
 		} as CodeMapBuildingTransition
 
-		it("should update the hoveredNodeName when hovering", () => {
-			nodePathPanelController.onBuildingHovered(dataHovered)
-
-			expect(nodePathPanelController["_viewModel"].hoveredNodeName).toEqual("path")
-		})
-
 		it("should update the hoveredNodePath when hovering", () => {
 			nodePathPanelController.onBuildingHovered(dataHovered)
 
-			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my"])
+			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my", "path"])
 		})
 
 		it("should update the hoveredNodeIsFile when hovering", () => {

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.spec.ts
@@ -37,7 +37,8 @@ describe("NodePathPanelController", () => {
 		const dataHovered = {
 			to: {
 				node: {
-					path: "/root/my/path"
+					path: "/root/my/path",
+					isLeaf: true
 				}
 			}
 		} as CodeMapBuildingTransition
@@ -45,7 +46,6 @@ describe("NodePathPanelController", () => {
 		it("should update the hoveredNodeName when hovering", () => {
 			nodePathPanelController.onBuildingHovered(dataHovered)
 
-			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my"])
 			expect(nodePathPanelController["_viewModel"].hoveredNodeName).toEqual("path")
 		})
 
@@ -53,6 +53,12 @@ describe("NodePathPanelController", () => {
 			nodePathPanelController.onBuildingHovered(dataHovered)
 
 			expect(nodePathPanelController["_viewModel"].hoveredNodePath).toEqual(["root", "my"])
+		})
+
+		it("should update the hoveredNodeIsFile when hovering", () => {
+			nodePathPanelController.onBuildingHovered(dataHovered)
+
+			expect(nodePathPanelController["_viewModel"].hoveredNodeIsFile).toEqual(true)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
@@ -8,9 +8,11 @@ export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 	private _viewModel: {
 		hoveredNodePath: string[]
 		hoveredNodeName: string
+		hoveredNodeIsFile: boolean
 	} = {
 		hoveredNodePath: [],
-		hoveredNodeName: null
+		hoveredNodeName: null,
+		hoveredNodeIsFile: null
 	}
 
 	/* @ngInject */
@@ -22,6 +24,7 @@ export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 	public onBuildingHovered(data: CodeMapBuildingTransition) {
 		if (data.to && data.to.node) {
 			this.updatePathAndName(data.to.node.path)
+			this._viewModel.hoveredNodeIsFile = data.to.node.isLeaf
 		}
 	}
 

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
@@ -7,11 +7,9 @@ import { SettingsService } from "../../state/settingsService/settings.service"
 export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 	private _viewModel: {
 		hoveredNodePath: string[]
-		hoveredNodeName: string
 		hoveredNodeIsFile: boolean
 	} = {
 		hoveredNodePath: [],
-		hoveredNodeName: null,
 		hoveredNodeIsFile: null
 	}
 
@@ -23,15 +21,9 @@ export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 
 	public onBuildingHovered(data: CodeMapBuildingTransition) {
 		if (data.to && data.to.node) {
-			this.updatePathAndName(data.to.node.path)
+			this._viewModel.hoveredNodePath = data.to.node.path.substr(1).split("/")
 			this._viewModel.hoveredNodeIsFile = data.to.node.isLeaf
 		}
-	}
-
-	private updatePathAndName(path: string) {
-		const pathComponents = path.substr(1).split("/")
-		this._viewModel.hoveredNodeName = pathComponents.pop()
-		this._viewModel.hoveredNodePath = pathComponents
 	}
 
 	public onBlacklistChanged(blacklist: BlacklistItem[]) {

--- a/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
+++ b/visualization/app/codeCharta/ui/nodePathPanel/nodePathPanel.component.ts
@@ -6,9 +6,11 @@ import { SettingsService } from "../../state/settingsService/settings.service"
 
 export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 	private _viewModel: {
-		hoveredNodePath: string
+		hoveredNodePath: string[]
+		hoveredNodeName: string
 	} = {
-		hoveredNodePath: null
+		hoveredNodePath: [],
+		hoveredNodeName: null
 	}
 
 	/* @ngInject */
@@ -19,10 +21,14 @@ export class NodePathPanelController implements BuildingHoveredEventSubscriber {
 
 	public onBuildingHovered(data: CodeMapBuildingTransition) {
 		if (data.to && data.to.node) {
-			this._viewModel.hoveredNodePath = data.to.node.path
-		} else {
-			this._viewModel.hoveredNodePath = null
+			this.updatePathAndName(data.to.node.path)
 		}
+	}
+
+	private updatePathAndName(path: string) {
+		const pathComponents = path.substr(1).split("/")
+		this._viewModel.hoveredNodeName = pathComponents.pop()
+		this._viewModel.hoveredNodePath = pathComponents
 	}
 
 	public onBlacklistChanged(blacklist: BlacklistItem[]) {

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
@@ -9,8 +9,8 @@
 		</md-button>
 	</div>
 
-	<file-panel-component ng-if="!$ctrl._viewModel.nodeHovered"></file-panel-component>
-	<node-path-panel-component ng-if="$ctrl._viewModel.nodeHovered"></node-path-panel-component>
+	<file-panel-component ng-show="!$ctrl._viewModel.nodeHovered"></file-panel-component>
+	<node-path-panel-component ng-show="$ctrl._viewModel.nodeHovered"></node-path-panel-component>
 
 	<div class="right-aligned">
 		<presentation-mode-button-component></presentation-mode-button-component>

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
@@ -9,8 +9,8 @@
 		</md-button>
 	</div>
 
-	<file-panel-component ng-show="!$ctrl._viewModel.nodeHovered"></file-panel-component>
-	<node-path-panel-component ng-show="$ctrl._viewModel.nodeHovered"></node-path-panel-component>
+	<file-panel-component ng-class="{ hidden: $ctrl._viewModel.nodeHovered }"></file-panel-component>
+	<node-path-panel-component ng-class="{ hidden: !$ctrl._viewModel.nodeHovered }"></node-path-panel-component>
 
 	<div class="right-aligned">
 		<presentation-mode-button-component></presentation-mode-button-component>

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.html
@@ -9,7 +9,8 @@
 		</md-button>
 	</div>
 
-	<file-panel-component></file-panel-component>
+	<file-panel-component ng-if="!$ctrl._viewModel.nodeHovered"></file-panel-component>
+	<node-path-panel-component ng-if="$ctrl._viewModel.nodeHovered"></node-path-panel-component>
 
 	<div class="right-aligned">
 		<presentation-mode-button-component></presentation-mode-button-component>

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -1,7 +1,7 @@
 tool-bar-component {
 	.tool-bar {
 		background-color: #f0f0f0;
-		min-height: 35px;
+		min-height: 40px;
 		overflow: auto;
 		margin-block-end: 0;
 		padding-bottom: 0;

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -1,12 +1,20 @@
 tool-bar-component {
 	.tool-bar {
 		background-color: #f0f0f0;
-		overflow: auto;
+		overflow: hidden;
 		margin-block-end: 0;
 		padding-bottom: 0;
 		margin-bottom: 0;
 		font-size: 0px;
 		border-bottom: 1px solid #cdcdcd;
+	}
+
+	file-panel-component.hidden {
+		display: none;
+	}
+
+	node-path-panel-component.hidden {
+		display: none;
 	}
 
 	.small-action-button {

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -9,12 +9,11 @@ tool-bar-component {
 		border-bottom: 1px solid #cdcdcd;
 	}
 
-	file-panel-component.hidden {
-		display: none;
-	}
-
-	node-path-panel-component.hidden {
-		display: none;
+	file-panel-component,
+	node-path-panel-component {
+		&.hidden {
+			display: none;
+		}
 	}
 
 	.small-action-button {

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -1,7 +1,6 @@
 tool-bar-component {
 	.tool-bar {
 		background-color: #f0f0f0;
-		min-height: 40px;
 		overflow: auto;
 		margin-block-end: 0;
 		padding-bottom: 0;

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -1,7 +1,8 @@
 tool-bar-component {
 	.tool-bar {
 		background-color: #f0f0f0;
-		height: 35px;
+		min-height: 35px;
+		overflow: auto;
 		margin-block-end: 0;
 		padding-bottom: 0;
 		margin-bottom: 0;

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.scss
@@ -1,10 +1,7 @@
 tool-bar-component {
 	.tool-bar {
 		background-color: #f0f0f0;
-		overflow: hidden;
-		margin-block-end: 0;
-		padding-bottom: 0;
-		margin-bottom: 0;
+		height: 35px;
 		font-size: 0px;
 		border-bottom: 1px solid #cdcdcd;
 	}

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.spec.ts
@@ -3,7 +3,7 @@ import { ToolBarController } from "./toolBar.component"
 import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
 import { DialogService } from "../dialog/dialog.service"
 import { IRootScopeService } from "angular"
-import { CodeMapBuildingTransition } from "../codeMap/codeMap.mouseEvent.service"
+import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 
 describe("ToolBarController", () => {
 	let $rootScope: IRootScopeService
@@ -52,17 +52,17 @@ describe("ToolBarController", () => {
 
 	describe("onBuildingHovered", () => {
 		it("should set nodeHovered to true if node is hovered", () => {
-			const dataHovered = ({ to: { node: {} } } as unknown) as CodeMapBuildingTransition
+			const dataHovered = ({ node: {} } as unknown) as CodeMapBuilding
 
 			toolBarController.onBuildingHovered(dataHovered)
 
 			expect(toolBarController["_viewModel"].nodeHovered).toBe(true)
 		})
+	})
 
+	describe("onBuildingUnhovered", () => {
 		it("should set nodeHovered to false if no node is hovered", () => {
-			const dataHovered = ({ to: null } as unknown) as CodeMapBuildingTransition
-
-			toolBarController.onBuildingHovered(dataHovered)
+			toolBarController.onBuildingUnhovered()
 
 			expect(toolBarController["_viewModel"].nodeHovered).toBe(false)
 		})

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.spec.ts
@@ -2,8 +2,11 @@ import "./toolBar.module"
 import { ToolBarController } from "./toolBar.component"
 import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
 import { DialogService } from "../dialog/dialog.service"
+import { IRootScopeService } from "angular"
+import { CodeMapBuildingTransition } from "../codeMap/codeMap.mouseEvent.service"
 
 describe("ToolBarController", () => {
+	let $rootScope: IRootScopeService
 	let toolBarController: ToolBarController
 	let dialogService: DialogService
 
@@ -16,11 +19,12 @@ describe("ToolBarController", () => {
 	function restartSystem() {
 		instantiateModule("app.codeCharta.ui.toolBar")
 
+		$rootScope = getService<IRootScopeService>("$rootScope")
 		dialogService = getService<DialogService>("dialogService")
 	}
 
 	function rebuildController() {
-		toolBarController = new ToolBarController(dialogService)
+		toolBarController = new ToolBarController($rootScope, dialogService)
 	}
 
 	function withMockedDialogService() {
@@ -43,6 +47,24 @@ describe("ToolBarController", () => {
 			toolBarController.showGlobalSettings()
 
 			expect(dialogService.showGlobalSettingsDialog).toHaveBeenCalled()
+		})
+	})
+
+	describe("onBuildingHovered", () => {
+		it("should set nodeHovered to true if node is hovered", () => {
+			const dataHovered = ({ to: { node: {} } } as unknown) as CodeMapBuildingTransition
+
+			toolBarController.onBuildingHovered(dataHovered)
+
+			expect(toolBarController["_viewModel"].nodeHovered).toBe(true)
+		})
+
+		it("should set nodeHovered to false if no node is hovered", () => {
+			const dataHovered = ({ to: null } as unknown) as CodeMapBuildingTransition
+
+			toolBarController.onBuildingHovered(dataHovered)
+
+			expect(toolBarController["_viewModel"].nodeHovered).toBe(false)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
@@ -4,7 +4,7 @@ import { BuildingHoveredEventSubscriber, CodeMapMouseEventService, CodeMapBuildi
 import { IRootScopeService } from "angular"
 
 export class ToolBarController implements BuildingHoveredEventSubscriber {
-	_viewModel: {
+	private _viewModel: {
 		nodeHovered: boolean
 	} = {
 		nodeHovered: null

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
@@ -1,9 +1,10 @@
 import "./toolBar.component.scss"
 import { DialogService } from "../dialog/dialog.service"
-import { BuildingHoveredEventSubscriber, CodeMapMouseEventService, CodeMapBuildingTransition } from "../codeMap/codeMap.mouseEvent.service"
+import { CodeMapMouseEventService, BuildingUnhoveredSubscriber, BuildingHoveredSubscriber } from "../codeMap/codeMap.mouseEvent.service"
 import { IRootScopeService } from "angular"
+import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 
-export class ToolBarController implements BuildingHoveredEventSubscriber {
+export class ToolBarController implements BuildingHoveredSubscriber, BuildingUnhoveredSubscriber {
 	private _viewModel: {
 		nodeHovered: boolean
 	} = {
@@ -12,7 +13,8 @@ export class ToolBarController implements BuildingHoveredEventSubscriber {
 
 	/* @ngInject */
 	constructor(private $rootScope: IRootScopeService, private dialogService: DialogService) {
-		CodeMapMouseEventService.subscribeToBuildingHoveredEvents(this.$rootScope, this)
+		CodeMapMouseEventService.subscribeToBuildingHovered(this.$rootScope, this)
+		CodeMapMouseEventService.subscribeToBuildingUnhovered(this.$rootScope, this)
 	}
 
 	public downloadFile() {
@@ -23,12 +25,12 @@ export class ToolBarController implements BuildingHoveredEventSubscriber {
 		this.dialogService.showGlobalSettingsDialog()
 	}
 
-	public onBuildingHovered(data: CodeMapBuildingTransition) {
-		if (data.to && data.to.node) {
-			this._viewModel.nodeHovered = true
-		} else {
-			this._viewModel.nodeHovered = false
-		}
+	public onBuildingHovered(data: CodeMapBuilding) {
+		this._viewModel.nodeHovered = true
+	}
+
+	public onBuildingUnhovered() {
+		this._viewModel.nodeHovered = false
 	}
 }
 

--- a/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
+++ b/visualization/app/codeCharta/ui/toolBar/toolBar.component.ts
@@ -1,9 +1,19 @@
 import "./toolBar.component.scss"
 import { DialogService } from "../dialog/dialog.service"
+import { BuildingHoveredEventSubscriber, CodeMapMouseEventService, CodeMapBuildingTransition } from "../codeMap/codeMap.mouseEvent.service"
+import { IRootScopeService } from "angular"
 
-export class ToolBarController {
+export class ToolBarController implements BuildingHoveredEventSubscriber {
+	_viewModel: {
+		nodeHovered: boolean
+	} = {
+		nodeHovered: null
+	}
+
 	/* @ngInject */
-	constructor(private dialogService: DialogService) {}
+	constructor(private $rootScope: IRootScopeService, private dialogService: DialogService) {
+		CodeMapMouseEventService.subscribeToBuildingHoveredEvents(this.$rootScope, this)
+	}
 
 	public downloadFile() {
 		this.dialogService.showDownloadDialog()
@@ -11,6 +21,14 @@ export class ToolBarController {
 
 	public showGlobalSettings() {
 		this.dialogService.showGlobalSettingsDialog()
+	}
+
+	public onBuildingHovered(data: CodeMapBuildingTransition) {
+		if (data.to && data.to.node) {
+			this._viewModel.nodeHovered = true
+		} else {
+			this._viewModel.nodeHovered = false
+		}
 	}
 }
 


### PR DESCRIPTION
# Move Path Panel to ToolBar

Depends on #735 which needs to be merged first
closes #607

## Description

- Show File Path when file is hovered, and file panel if nothing is hovered.
- Move File Path to ToolBar
- Use folder/file icon for hovered node

![cc_file_path](https://user-images.githubusercontent.com/20796577/67471416-ae61b900-f64f-11e9-9c84-50293b9a6a2b.gif)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
