### PR TITLE
Bug/775/sum symbol shows for leafs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+- Sum symbol for hovered metric values only shows for folders #775
+
 ### Chore
 
 ## [1.38.0] - 2019-11-08

--- a/visualization/app/codeCharta/ui/metricType/metricType.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricType/metricType.component.spec.ts
@@ -191,6 +191,18 @@ describe("MetricTypeController", () => {
 
 			expect(metricTypeController["_viewModel"].isBuildingHovered).toBeTruthy()
 		})
+
+		it("should set isBuildingHovered to false when going from a folder to leaf", () => {
+			metricTypeController.onBuildingHovered({
+				node: { isLeaf: false }
+			} as CodeMapBuilding)
+
+			metricTypeController.onBuildingHovered({
+				node: { isLeaf: true }
+			} as CodeMapBuilding)
+
+			expect(metricTypeController["_viewModel"].isBuildingHovered).toBeFalsy()
+		})
 	})
 
 	describe("onBuildingUnhovered", () => {

--- a/visualization/app/codeCharta/ui/metricType/metricType.component.ts
+++ b/visualization/app/codeCharta/ui/metricType/metricType.component.ts
@@ -43,9 +43,7 @@ export class MetricTypeController
 	}
 
 	public onBuildingHovered(hoveredBuilding: CodeMapBuilding) {
-		if (hoveredBuilding.node && !hoveredBuilding.node.isLeaf) {
-			this._viewModel.isBuildingHovered = true
-		}
+		this._viewModel.isBuildingHovered = hoveredBuilding.node && !hoveredBuilding.node.isLeaf
 	}
 
 	public onBuildingUnhovered() {


### PR DESCRIPTION
# Bug/775/sum symbol shows for leafs

closes #775 

## Description

- Sum symbol for hovered metric values only shows for folders #775 

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail