### PR TITLE
Fixed: Focus of UI elements not removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Remove focus of UI elements when they are not visible anymore
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.41.0] - 2019-12-06

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -160,6 +160,7 @@ export class CodeMapMouseEventService
 	}
 
 	public onDocumentMouseDown(event) {
+		$(document.activeElement).blur()
 		if (event.button === 0) {
 			this.onLeftClick()
 		} else if (event.button === 2) {

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.ts
@@ -6,6 +6,7 @@ export class RibbonBarController {
 
 	public toggle(event) {
 		const boxElement = $(event.srcElement).closest("md-card")
+		$(document.activeElement).blur()
 
 		if (boxElement.hasClass(this.EXPANDED_CLASS)) {
 			boxElement.removeClass(this.EXPANDED_CLASS)

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
@@ -37,6 +37,19 @@ describe("RibbonBar", () => {
 		expect(actual).toContain("600")
 	})
 
+	it("focus of ui element should be removed on ribbonBar toggle", async () => {
+		const panel = "color-metric"
+		await ribbonBar.togglePanel(panel)
+		await ribbonBar.focusSomething()
+		const activeBefore = await ribbonBar.getActiveClassName()
+
+		await ribbonBar.togglePanel(panel)
+
+		const activeAfter = await ribbonBar.getActiveClassName()
+		expect(activeBefore).not.toBe("ng-scope")
+		expect(activeAfter).toBe("ng-scope")
+	})
+
 	describe("opening and closing ribbon-bar cards", () => {
 		it("searchPanel", async () => {
 			expect(await searchPanel.isOpen()).toBeFalsy()

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.po.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.po.ts
@@ -19,4 +19,15 @@ export class RibbonBarPageObject {
 	public async getAreaMetricValue(): Promise<number> {
 		return await this.page.$eval("area-metric-chooser-component .metric-value", el => el["innerText"])
 	}
+
+	public async focusSomething(): Promise<void> {
+		await this.page.evaluate(() => {
+			const element = <HTMLElement>document.getElementsByClassName("md-ink-ripple")[0]
+			element.focus()
+		})
+	}
+
+	public async getActiveClassName(): Promise<string> {
+		return this.page.evaluate(() => document.activeElement.className)
+	}
 }


### PR DESCRIPTION
# Remove focus of UI Elements

## What is this PR fixing

Sometimes CodeCharta retains the focus on some unexpected UI elements, for example

1. Change the AreaMetric by selecting a metric from the dropdown list
2. Click on the CodeMap area (to close the dropdown)
3. Now use the up/down arrow keys

Now the dropdown of AreaMetric dropdown will open again and prevent the user from using the arrow keys in the codemap area. The same issue can also occur to other controls. Fruthermore removing the focus on toggle of the Ribbon bar prevents the app from looking like in the screenshot below, when pressing tab once, in the closed state.

![grafik](https://user-images.githubusercontent.com/20796577/71348788-9d5cf780-256d-11ea-8341-d12e7e03653e.png)



## Description

- Unfocus UI elements on toggle of the Ribbon bar
- Unfocus UI elements on click of the CodeMap

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
