### PR TITLE
Bug/768/other categorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Calculation of other Group for fileExtensionBar #768
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.41.0] - 2019-12-06

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
@@ -16,7 +16,7 @@
 				ng-mouseleave="$ctrl.clearHighlightedBarHoveredBuildings()"
 				title="{{ item.relativeMetricValue.toFixed(2) }}%"
 			>
-				<span ng-if="item.relativeMetricValue > 2">
+				<span ng-if="item.relativeMetricValue >= item.fileExtension.length/2+1">
 					{{ item.fileExtension }}
 				</span>
 			</p>

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
@@ -16,7 +16,9 @@
 				ng-mouseleave="$ctrl.clearHighlightedBarHoveredBuildings()"
 				title="{{ item.relativeMetricValue.toFixed(2) }}%"
 			>
-				{{ item.fileExtension }}
+				<span ng-if="item.relativeMetricValue > 2">
+					{{ item.fileExtension }}
+				</span>
 			</p>
 		</div>
 	</div>

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
@@ -97,10 +97,10 @@ describe("FileExtensionCalculator", () => {
 				{ fileExtension: "jpg", absoluteMetricValue: 130, relativeMetricValue: 34.48275862068966, color: null },
 				{ fileExtension: "json", absoluteMetricValue: 70, relativeMetricValue: 18.56763925729443, color: null },
 				{
-					fileExtension: "other",
+					fileExtension: "None",
 					absoluteMetricValue: 15,
 					relativeMetricValue: 3.978779840848806,
-					color: "#676867"
+					color: null
 				}
 			]
 

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
@@ -157,7 +157,7 @@ describe("FileExtensionCalculator", () => {
 				}
 			]
 			map.children.push(...additionalChildren)
-			FileExtensionCalculator["OTHER_GROUP_THRESHOLD_VALUE"] = 95
+			FileExtensionCalculator["OTHER_GROUP_THRESHOLD_VALUE"] = 2.0
 
 			const result: MetricDistribution[] = FileExtensionCalculator.getMetricDistribution(map, "rloc", [])
 

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.ts
@@ -14,7 +14,7 @@ export interface MetricDistribution {
 export class FileExtensionCalculator {
 	private static readonly NO_EXTENSION = "None"
 	private static readonly OTHER_EXTENSION = "other"
-	private static OTHER_GROUP_THRESHOLD_VALUE = 5.0
+	private static OTHER_GROUP_THRESHOLD_VALUE = 3.0
 
 	public static getMetricDistribution(map: CodeMapNode, metric: string, blacklist: BlacklistItem[]): MetricDistribution[] {
 		let distribution: MetricDistribution[] = this.getAbsoluteDistribution(map, metric, blacklist)

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.ts
@@ -14,7 +14,7 @@ export interface MetricDistribution {
 export class FileExtensionCalculator {
 	private static readonly NO_EXTENSION = "None"
 	private static readonly OTHER_EXTENSION = "other"
-	private static OTHER_GROUP_THRESHOLD_VALUE = 90
+	private static OTHER_GROUP_THRESHOLD_VALUE = 5.0
 
 	public static getMetricDistribution(map: CodeMapNode, metric: string, blacklist: BlacklistItem[]): MetricDistribution[] {
 		let distribution: MetricDistribution[] = this.getAbsoluteDistribution(map, metric, blacklist)
@@ -60,14 +60,12 @@ export class FileExtensionCalculator {
 	}
 
 	private static getMetricDistributionWithOthers(distribution: MetricDistribution[]): MetricDistribution[] {
-		let cummulativeRelativeSum: number = 0
 		let otherExtension: MetricDistribution = this.getOtherExtension()
 		let visibleDistributions: MetricDistribution[] = []
 
 		distribution.forEach((x: MetricDistribution) => {
-			if (cummulativeRelativeSum < FileExtensionCalculator.OTHER_GROUP_THRESHOLD_VALUE) {
+			if (x.relativeMetricValue > FileExtensionCalculator.OTHER_GROUP_THRESHOLD_VALUE) {
 				visibleDistributions.push(x)
-				cummulativeRelativeSum += x.relativeMetricValue
 			} else {
 				otherExtension.absoluteMetricValue += x.absoluteMetricValue
 				otherExtension.relativeMetricValue += x.relativeMetricValue


### PR DESCRIPTION
# Bug/768/other categorization

closes #768

## Description

- Other categorization is now based on the proportion of the respective languages (<3%) instead of just summarizing the last 10% of the total project. This avoids two issues:

1. Having one single language "summarized" as other (i.e. in a project with 92% C++ and 8% XML, previous to this bugfix the XML would have been shown as "other")
2. Very small fragmented bars, like the screenshot in the issue shows. The same project now gets a reasonable bar;

{Descriptive pull request text}
![grafik](https://user-images.githubusercontent.com/20796577/71847029-42c6ae00-30cc-11ea-9184-e4233f9dc945.png)

- Additionally long File Extensions are not shown in the bar, if there is not enough space. The names can be seen by clicking on the bar (i.e. expanding it)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
