### PR TITLE
Feature/773/remove project name

### DIFF
--- a/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/CSVExporter.kt
+++ b/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/CSVExporter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.exporter.csv
 
 import com.univocity.parsers.csv.CsvWriter
@@ -42,7 +13,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "csvexport",
         description = ["generates csv file with header"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class CSVExporter: Callable<Void> {
 

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeFilter.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeFilter.kt
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "edgefilter",
         description = ["aggregtes edgeAttributes as nodeAttributes into a new cc.json file"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class EdgeFilter: Callable<Void?> {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeProjectBuilder.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeProjectBuilder.kt
@@ -37,7 +37,6 @@ class EdgeProjectBuilder(private val project: Project, private val pathSeparator
     private val logger = KotlinLogging.logger {}
 
     private val projectBuilder = ProjectBuilder(
-            getProjectName(),
             listOf(MutableNode("root", NodeType.Folder)),
             mutableListOf(),
             getAttributeTypes())
@@ -48,10 +47,6 @@ class EdgeProjectBuilder(private val project: Project, private val pathSeparator
             newAttributetypes[it.key] = it.value.toMutableList()
         }
         return newAttributetypes
-    }
-
-    fun getProjectName(): String {
-        return project.projectName
     }
 
     fun merge(): Project {

--- a/analysis/filter/MergeFilter/README.md
+++ b/analysis/filter/MergeFilter/README.md
@@ -4,26 +4,27 @@ Reads the specified files, merges visualisation data and prints to stdout.
 
 ## Usage
 
- > `ccsh merge <reference json file> <json files>`
- or
- > `ccsh merge <folder> `
+> `ccsh merge <reference json file> <json files>`
+> or
+> `ccsh merge <folder>`
 
-The first file with visualisation data is used as reference for the merging strategy. 
-In case of different ProjectNames the first ProjectName is used. The visualisation data in the additional
+The first file with visualisation data is used as reference for the merging strategy.
+The visualisation data in the additional
 json files, given they have the same API version, are fitted into this reference structure according to a
 specific strategy. Currently there are two main strategies:
+
 - recursive (`--recursive`) (default): leave structure of additional files. This will also merge optional edges.
-- leaf (`--leaf`) (beta):  fit leaf nodes into reference structure according to their name (and tail of their path), 
-either adding missing leaves (`--add-missing`) or ignoring them (default)
+- leaf (`--leaf`) (beta): fit leaf nodes into reference structure according to their name (and tail of their path),
+  either adding missing leaves (`--add-missing`) or ignoring them (default)
 
 If files with different project names shoud be merged, a new project name must be specified with -p.
 
 Both strategies will merge the unique list entries for `attributeTypes` and `blacklist`. When invoked with `-h` or `--help` MergeFilter prints its usage.
 
- ### Examples
- 
- > `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json`
+### Examples
 
- > `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json --leaf --add-missing`
+> `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json`
 
- > `ccsh merge file1.cc.json ../foo/ -o=test.cc.json -p=NewProjectName` (Merges all project files in foo with the reference file)
+> `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json --leaf --add-missing`
+
+> `ccsh merge file1.cc.json ../foo/ -o=test.cc.json` (Merges all project files in foo with the reference file)

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/LeafNodeMergerStrategy.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/LeafNodeMergerStrategy.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.filter.mergefilter
 
 import de.maibornwolff.codecharta.model.MutableNode

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeException.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeException.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.filter.mergefilter
 
 class MergeException(s: String): RuntimeException(s)

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.filter.mergefilter
 
 import de.maibornwolff.codecharta.model.Project
@@ -39,7 +10,7 @@ import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "merge",
         description = ["merges multiple cc.json files"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class MergeFilter: Callable<Void?> {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
@@ -59,9 +30,6 @@ class MergeFilter: Callable<Void?> {
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
-
-    @CommandLine.Option(names = ["-p", "--project-name"], description = ["Specify project name for merged file"])
-    private var projectName: String? = null
 
     @CommandLine.Option(names = ["--ignore-case"], description = ["ignores case when checking node names"])
     private var ignoreCase = false
@@ -93,7 +61,7 @@ class MergeFilter: Callable<Void?> {
                     }
                 }
 
-        val mergedProject = ProjectMerger(srcProjects, nodeMergerStrategy, projectName).merge()
+        val mergedProject = ProjectMerger(srcProjects, nodeMergerStrategy).merge()
 
         val writer = outputFile?.bufferedWriter() ?: System.out.bufferedWriter()
         ProjectSerializer.serializeProject(mergedProject, writer)
@@ -112,12 +80,10 @@ class MergeFilter: Callable<Void?> {
             CommandLine.call(MergeFilter(), System.out, *args)
         }
 
-        fun mergePipedWithCurrentProject(pipedProject: Project, currentProject: Project, projectName: String?): Project {
+        fun mergePipedWithCurrentProject(pipedProject: Project, currentProject: Project): Project {
             return ProjectMerger(
                     listOf(pipedProject, currentProject),
-                    RecursiveNodeMergerStrategy(false),
-                    projectName ?: pipedProject.projectName
-            ).merge()
+                    RecursiveNodeMergerStrategy(false)).merge()
         }
     }
 }

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMerger.kt
@@ -1,57 +1,15 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.filter.mergefilter
 
 import de.maibornwolff.codecharta.model.*
 import mu.KotlinLogging
 
-class ProjectMerger(private val projects: List<Project>, private val nodeMerger: NodeMergerStrategy,
-                    private val projectName: String? = null) {
+class ProjectMerger(private val projects: List<Project>, private val nodeMerger: NodeMergerStrategy) {
 
     private val logger = KotlinLogging.logger { }
-
-    fun extractProjectName(): String {
-        if (projectName != null) return projectName
-
-        val projectNames = projects.map { p -> p.projectName }
-        if (!projectNames.all { p -> p == projectNames.first() }) {
-            throw MergeException(
-                    "Project Names do not match. If files with different project names should be merged, a new project name must be provided using -p.")
-        }
-        return projectNames.first()
-    }
 
     fun merge(): Project {
         return when {
             areAllAPIVersionsCompatible() -> ProjectBuilder(
-                    extractProjectName(),
                     mergeProjectNodes(),
                     mergeEdges(),
                     mergeAttributeTypes(),
@@ -85,7 +43,7 @@ class ProjectMerger(private val projects: List<Project>, private val nodeMerger:
 
     private fun getEdgesOfMasterAndWarnIfDiscards(): MutableList<Edge> {
         projects.forEachIndexed { i, project ->
-            if (project.edges.isNotEmpty() && i > 0) logger.warn("Edges of ${project.projectName} were ignored. Use recursive strategy to merge edges.")
+            if (project.edges.isNotEmpty() && i > 0) logger.warn("Edges were not merged. Use recursive strategy to merge edges.")
         }
         return projects.first().edges.toMutableList()
     }

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/RecursiveNodeMergerStrategy.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/RecursiveNodeMergerStrategy.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.filter.mergefilter
 
 import de.maibornwolff.codecharta.model.MutableNode

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ProjectMergerTest.kt
@@ -53,33 +53,6 @@ class ProjectMergerTest: Spek({
             }
         }
 
-        context("merging project with different names") {
-            val projects = listOf(
-                    Project("test1"),
-                    Project("test2")
-            )
-
-            it("should throw a exception") {
-                assertFailsWith(MergeException::class) {
-                    ProjectMerger(projects, nodeMergerStrategy).merge()
-                }
-            }
-        }
-
-        context("merging project providing a project name") {
-            val projectName = "arbitraryString"
-            val projects = listOf(
-                    Project("test1"),
-                    Project("test2")
-            )
-
-            it("project should have provided project name") {
-                val projectNameMerge = ProjectMerger(projects, nodeMergerStrategy, projectName).extractProjectName()
-                assertThat(projectNameMerge, CoreMatchers.`is`(projectName))
-            }
-
-        }
-
         context("merging project with same API major versions") {
             val projectName = "test"
             val projects = listOf(
@@ -89,7 +62,7 @@ class ProjectMergerTest: Spek({
 
             it("should merge projects") {
                 val project = ProjectMerger(projects, nodeMergerStrategy).merge()
-                assertThat(project.projectName, CoreMatchers.`is`(projectName))
+                assertThat(project.projectName, CoreMatchers.`is`(""))
             }
         }
 
@@ -103,19 +76,6 @@ class ProjectMergerTest: Spek({
                 assertFailsWith(MergeException::class) {
                     ProjectMerger(projects, nodeMergerStrategy).merge()
                 }
-            }
-        }
-
-        context("merging projects with same name and API version") {
-            val projectName = "test"
-            val projects = listOf(
-                    Project(projectName, apiVersion = "1.1"),
-                    Project(projectName, apiVersion = "1.1")
-            )
-
-            it("should extract project name") {
-                val name = ProjectMerger(projects, nodeMergerStrategy).extractProjectName()
-                assertThat(name, CoreMatchers.`is`(projectName))
             }
         }
 

--- a/analysis/filter/StructureModifier/README.md
+++ b/analysis/filter/StructureModifier/README.md
@@ -1,6 +1,7 @@
 # StructureModifier
 
 The StructureModifier is used to modify the structure of .cc.json files. It enables to ...
+
 - remove nodes from a project. The resulting project will not include these nodes and their children.
 - declare a node as root. This means that the chosen node will become the root node of the resulting sub-project.
 - move nodes within the project. All children of the source node will be transferred to the destination node.
@@ -11,7 +12,7 @@ The edges and blacklist entries associated with moved/removed nodes will be alte
 ## Usage
 
 ```
-ccsh modify [-h] [-f=<moveFrom>] [-n=<projectName>] [-o=<outputFile>]
+ccsh modify [-h] [-f=<moveFrom>] [-o=<outputFile>]
                    [-p=<printLevels>] [-s=<setRoot>] [-t=<moveTo>]
                    [-r=<remove>...]... [FILE]
 ```
@@ -22,8 +23,6 @@ ccsh modify [-h] [-f=<moveFrom>] [-n=<projectName>] [-o=<outputFile>]
       [FILE]                 input project file
   -f, --moveFrom=<moveFrom>  move nodes in project folder...
   -h, --help                 displays this help and exits
-  -n, --projectName=<projectName>
-                             project name of new file
   -o, --outputFile=<outputFile>
                              output File (or empty for stdout)
   -p, --printLevels=<printLevels>
@@ -33,7 +32,6 @@ ccsh modify [-h] [-f=<moveFrom>] [-n=<projectName>] [-o=<outputFile>]
   -t, --moveTo=<moveTo>      ... move nodes to destination folder
 ```
 
-
 ## Examples
 
 > sh ccsh modify foo.cc.json -p=2
@@ -42,11 +40,12 @@ ccsh modify [-h] [-f=<moveFrom>] [-n=<projectName>] [-o=<outputFile>]
 
 > sh ccsh modify foo.cc.json --moveFrom=/root/foo --moveTo=/root/bar -outputFile=project.cc.json
 
-> sh ccsh modify foo.cc.json --setRoot=/root/foo/ --projectName=NewName
+> sh ccsh modify foo.cc.json --setRoot=/root/foo/
 
- ## Piped input
+## Piped input
 
- Instead of providing a cc.json file as input, a project can also be piped to the filter:
- ```
- cat demo.cc.json | sh ccsh modify -p=2
- ```
+Instead of providing a cc.json file as input, a project can also be piped to the filter:
+
+```
+cat demo.cc.json | sh ccsh modify -p=2
+```

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/FolderMover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/FolderMover.kt
@@ -3,7 +3,7 @@ package de.maibornwolff.codecharta.filter.structuremodifier
 import de.maibornwolff.codecharta.model.*
 import mu.KotlinLogging
 
-class FolderMover(private val project: Project, private val projectName: String?) {
+class FolderMover(private val project: Project) {
 
     private val logger = KotlinLogging.logger { }
     private var toMove: List<MutableNode>? = null
@@ -15,7 +15,6 @@ class FolderMover(private val project: Project, private val projectName: String?
         }
 
         return ProjectBuilder(
-                projectName ?: project.projectName,
                 moveNodes(moveFrom, moveTo),
                 extractEdges(moveFrom, moveTo),
                 copyAttributeTypes(),

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -3,7 +3,7 @@ package de.maibornwolff.codecharta.filter.structuremodifier
 import de.maibornwolff.codecharta.model.*
 import mu.KotlinLogging
 
-class NodeRemover(private val project: Project, private val projectName: String?) {
+class NodeRemover(private val project: Project) {
     private val logger = KotlinLogging.logger {}
 
     fun remove(paths: Array<String>): Project {
@@ -15,7 +15,6 @@ class NodeRemover(private val project: Project, private val projectName: String?
         }
 
         return ProjectBuilder(
-                projectName ?: project.projectName,
                 removeNodes(pathSegments),
                 removeEdges(paths),
                 copyAttributeTypes(),

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ProjectStructurePrinter.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ProjectStructurePrinter.kt
@@ -7,8 +7,6 @@ import java.io.PrintStream
 class ProjectStructurePrinter(private val project: Project, private val output: PrintStream = System.out) {
 
     fun printProjectStructure(maxDepth: Int) {
-        output.println("${project.projectName}:")
-        output.println("-".repeat(project.projectName.length + 1))
         printNodeRecursively(maxDepth, 0, project.rootNode.toMutableNode())
     }
 

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "modify",
         description = ["changes the structure of cc.json files"],
-        footer = ["Copyright(c) 2019, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class StructureModifier(private val input: InputStream = System.`in`,
                         private val output: PrintStream = System.out,
                         private val error: PrintStream = System.err) : Callable<Void?> {
@@ -31,9 +31,6 @@ class StructureModifier(private val input: InputStream = System.`in`,
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
-
-    @CommandLine.Option(names = ["-n", "--projectName"], description = ["project name of new file"])
-    private var projectName: String? = null
 
     @CommandLine.Option(names = ["-f", "--moveFrom"], description = ["move nodes in project folder..."])
     private var moveFrom: String? = null
@@ -56,9 +53,9 @@ class StructureModifier(private val input: InputStream = System.`in`,
                 ProjectStructurePrinter(project, output).printProjectStructure(printLevels)
                 return null
             }
-            setRoot != null -> project = SubProjectExtractor(project, projectName).extract(setRoot!!)
-            remove.isNotEmpty() -> project = NodeRemover(project, projectName).remove(remove)
-            moveFrom != null -> project = FolderMover(project, projectName).move(moveFrom, moveTo) ?: return null
+            setRoot != null -> project = SubProjectExtractor(project).extract(setRoot!!)
+            remove.isNotEmpty() -> project = NodeRemover(project).remove(remove)
+            moveFrom != null -> project = FolderMover(project).move(moveFrom, moveTo) ?: return null
         }
 
         val writer = outputFile?.bufferedWriter() ?: output.bufferedWriter()

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractor.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractor.kt
@@ -3,7 +3,7 @@ package de.maibornwolff.codecharta.filter.structuremodifier
 import de.maibornwolff.codecharta.model.*
 import mu.KotlinLogging
 
-class SubProjectExtractor(private val project: Project, private val projectName: String?) {
+class SubProjectExtractor(private val project: Project) {
 
     private val logger = KotlinLogging.logger { }
     private lateinit var path: String
@@ -12,7 +12,6 @@ class SubProjectExtractor(private val project: Project, private val projectName:
         this.path = path
         val pathSegments = path.removePrefix("/").split("/").filter { it.isNotEmpty() }
         return ProjectBuilder(
-                projectName ?: project.projectName,
                 addRoot(extractNodes(pathSegments, project.rootNode.toMutableNode())),
                 extractEdges(path),
                 copyAttributeTypes(),

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/FolderMoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/FolderMoverTest.kt
@@ -19,7 +19,7 @@ class FolderMoverTest {
 
     @Test
     fun `should remove the source node`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/src/folder3", "/root/foo")
 
@@ -31,16 +31,16 @@ class FolderMoverTest {
 
     @Test
     fun `should move nothing if source node is not found`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/does/not/exist", "/something")
 
-        Assertions.assertThat(result).isEqualToComparingFieldByFieldRecursively(sampleProject)
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(sampleProject)
     }
 
     @Test
     fun `should return nothing if destination folder is null`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/src/folder3", null)
 
@@ -50,7 +50,7 @@ class FolderMoverTest {
     @Test
     fun `should merge content of source folder into existing folder, if existent`() {
         serializeProject()
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/src/folder3", "/root/src/test")
 
@@ -61,7 +61,7 @@ class FolderMoverTest {
 
     @Test
     fun `should place content in newly created node, if destination does not exist`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/src/folder3", "/root/foo")
 
@@ -73,7 +73,7 @@ class FolderMoverTest {
 
     @Test
     fun `should copy unaffected edges`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
         val unaffectedEdge = sampleProject.edges[3]
 
         val result = folderMover.move("/root/foo/", "/root/bar")
@@ -84,7 +84,7 @@ class FolderMoverTest {
 
     @Test
     fun `should alter from and to node of affected edges`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/foo", "root/bar/")!!
 
@@ -99,7 +99,7 @@ class FolderMoverTest {
 
     @Test
     fun `should only alter to node of affected edges`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/foo", "/root/bar")!!
 
@@ -111,7 +111,7 @@ class FolderMoverTest {
 
     @Test
     fun `should change path of relevant blacklist items`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/foo", "/root/bar")!!
 
@@ -123,7 +123,7 @@ class FolderMoverTest {
 
     @Test
     fun `should be able to move from root`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root", "/root/new")
 
@@ -135,7 +135,7 @@ class FolderMoverTest {
 
     @Test
     fun `should be able to move to root`() {
-        val folderMover = FolderMover(sampleProject, null)
+        val folderMover = FolderMover(sampleProject)
 
         val result = folderMover.move("/root/src", "/root")
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -18,16 +18,16 @@ class NodeRemoverTest {
 
     @Test
     fun `Non existent path leads to replication of the project`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/somethig"))
 
-        Assertions.assertThat(result).isEqualToComparingFieldByFieldRecursively(sampleProject)
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(sampleProject)
     }
 
     @Test
     fun `Non affected nodes are kept`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/src/main"))
 
@@ -37,7 +37,7 @@ class NodeRemoverTest {
 
     @Test
     fun `specified nodes are removed`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/src/main"))
 
@@ -48,7 +48,7 @@ class NodeRemoverTest {
 
     @Test
     fun `multiple nodes are removed`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/src/main/file1.java", "root/src/folder3/"))
 
@@ -59,29 +59,20 @@ class NodeRemoverTest {
     }
 
     @Test
-    fun `project name is set to specified name`() {
-        val subProjectExtractor = NodeRemover(sampleProject, "fooBar")
-
-        val result = subProjectExtractor.remove(arrayOf())
-
-        Assertions.assertThat(result.projectName).isEqualTo("fooBar")
-    }
-
-    @Test
     fun `Affected edges are removed`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/foo"))
 
         Assertions.assertThat(result.edges.size).isEqualTo(1)
-        Assertions.assertThat(result.edges.first()).isEqualToComparingFieldByFieldRecursively(sampleProject.edges.last())
+        Assertions.assertThat(result.edges.first()).usingRecursiveComparison().isEqualTo(sampleProject.edges.last())
         Assertions.assertThat(result.edges.map { it.fromNodeName }).doesNotContain("/root/foo")
         Assertions.assertThat(result.edges.map { it.toNodeName }).doesNotContain("/root/foo")
     }
 
     @Test
     fun `Affected edges are removed for multiple removals`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
         val toExclude = arrayOf("/root/foo/file1", "root/else/")
 
         val result = subProjectExtractor.remove(toExclude)
@@ -94,7 +85,7 @@ class NodeRemoverTest {
 
     @Test
     fun `Affected blacklist items are removed`() {
-        val subProjectExtractor = NodeRemover(sampleProject, null)
+        val subProjectExtractor = NodeRemover(sampleProject)
 
         val result = subProjectExtractor.remove(arrayOf("/root/foo"))
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ProjectStructurePrinterTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ProjectStructurePrinterTest.kt
@@ -23,15 +23,6 @@ class ProjectStructurePrinterTest {
     }
 
     @Test
-    fun `ProjectName is printed`() {
-        val projectStructurePrinter = ProjectStructurePrinter(sampleProject)
-
-        projectStructurePrinter.printProjectStructure(0)
-
-        Assertions.assertThat(outContent.toString()).contains(sampleProject.projectName)
-    }
-
-    @Test
     fun `Nodes on desired max hierarchy level are printed`() {
         val projectStructurePrinter = ProjectStructurePrinter(sampleProject)
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
@@ -12,7 +12,7 @@ class StructureModifierTest {
     fun `reads project from file`() {
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-r=/does/not/exist"))
 
-        Assertions.assertThat(cliResult).contains(listOf("MyProject", "otherFile.java"))
+        Assertions.assertThat(cliResult).contains(listOf("otherFile.java"))
     }
 
     @Test
@@ -21,7 +21,7 @@ class StructureModifierTest {
 
         val cliResult = executeForOutput(input, arrayOf("-r=/does/not/exist"))
 
-        Assertions.assertThat(cliResult).contains(listOf("MyProject", "otherFile.java"))
+        Assertions.assertThat(cliResult).contains(listOf("otherFile.java"))
     }
 
     @Test
@@ -42,7 +42,7 @@ class StructureModifierTest {
         val input = File("src/test/resources/sample_project.cc.json").bufferedReader().readLines().joinToString(separator = "\n") { it }
         val cliResult = executeForOutput(input, arrayOf("-r=/does/not/exist"))
 
-        Assertions.assertThat(cliResult).contains(listOf("MyProject", "otherFile.java"))
+        Assertions.assertThat(cliResult).contains(listOf("otherFile.java"))
     }
 
     @Test
@@ -71,7 +71,7 @@ class StructureModifierTest {
     fun `removes nodes`() {
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-r=/root/src"))
 
-        Assertions.assertThat(cliResult).contains(listOf("MyProject", "root"))
+        Assertions.assertThat(cliResult).contains(listOf("root"))
         Assertions.assertThat(cliResult).doesNotContain(listOf("src", "otherFile.java"))
     }
 
@@ -87,6 +87,6 @@ class StructureModifierTest {
     fun `prints structure`() {
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-p=2"))
 
-        Assertions.assertThat(cliResult).contains(listOf("MyProject", "folder3", "- - "))
+        Assertions.assertThat(cliResult).contains(listOf("folder3", "- - "))
     }
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
@@ -50,15 +50,6 @@ class SubProjectExtractorTest {
     }
 
     @Test
-    fun `Project name is kept if not provided`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject)
-
-        val result = subProjectExtractor.extract("/root/something")
-
-        Assertions.assertThat(result.projectName).isEqualTo(sampleProject.projectName)
-    }
-
-    @Test
     fun `Only edges part of sub-project are kept`() {
         val subProjectExtractor = SubProjectExtractor(sampleProject)
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
@@ -19,7 +19,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Non existent path leads to empty project`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/something")
 
@@ -28,7 +28,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Single path is extracted`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("root/src/test")
         println(result)
@@ -41,7 +41,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Attributes of extracted nodes are kept`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/src/test")
 
@@ -50,17 +50,8 @@ class SubProjectExtractorTest {
     }
 
     @Test
-    fun `Project name is changed if provided`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, "foo")
-
-        val result = subProjectExtractor.extract("/root/something")
-
-        Assertions.assertThat(result.projectName).isEqualTo("foo")
-    }
-
-    @Test
     fun `Project name is kept if not provided`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/something")
 
@@ -69,7 +60,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Only edges part of sub-project are kept`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/foo")
 
@@ -79,7 +70,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Edges of selected sub-project renamed`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/foo")
 
@@ -91,7 +82,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Subproject with no matching edges has no edges`() {
-        val subProjectExtractor = SubProjectExtractor(sampleProject, null)
+        val subProjectExtractor = SubProjectExtractor(sampleProject)
 
         val result = subProjectExtractor.extract("/root/something")
 

--- a/analysis/filter/StructureModifier/src/test/resources/sample_project.cc.json
+++ b/analysis/filter/StructureModifier/src/test/resources/sample_project.cc.json
@@ -1,5 +1,5 @@
 {
-  "projectName": "MyProject",
+  "projectName": "",
   "apiVersion": "1.1",
   "nodes": [
     {

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "csvimport",
         description = ["generates cc.json from csv with header"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class CSVImporter: Callable<Void> {
 
@@ -17,9 +17,6 @@ class CSVImporter: Callable<Void> {
 
     @CommandLine.Option(names = ["-d", "--delimeter"], description = ["delimeter in csv file"])
     private var csvDelimiter = ','
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "SCMLogParser"
 
     @CommandLine.Option(names = ["--pathSeparator"], description = ["path separator (default = '/')"])
     private var pathSeparator = '/'
@@ -32,7 +29,7 @@ class CSVImporter: Callable<Void> {
 
     @Throws(IOException::class)
     override fun call(): Void? {
-        val csvProjectBuilder = CSVProjectBuilder(projectName, pathSeparator, csvDelimiter)
+        val csvProjectBuilder = CSVProjectBuilder(pathSeparator, csvDelimiter)
         files.map { it.inputStream() }.forEach<InputStream> { csvProjectBuilder.parseCSVStream(it) }
         val project = csvProjectBuilder.build()
         ProjectSerializer.serializeProject(project, writer())

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVProjectBuilder.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.csv
 
 import com.univocity.parsers.csv.CsvParser
@@ -41,7 +12,6 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 
 class CSVProjectBuilder(
-        projectName: String,
         private val pathSeparator: Char,
         private val csvDelimiter: Char,
         private val pathColumnName: String = "path",
@@ -51,7 +21,7 @@ class CSVProjectBuilder(
     private val logger = KotlinLogging.logger {}
 
     private val includeRows: (Array<String>) -> Boolean = { true }
-    private val projectBuilder = ProjectBuilder(projectName)
+    private val projectBuilder = ProjectBuilder()
             .withMetricTranslator(metricNameTranslator)
 
     fun parseCSVStream(

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/SourceMonitorImporter.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/SourceMonitorImporter.kt
@@ -7,14 +7,11 @@ import java.io.*
 import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "sourcemonitorimport", description = ["generates cc.json from sourcemonitor csv"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class SourceMonitorImporter: Callable<Void> {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "testProject"
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
@@ -29,7 +26,7 @@ class SourceMonitorImporter: Callable<Void> {
     @Throws(IOException::class)
     override fun call(): Void? {
         val csvProjectBuilder =
-                CSVProjectBuilder(projectName, pathSeparator, csvDelimiter, "File Name", sourceMonitorReplacement)
+                CSVProjectBuilder(pathSeparator, csvDelimiter, "File Name", sourceMonitorReplacement)
         files.map { it.inputStream() }.forEach<InputStream> { csvProjectBuilder.parseCSVStream(it) }
         val project = csvProjectBuilder.build()
         ProjectSerializer.serializeProject(project, writer())

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/CSVProjectBuilderTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/CSVProjectBuilderTest.kt
@@ -15,7 +15,7 @@ class CSVProjectBuilderTest: Spek({
     }
 
     describe("a CSVProjectBuilder") {
-        val csvProjectBuilder = CSVProjectBuilder("test", '\\', ',')
+        val csvProjectBuilder = CSVProjectBuilder('\\', ',')
 
         context("adding invalid csv") {
 
@@ -56,7 +56,7 @@ class CSVProjectBuilderTest: Spek({
     }
 
     describe("a CSVProjectBuilder") {
-        val csvProjectBuilder = CSVProjectBuilder("test", '\\', ',')
+        val csvProjectBuilder = CSVProjectBuilder('\\', ',')
 
         context("adding line with metric values") {
             val attribName = "attname"
@@ -79,7 +79,7 @@ class CSVProjectBuilderTest: Spek({
     }
 
     describe("a CSVProjectBuilder") {
-        val csvProjectBuilder = CSVProjectBuilder("test", '\\', ',')
+        val csvProjectBuilder = CSVProjectBuilder('\\', ',')
 
         context("adding file with subdirectory") {
             val directoryName = "someNodeName"
@@ -97,7 +97,7 @@ class CSVProjectBuilderTest: Spek({
     }
 
     describe("CSVProjectBuilder for Sourcemonitor") {
-        val csvProjectBuilder = CSVProjectBuilder("test", '\\', ',',
+        val csvProjectBuilder = CSVProjectBuilder('\\', ',',
                 metricNameTranslator = MetricNameTranslator(mapOf(Pair("File Name", "path"))))
 
         context("reading csv lines from Sourcemonitor") {

--- a/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/CSVProjectBuilder.kt
+++ b/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/CSVProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.codemaat
 
 import com.univocity.parsers.csv.CsvParser
@@ -42,7 +13,6 @@ import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
 
 class CSVProjectBuilder(
-        projectName: String,
         private val pathSeparator: Char,
         private val csvDelimiter: Char,
         metricNameTranslator: MetricNameTranslator = MetricNameTranslator.TRIVIAL,
@@ -52,7 +22,7 @@ class CSVProjectBuilder(
     private val logger = KotlinLogging.logger {}
 
     private val includeRows: (Array<String>) -> Boolean = { true }
-    private val projectBuilder = ProjectBuilder(projectName)
+    private val projectBuilder = ProjectBuilder()
             .withMetricTranslator(metricNameTranslator)
             .addAttributeTypes(attributeTypes)
 

--- a/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/CodeMaatImporter.kt
+++ b/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/CodeMaatImporter.kt
@@ -9,14 +9,11 @@ import java.io.*
 import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "codemaatimport", description = ["generates cc.json from codemaat coupling csv"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class CodeMaatImporter: Callable<Void> {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "testProject"
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
@@ -31,7 +28,7 @@ class CodeMaatImporter: Callable<Void> {
     @Throws(IOException::class)
     override fun call(): Void? {
         val csvProjectBuilder =
-                CSVProjectBuilder(projectName, pathSeparator, csvDelimiter, codemaatReplacement, attributeTypes)
+                CSVProjectBuilder(pathSeparator, csvDelimiter, codemaatReplacement, attributeTypes)
         files.map { it.inputStream() }.forEach<InputStream> { csvProjectBuilder.parseCSVStream(it) }
         val project = csvProjectBuilder.build()
 

--- a/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/CSVCodeMaatTest.kt
+++ b/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/CSVCodeMaatTest.kt
@@ -10,7 +10,7 @@ import org.spekframework.spek2.style.specification.describe
 class CSVCodeMaatTest: Spek({
 
     describe("CSVProjectBuilder for CodeMaat") {
-        val csvProjectBuilder = CSVProjectBuilder("test", '\\', ',',
+        val csvProjectBuilder = CSVProjectBuilder('\\', ',',
                 MetricNameTranslator(mapOf(Pair("File Name", "path"))))
 
         context("reading csv lines from CodeMaat") {

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverter.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo
 
 import de.maibornwolff.codecharta.importer.crococosmo.model.Graph
@@ -38,9 +9,9 @@ import de.maibornwolff.codecharta.model.Project
 
 class CrococosmoConverter {
 
-    fun convertToProjectsMap(projectName: String, graph: Graph): Map<String, Project> {
+    fun convertToProjectsMap(graph: Graph): Map<String, Project> {
         return graph.schema.versions.versions
-                .associateBy({ createVersionName(it) }, { createProject(projectName, graph, it.id) })
+                .associateBy({ createVersionName(it) }, { createProject(graph, it.id) })
     }
 
     private fun createVersionName(it: SchemaVersion) =
@@ -50,8 +21,8 @@ class CrococosmoConverter {
                 else                     -> it.id
             }
 
-    fun createProject(projectName: String, graph: Graph, version: String = graph.schema.versions.versions.first().id) =
-            Project(projectName, createNodeListForProject(graph.nodes, version))
+    fun createProject(graph: Graph, version: String = graph.schema.versions.versions.first().id) =
+            Project("", createNodeListForProject(graph.nodes, version))
 
     private fun createNodeListForProject(nodes: List<de.maibornwolff.codecharta.importer.crococosmo.model.Node>,
                                          version: String): List<Node> {
@@ -71,7 +42,7 @@ class CrococosmoConverter {
         return when {
             origin.name.isNullOrEmpty() -> convertToNodeList(origin.children.orEmpty(), version)
             else                        -> listOf(
-                    Node(origin.name!!, getNodeType(origin), createAttributeListForNode(origin.versions, version), "",
+                    Node(origin.name, getNodeType(origin), createAttributeListForNode(origin.versions, version), "",
                             convertToNodeList(origin.children.orEmpty(), version)))
         }
     }

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoDeserializer.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoDeserializer.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo
 
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoImporter.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoImporter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo
 
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
@@ -37,7 +8,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "crococosmoimport",
         description = ["generates cc.json from crococosmo xml file"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class CrococosmoImporter: Callable<Void> {
 
@@ -47,16 +18,13 @@ class CrococosmoImporter: Callable<Void> {
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
 
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "CrococosmoImporter"
-
     @CommandLine.Option(names = ["-o", "--outputFile"],
             description = ["output File or prefix for File (or empty for stdout)"])
     private var outputFile: String? = null
 
     override fun call(): Void? {
         val graph = CrococosmoDeserializer().deserializeCrococosmoXML(file!!.inputStream())
-        val projects = CrococosmoConverter().convertToProjectsMap(projectName, graph)
+        val projects = CrococosmoConverter().convertToProjectsMap(graph)
         projects.forEach {
             val suffix = if (projects.isNotEmpty()) "_" + it.key else ""
             ProjectSerializer.serializeProject(it.value, writer(suffix))

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Attribute.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Attribute.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo.model
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Graph.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Graph.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Node.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Node.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Schema.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties

--- a/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Version.kt
+++ b/analysis/import/CrococosmoImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/crococosmo/model/Version.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo.model
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/analysis/import/CrococosmoImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverterTest.kt
+++ b/analysis/import/CrococosmoImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoConverterTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo
 
 import com.natpryce.hamkrest.assertion.assertThat
@@ -43,7 +14,7 @@ class CrococosmoConverterTest {
     @Test
     fun convertedProjectShouldContainRootNode() {
         val g = Graph(schema, listOf())
-        val project = converter.createProject("sample Project", g)
+        val project = converter.createProject(g)
         assertThat(project.rootNode.isLeaf, equalTo(true))
     }
 
@@ -51,7 +22,7 @@ class CrococosmoConverterTest {
     fun convertedProjectShouldCollapseNodesWithoutName() {
         val nodeWithoutName = Node("", "type", listOf(), listOf())
         val g = Graph(schema, listOf(Node("node name", "type", listOf(nodeWithoutName), listOf())))
-        val project = converter.createProject("sample Project", g)
+        val project = converter.createProject(g)
         val grantChildren = project.rootNode.children[0].children
 
         assertThat(grantChildren.count(), equalTo(0))
@@ -61,7 +32,7 @@ class CrococosmoConverterTest {
     fun convertedProjectShouldNotCollapseNodesWithName() {
         val nodeWithName = Node("happyChild", "type", listOf(), listOf())
         val g = Graph(schema, listOf(Node("node name", "type", listOf(nodeWithName), listOf())))
-        val project = converter.createProject("sample Project", g)
+        val project = converter.createProject(g)
         val grantChildren = project.rootNode.children[0].children
 
         assertThat(grantChildren.count(), equalTo(1))
@@ -71,7 +42,7 @@ class CrococosmoConverterTest {
     fun convertedProjectShouldContainNode() {
         val nodeName = "node name"
         val g = Graph(schema, listOf(Node(nodeName, "type", listOf(), listOf())))
-        val project = converter.createProject("sample Project", g)
+        val project = converter.createProject(g)
         val children = project.rootNode.children
 
         assertThat(children.filter({ nodeName == it.name }).count(), equalTo(1))
@@ -86,7 +57,7 @@ class CrococosmoConverterTest {
         val e = Node("some node", "type", listOf(), listOf(v))
         val g = Graph(schema, listOf(e))
 
-        val project = converter.createProject("sample Project", g)
+        val project = converter.createProject(g)
 
         var node = project.rootNode
         while (!node.children.isEmpty()) {
@@ -100,7 +71,7 @@ class CrococosmoConverterTest {
 
         val `in` = this.javaClass.classLoader.getResourceAsStream("test.xml")
         val graph = CrococosmoDeserializer().deserializeCrococosmoXML(`in`)
-        val project = converter.createProject("test", graph)
+        val project = converter.createProject(graph)
 
         assertThat(project.rootNode.leafObjects.count(), equalTo(17))
     }
@@ -110,7 +81,7 @@ class CrococosmoConverterTest {
         val schemaWithMultipleVersions = Schema(listOf(SchemaVersion("1"), SchemaVersion("2")))
         val nodeWithoutName = Node("", "type", listOf(), listOf())
         val g = Graph(schemaWithMultipleVersions, listOf(Node("node name", "type", listOf(nodeWithoutName), listOf())))
-        val projects = converter.convertToProjectsMap("sample Project", g)
+        val projects = converter.convertToProjectsMap(g)
 
         assertThat(projects.size, equalTo(2))
     }

--- a/analysis/import/CrococosmoImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoDeserializerTest.kt
+++ b/analysis/import/CrococosmoImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/crococosmo/CrococosmoDeserializerTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.crococosmo
 
 import org.junit.jupiter.api.Test

--- a/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeDeserializer.kt
+++ b/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeDeserializer.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.jasome
 
 import com.fasterxml.jackson.databind.DeserializationFeature

--- a/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeImporter.kt
+++ b/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeImporter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.jasome
 
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
@@ -37,7 +8,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "jasomeimport",
         description = ["generates cc.json from jasome xml file"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class JasomeImporter: Callable<Void> {
 
@@ -47,9 +18,6 @@ class JasomeImporter: Callable<Void> {
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
 
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "JasomeImporter"
-
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
 
@@ -57,7 +25,7 @@ class JasomeImporter: Callable<Void> {
 
     override fun call(): Void? {
         val jasomeProject = JasomeDeserializer().deserializeJasomeXML(file!!.inputStream())
-        val project = JasomeProjectBuilder(projectName).add(jasomeProject).build()
+        val project = JasomeProjectBuilder().add(jasomeProject).build()
         ProjectSerializer.serializeProject(project, writer)
 
         return null

--- a/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeProjectBuilder.kt
+++ b/analysis/import/JasomeImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.jasome
 
 import de.maibornwolff.codecharta.importer.jasome.model.Class
@@ -34,9 +5,9 @@ import de.maibornwolff.codecharta.importer.jasome.model.Package
 import de.maibornwolff.codecharta.model.*
 import java.math.BigDecimal
 
-class JasomeProjectBuilder(projectName: String = "") {
+class JasomeProjectBuilder() {
 
-    private val projectBuilder = ProjectBuilder(projectName)
+    private val projectBuilder = ProjectBuilder()
 
     fun add(jasomeProject: de.maibornwolff.codecharta.importer.jasome.model.Project): JasomeProjectBuilder {
         jasomeProject.packages.orEmpty().forEach { this.add(it) }

--- a/analysis/import/JasomeImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeDeserializerTest.kt
+++ b/analysis/import/JasomeImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeDeserializerTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.jasome
 
 import org.hamcrest.MatcherAssert
@@ -40,7 +11,7 @@ class JasomeDeserializerTest: Spek({
 
         context("deserializing a project ") {
             val jasomeProject = jasomeDeserializer.deserializeJasomeXML(
-                    this.javaClass.classLoader.getResourceAsStream("jasome.xml")
+                    this.javaClass.classLoader.getResourceAsStream("jasome.xml")!!
             )
 
             it("should have packages") {

--- a/analysis/import/JasomeImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeProjectBuilderTest.kt
+++ b/analysis/import/JasomeImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/jasome/JasomeProjectBuilderTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.jasome
 
 import de.maibornwolff.codecharta.importer.jasome.model.Class
@@ -43,8 +14,8 @@ import org.spekframework.spek2.style.specification.describe
 
 class JasomeProjectBuilderTest: Spek({
     describe("JasomeProjectBuilder adding an empty Jasome Project") {
-        val projectBuilder = JasomeProjectBuilder("test")
-        val jasomeProject = de.maibornwolff.codecharta.importer.jasome.model.Project(listOf())
+        val projectBuilder = JasomeProjectBuilder()
+        val jasomeProject = Project(listOf())
         val project = projectBuilder
                 .add(jasomeProject)
                 .build()
@@ -55,7 +26,7 @@ class JasomeProjectBuilderTest: Spek({
     }
 
     describe("JasomeProjectBuilder adding a Jasome Project with a Class") {
-        val projectBuilder = JasomeProjectBuilder("test")
+        val projectBuilder = JasomeProjectBuilder()
         val jasomeClass = Class(
                 name = "ClassName",
                 metrics = listOf(Metric("ClTCi", "6,333333333"))
@@ -95,9 +66,9 @@ class JasomeProjectBuilderTest: Spek({
     }
 
     describe("JasomeProjectBuilder adding an big Jasome Project") {
-        val projectBuilder = JasomeProjectBuilder("test")
+        val projectBuilder = JasomeProjectBuilder()
         val jasomeProject = JasomeDeserializer().deserializeJasomeXML(
-                this.javaClass.classLoader.getResourceAsStream("jasome.xml")
+                this.javaClass.classLoader.getResourceAsStream("jasome.xml")!!
         )
         val project = projectBuilder
                 .add(jasomeProject)

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogParser.kt
@@ -26,7 +26,7 @@ import java.util.stream.Stream
 @CommandLine.Command(
         name = "scmlogparser",
         description = ["generates cc.json from scm log file (git or svn)"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class SCMLogParser(private val input: InputStream = System.`in`,
                    private val output: PrintStream = System.out,
@@ -40,9 +40,6 @@ class SCMLogParser(private val input: InputStream = System.`in`,
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile = ""
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "SCMLogParser"
 
     @CommandLine.Option(names = ["--git"], hidden = true,
             description = ["analysis of git log, equivalent --input-format GIT_LOG"])
@@ -96,13 +93,12 @@ class SCMLogParser(private val input: InputStream = System.`in`,
                 file!!,
                 logParserStrategy,
                 metricsFactory,
-                projectName,
                 addAuthor,
                 silent)
 
         val pipedProject = ProjectDeserializer.deserializeProject(input)
         if (pipedProject != null) {
-            project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project, projectName)
+            project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project)
         }
         if (outputFile.isNotEmpty()) {
             ProjectSerializer.serializeProjectAndWriteToFile(project, outputFile)
@@ -139,7 +135,6 @@ class SCMLogParser(private val input: InputStream = System.`in`,
             pathToLog: File,
             parserStrategy: LogParserStrategy,
             metricsFactory: MetricsFactory,
-            projectName: String,
             containsAuthors: Boolean,
             silent: Boolean = false
     ): Project {
@@ -147,7 +142,7 @@ class SCMLogParser(private val input: InputStream = System.`in`,
         if (!silent) error.println("Assumed encoding $encoding")
         val lines: Stream<String> = pathToLog.readLines(Charset.forName(encoding)).stream()
 
-        val projectConverter = ProjectConverter(containsAuthors, projectName)
+        val projectConverter = ProjectConverter(containsAuthors)
         return SCMLogProjectCreator(parserStrategy, metricsFactory, projectConverter, silent).parse(lines)
     }
 

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
@@ -37,7 +37,7 @@ import java.util.*
 /**
  * creates Projects from List of VersionControlledFiles
  */
-class ProjectConverter(private val containsAuthors: Boolean, private val projectName: String) {
+class ProjectConverter(private val containsAuthors: Boolean) {
 
     private val ROOT_PREFIX = "/root/"
 
@@ -67,7 +67,7 @@ class ProjectConverter(private val containsAuthors: Boolean, private val project
     }
 
     fun convert(versionControlledFiles: List<VersionControlledFile>): Project {
-        val projectBuilder = ProjectBuilder(projectName)
+        val projectBuilder = ProjectBuilder()
 
         versionControlledFiles
                 .filter { vc -> !vc.markedDeleted() }

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/PipedInputStream.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/PipedInputStream.kt
@@ -12,7 +12,7 @@ class PipedInputStream {
 
     private fun getResultString(): String {
         val input = File("src/test/resources/cc_project.cc.json").bufferedReader().readLines().joinToString(separator = "\n") { it }
-        return executeForOutput(input, arrayOf(resource, "--input-format=GIT_LOG_NUMSTAT", "-p=FooProject"))
+        return executeForOutput(input, arrayOf(resource, "--input-format=GIT_LOG_NUMSTAT"))
     }
 
 
@@ -29,13 +29,6 @@ class PipedInputStream {
         assertThat(output).contains(
                 """"name":"FooBar.java"""",
                 """"coverage":0.0"""
-        )
-    }
-
-    @Test
-    fun `json output does have project name of current project`() {
-        assertThat(output).contains(
-                """"projectName":"FooProject""""
         )
     }
 

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorGoldenMasterTest.kt
@@ -39,8 +39,6 @@ class SCMLogProjectCreatorGoldenMasterTest(
         }
     }
 
-    private val PROJECT_NAME = "SCMLogParser"
-
     private val metricsFactory = MetricsFactory(Arrays.asList(
             "number_of_authors",
             "number_of_commits",
@@ -53,7 +51,7 @@ class SCMLogProjectCreatorGoldenMasterTest(
     @Throws(Exception::class)
     fun logParserGoldenMasterTest() {
         // given
-        val projectConverter = ProjectConverter(containsAuthors, PROJECT_NAME)
+        val projectConverter = ProjectConverter(containsAuthors)
 
         val svnSCMLogProjectCreator = SCMLogProjectCreator(strategy, metricsFactory, projectConverter, silent = true)
         val ccjsonReader = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(expectedProjectFilename)!!)

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/SCMLogProjectCreatorTest.kt
@@ -36,7 +36,7 @@ class SCMLogProjectCreatorTest(
     }
 
     private val metricsFactory = MetricsFactory()
-    private val projectConverter = ProjectConverter(false, "")
+    private val projectConverter = ProjectConverter(false)
 
     @Test
     @Throws(Exception::class)

--- a/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverterTest.kt
+++ b/analysis/import/SCMLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverterTest.kt
@@ -29,21 +29,19 @@ class ProjectConverterTest {
     @Throws(Exception::class)
     fun canCreateAnEmptyProject() {
         // given
-        val projectname = "Projectname"
-        val projectConverter = ProjectConverter(true, projectname)
+        val projectConverter = ProjectConverter(true)
 
         // when
         val project = projectConverter.convert(emptyList())
 
         //then
         assertThat(project.rootNode.leaves).hasSize(1)
-        assertThat(project.projectName).isEqualTo(projectname)
     }
 
     @Test
     fun canConvertProjectWithAuthors() {
         //given
-        val projectConverter = ProjectConverter(true, "ProjectWithAuthors")
+        val projectConverter = ProjectConverter(true)
         val file1 = VersionControlledFile("File 1", metricsFactory)
         file1.registerCommit(Commit("Author", modificationsByFilename("File 1", "File 2"), OffsetDateTime.now()))
 
@@ -57,7 +55,7 @@ class ProjectConverterTest {
     @Test
     fun canConvertProjectWithoutAuthors() {
         //given
-        val projectConverter = ProjectConverter(false, "ProjectWithoutAuthors")
+        val projectConverter = ProjectConverter(false)
         val file1 = VersionControlledFile("File 1", metricsFactory)
         file1.registerCommit(Commit("Author", modificationsByFilename("File 1", "File 2"), OffsetDateTime.now()))
 
@@ -71,7 +69,7 @@ class ProjectConverterTest {
     @Test
     fun edgesAreRegisteredInProject() {
         //given
-        val projectConverter = ProjectConverter(true, "ProjectWithAuthors")
+        val projectConverter = ProjectConverter(true)
         val metricsFactory = MetricsFactory().createMetrics()
         val file1 = VersionControlledFile("File 1", metricsFactory)
         val commit = Commit("Author", modificationsByFilename("File 1", "File 2"), OffsetDateTime.now())

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinker.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarCodeURLLinker.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.importer.sonar.model.Component

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectBuilder.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.importer.sonar.model.Component
@@ -37,7 +8,6 @@ import de.maibornwolff.codecharta.model.*
 import de.maibornwolff.codecharta.translator.MetricNameTranslator
 
 class SonarComponentProjectBuilder(
-        name: String,
         private val sonarCodeURLLinker: SonarCodeURLLinker = SonarCodeURLLinker.NULL,
         private val translator: MetricNameTranslator = MetricNameTranslator.TRIVIAL,
         private val usePath: Boolean = false
@@ -45,7 +15,7 @@ class SonarComponentProjectBuilder(
 
     private var totalComponents = 0
     private var processedComponents = -1
-    private val projectBuilder = ProjectBuilder(name)
+    private val projectBuilder = ProjectBuilder()
     val size: Int
         get() = projectBuilder.size
 

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterException.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterException.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 class SonarImporterException: RuntimeException {

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.filter.mergefilter.MergeFilter
@@ -42,7 +13,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "sonarimport",
         description = ["generates cc.json from metric data from SonarQube"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class SonarImporterMain(private val input: InputStream = System.`in`,
                         private val output: PrintStream = System.out,
@@ -92,11 +63,11 @@ class SonarImporterMain(private val input: InputStream = System.`in`,
     override fun call(): Void? {
         print(" ")
         val importer = createMesauresAPIImporter()
-        var project = importer.getProjectFromMeasureAPI(projectId, projectId, metrics)
+        var project = importer.getProjectFromMeasureAPI(projectId, metrics)
 
         val pipedProject = ProjectDeserializer.deserializeProject(input)
         if (pipedProject != null) {
-            project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project, projectId)
+            project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project)
         }
         ProjectSerializer.serializeProject(project, writer())
 

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMeasuresAPIImporter.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMeasuresAPIImporter.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMeasuresAPIDatasource
@@ -41,13 +12,13 @@ class SonarMeasuresAPIImporter @JvmOverloads constructor(
         private val translator: MetricNameTranslator = MetricNameTranslator.TRIVIAL,
         private val usePath: Boolean = false) {
 
-    fun getProjectFromMeasureAPI(projectKey: String, projectName: String, metrics: List<String>): Project {
+    fun getProjectFromMeasureAPI(projectKey: String, metrics: List<String>): Project {
         val metricsList = getMetricList(metrics)
         System.err.println("Get values for metrics $metricsList.")
 
         val componentMap = measuresDS!!.getComponentMap(projectKey, metricsList)
 
-        val projectBuilder = SonarComponentProjectBuilder(projectName, sonarCodeURLLinker, translator, usePath)
+        val projectBuilder = SonarComponentProjectBuilder(sonarCodeURLLinker, translator, usePath)
         return projectBuilder.addComponentMapsAsNodes(componentMap).build()
     }
 

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMetricTranslatorFactory.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMetricTranslatorFactory.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.translator.MetricNameTranslator

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectBuilderTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarComponentProjectBuilderTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.importer.sonar.model.Component
@@ -47,7 +18,7 @@ class SonarComponentProjectBuilderTest {
         val measure = Measure("metric", "50.0")
         val name = "name"
         val component = Component("id", null, name, "path", Qualifier.FIL, listOf(measure).toMutableList())
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()
@@ -64,7 +35,7 @@ class SonarComponentProjectBuilderTest {
         val measure = Measure("metric", "50.0")
         val id = "id"
         val component = Component(id, null, null, null, Qualifier.FIL, listOf(measure).toMutableList())
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()
@@ -86,7 +57,7 @@ class SonarComponentProjectBuilderTest {
         val name = "name"
         val path = "someFileName"
         val component = Component(id, key, name, path, Qualifier.FIL, listOf(measure).toMutableList())
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()
@@ -106,7 +77,7 @@ class SonarComponentProjectBuilderTest {
         // given
         val measure = Measure("metric", "bla")
         val component = Component("id", "key", "name", "path", Qualifier.FIL, listOf(measure).toMutableList())
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()
@@ -121,7 +92,7 @@ class SonarComponentProjectBuilderTest {
     fun should_insert_a_file_node_from_uts_component() {
         // given
         val component = Component("id", "key", "name", "path", Qualifier.UTS)
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()
@@ -136,7 +107,7 @@ class SonarComponentProjectBuilderTest {
     fun should_insert_a_folder_node_from_dir_component() {
         // given
         val component = Component("id", "key", "name", "path", Qualifier.DIR)
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component)
@@ -151,7 +122,7 @@ class SonarComponentProjectBuilderTest {
         val component = Component("id", "key", "name", "path", Qualifier.FIL)
         val components = ComponentMap()
         components.updateComponent(component)
-        val projectBuilder = SonarComponentProjectBuilder("project")
+        val projectBuilder = SonarComponentProjectBuilder()
 
         // when
         val project = projectBuilder.addComponentAsNode(component)
@@ -166,7 +137,7 @@ class SonarComponentProjectBuilderTest {
         val path = "someFileName"
         val component = Component("id", "key", "name", path, Qualifier.FIL)
         val projectBuilder =
-                SonarComponentProjectBuilder("project", SonarCodeURLLinker.NULL, MetricNameTranslator.TRIVIAL, true)
+                SonarComponentProjectBuilder(SonarCodeURLLinker.NULL, MetricNameTranslator.TRIVIAL, true)
 
         // when
         val project = projectBuilder.addComponentAsNode(component).build()

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMeasuresAPIImporterTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarMeasuresAPIImporterTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2017, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.sonar
 
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMeasuresAPIDatasource
@@ -89,7 +60,7 @@ class SonarMeasuresAPIImporterTest {
 
         // when
         val project =
-                sonar.getProjectFromMeasureAPI(projectKey, "componentShouldBeInsertedAccordingToComponentPath", metrics)
+                sonar.getProjectFromMeasureAPI("testProject", metrics)
 
         // then
         assertThat(project, not(nullValue()))

--- a/analysis/import/SourceCodeParser/README.md
+++ b/analysis/import/SourceCodeParser/README.md
@@ -60,7 +60,6 @@ The resulting project has the project name specified for the SourceCodeParser.
 - -h, --help
 - -i, --noIssues (do not search for sonar issues)
 - -o, --outputFile=\<outputFile> (file to write output to, if empty stdout is used)
-- -p, --projectName=\<projectName>
 - -v, --verbose
 
 ## Sonar Plugins

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/SourceCodeParserMain.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/SourceCodeParserMain.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable
 @Command(
         name = "sourcecodeparser",
         description = ["generates cc.json from source code"],
-        footer = ["This program uses the SonarJava, which is licensed under the GNU Lesser General Public Library, version 3.\nCopyright(c) 2019, MaibornWolff GmbH"]
+        footer = ["This program uses the SonarJava, which is licensed under the GNU Lesser General Public Library, version 3.\nCopyright(c) 2020, MaibornWolff GmbH"]
 )
 class SourceCodeParserMain(
         private val outputStream: PrintStream,
@@ -35,9 +35,6 @@ class SourceCodeParserMain(
 
     @Option(names = ["--defaultExcludes"], description = ["exclude build, target, dist and out folders as well as files/folders starting with '.' "])
     private var defaultExcludes = false
-
-    @Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "DefaultProjectName"
 
     @Option(names = ["-f", "--format"], description = ["the format to output"], converter = [(OutputTypeConverter::class)])
     private var outputFormat = OutputFormat.JSON
@@ -78,7 +75,7 @@ class SourceCodeParserMain(
 
     private fun getMetricWriter(): MetricWriter {
         return when (outputFormat) {
-            OutputFormat.JSON -> JSONMetricWriter(projectName, getOutputWriter())
+            OutputFormat.JSON -> JSONMetricWriter(getOutputWriter())
             OutputFormat.TABLE -> CSVMetricWriter(getOutputWriter())
         }
     }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/metricwriters/JSONMetricWriter.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/metricwriters/JSONMetricWriter.kt
@@ -10,8 +10,8 @@ import de.maibornwolff.codecharta.model.ProjectBuilder
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import java.io.Writer
 
-class JSONMetricWriter(private val projectName: String, private val writer: Writer) : MetricWriter {
-  private val projectBuilder = ProjectBuilder(this.projectName)
+class JSONMetricWriter(private val writer: Writer) : MetricWriter {
+  private val projectBuilder = ProjectBuilder()
 
   override fun generate(projectMetrics: ProjectMetrics, allMetrics: Set<String>, pipedProject: Project?) {
 
@@ -19,7 +19,7 @@ class JSONMetricWriter(private val projectName: String, private val writer: Writ
 
     var project = projectBuilder.build()
     if (pipedProject != null) {
-      project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project, projectName)
+      project = MergeFilter.mergePipedWithCurrentProject(pipedProject, project)
     }
     ProjectSerializer.serializeProject(project, writer)
   }

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/e2e/PipedInputStream.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/e2e/PipedInputStream.kt
@@ -33,16 +33,8 @@ class PipedInputStream {
     }
 
     @Test
-    fun `json output does have project name of current project`() {
-        assertThat(output).contains(
-                """"projectName":"DefaultProjectName""""
-        )
-    }
-
-    @Test
     fun `node attributes of piped input and result nodes are merged`() {
         assertThat(output).contains(
-                """"projectName":"DefaultProjectName"""",
                 """"myMetric":42.0""",
                 """"rloc":31"""
         )

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/metricwriters/JSONMetricWriterTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/metricwriters/JSONMetricWriterTest.kt
@@ -15,18 +15,6 @@ import java.io.PrintStream
 class JSONMetricWriterTest {
 
     @Test
-    fun `project name is set correctly`() {
-        val metrics = ProjectMetrics()
-        val result = ByteArrayOutputStream()
-        val projectName = "foo"
-
-        val metricWriter = JSONMetricWriter(projectName, OutputStreamWriter(PrintStream(result)))
-        metricWriter.generate(metrics, setOf())
-
-        Assertions.assertThat(result.toString()).contains("\"projectName\":\"foo\"")
-    }
-
-    @Test
     fun `file hierarchy and names are correct`() {
         val expectedResultFile = File("src/test/resources/jsonMetricHierarchy.json").absoluteFile
         val metrics = ProjectMetrics()
@@ -35,7 +23,7 @@ class JSONMetricWriterTest {
         metrics.addFile("foo3/bar.java")
         val result = ByteArrayOutputStream()
 
-        JSONMetricWriter("", OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
+        JSONMetricWriter(OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
 
         val resultJSON = JSONObject(result.toString()).toString()
 
@@ -54,9 +42,8 @@ class JSONMetricWriterTest {
         metrics.addFileMetricMap("foo.java", fileMetrics1)
         metrics.addFileMetricMap("bar.kt", fileMetrics2)
         val result = ByteArrayOutputStream()
-        val projectName = "foo"
 
-        JSONMetricWriter(projectName, OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
+        JSONMetricWriter(OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
 
         val resultJSON = JSONObject(result.toString()).toString()
 
@@ -74,7 +61,7 @@ class JSONMetricWriterTest {
         metrics.addFileMetricMap("foo.java", fileMetrics)
         val result = ByteArrayOutputStream()
 
-        JSONMetricWriter("project", OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
+        JSONMetricWriter(OutputStreamWriter(PrintStream(result))).generate(metrics, setOf())
 
         val resultJSON = JSONObject(result.toString())
         val leaf = resultJSON.getJSONArray("nodes").getJSONObject(0).getJSONArray("children").getJSONObject(0)

--- a/analysis/import/SourceCodeParser/src/test/resources/jsonMetricValues.json
+++ b/analysis/import/SourceCodeParser/src/test/resources/jsonMetricValues.json
@@ -33,5 +33,5 @@
   "attributeTypes": {},
   "edges": [],
   "blacklist": [],
-  "projectName": "foo"
+  "projectName": ""
 }

--- a/analysis/import/TokeiImporter/README.md
+++ b/analysis/import/TokeiImporter/README.md
@@ -43,8 +43,6 @@ generates cc.json from tokei json
   -h, --help   displays this help and exits
   -o, --outputFile=<outputFile>
                output File (or empty for stdout)
-  -p, --projectName=<projectName>
-               project name
   -r, --rootName=<rootName>
                root folder as specified when executing tokei
 ```

--- a/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/TokeiImporter.kt
+++ b/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/TokeiImporter.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
         name = "tokeiimporter",
         description = ["generates cc.json from tokei json"],
-        footer = ["Copyright(c) 2019, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class TokeiImporter(private val input: InputStream = System.`in`,
                     private val output: PrintStream = System.out,
@@ -28,9 +28,6 @@ class TokeiImporter(private val input: InputStream = System.`in`,
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "TokeiImporter"
 
     @CommandLine.Option(names = ["-r", "--rootName"], description = ["root folder as specified when executing tokei"])
     private var rootName = "."
@@ -47,7 +44,7 @@ class TokeiImporter(private val input: InputStream = System.`in`,
     @Throws(IOException::class)
     override fun call(): Void? {
         print(" ")
-        projectBuilder = ProjectBuilder(projectName)
+        projectBuilder = ProjectBuilder()
         val root = getInput() ?: return null
 
         val languageSummaries = root.asJsonObject.get(TOP_LEVEL_OBJECT).asJsonObject

--- a/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/TokeiImporterTest.kt
+++ b/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/TokeiImporterTest.kt
@@ -12,7 +12,7 @@ class TokeiImporterTest {
     fun `reads tokei from file`() {
         val cliResult = executeForOutput("", arrayOf("src/test/resources/tokei_results.json", "--pathSeparator=\\"))
 
-        Assertions.assertThat(cliResult).contains(listOf("TokeiImporter", "CHANGELOG.md", "\"loc\":450"))
+        Assertions.assertThat(cliResult).contains(listOf("CHANGELOG.md", "\"loc\":450"))
     }
 
     @Test
@@ -21,7 +21,7 @@ class TokeiImporterTest {
 
         val cliResult = executeForOutput(input, arrayOf("--pathSeparator=\\"))
 
-        Assertions.assertThat(cliResult).contains(listOf("TokeiImporter", "CHANGELOG.md", "\"loc\":450"))
+        Assertions.assertThat(cliResult).contains(listOf("CHANGELOG.md", "\"loc\":450"))
     }
 
     @Test
@@ -44,15 +44,7 @@ class TokeiImporterTest {
         val input = File("src/test/resources/tokei_results.json").bufferedReader().readLines().joinToString(separator = "\n") { it }
         val cliResult = executeForOutput(input, arrayOf("-r=/does/not/exist"))
 
-        Assertions.assertThat(cliResult).contains(listOf("TokeiImporter", "CHANGELOG.md", "\"loc\":450"))
-    }
-
-    @Test
-    fun `sets project name`() {
-        val cliResult = executeForOutput("", arrayOf("src/test/resources/tokei_with_root.json", "-p=myProject"))
-
-        val project = ProjectDeserializer.deserializeProject(cliResult)
-        Assertions.assertThat(project.projectName).isEqualTo("myProject")
+        Assertions.assertThat(cliResult).contains(listOf("CHANGELOG.md", "\"loc\":450"))
     }
 
     @Test

--- a/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandCSVHeader.kt
+++ b/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandCSVHeader.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.understand
 
 import mu.KotlinLogging

--- a/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandCSVRow.kt
+++ b/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandCSVRow.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.understand
 
 import de.maibornwolff.codecharta.model.*

--- a/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandImporter.kt
+++ b/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandImporter.kt
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package de.maibornwolff.codecharta.importer.understand
 
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
@@ -35,14 +7,11 @@ import java.io.*
 import java.util.concurrent.Callable
 
 @CommandLine.Command(name = "understandimport", description = ["generates cc.json from SciTools (TM) Understand csv"],
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"])
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"])
 class UnderstandImporter: Callable<Void> {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
-
-    @CommandLine.Option(names = ["-p", "--projectName"], description = ["project name"])
-    private var projectName = "testProject"
 
     @CommandLine.Option(names = ["-o", "--outputFile"], description = ["output File (or empty for stdout)"])
     private var outputFile: File? = null
@@ -57,7 +26,7 @@ class UnderstandImporter: Callable<Void> {
 
     @Throws(IOException::class)
     override fun call(): Void? {
-        val projectBuilder = UnderstandProjectBuilder(projectName, pathSeparator)
+        val projectBuilder = UnderstandProjectBuilder(pathSeparator)
         files.forEach { projectBuilder.parseCSVStream(it.inputStream()) }
         val project = projectBuilder.build()
         ProjectSerializer.serializeProject(project, writer())

--- a/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandProjectBuilder.kt
+++ b/analysis/import/UnderstandImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.understand
 
 import com.univocity.parsers.csv.CsvParser
@@ -43,14 +14,13 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 
 class UnderstandProjectBuilder(
-        projectName: String,
         private val pathSeparator: Char
 ) {
 
     private val logger = KotlinLogging.logger {}
     private val filterRule: (MutableNode) -> Boolean = { it.type == NodeType.File || it.type == NodeType.Folder }
 
-    private val projectBuilder = ProjectBuilder(projectName)
+    private val projectBuilder = ProjectBuilder()
             .withMetricTranslator(understandReplacement)
             .withFilter(filterRule)
 

--- a/analysis/import/UnderstandImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandProjectBuilderTest.kt
+++ b/analysis/import/UnderstandImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/understand/UnderstandProjectBuilderTest.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.importer.understand
 
 import de.maibornwolff.codecharta.model.NodeType
@@ -38,12 +9,12 @@ import org.spekframework.spek2.style.specification.describe
 class UnderstandProjectBuilderTest: Spek({
 
     describe("UnderstandProjectBuilder for Understand") {
-        val understandProjectBuilder = UnderstandProjectBuilder("test", '/')
+        val understandProjectBuilder = UnderstandProjectBuilder('/')
 
 
         context("reading csv lines from Understand") {
             val project = understandProjectBuilder
-                    .parseCSVStream(this.javaClass.classLoader.getResourceAsStream("understand.csv"))
+                    .parseCSVStream(this.javaClass.classLoader.getResourceAsStream("understand.csv")!!)
                     .build()
 
             it("project has number number of files in csv") {
@@ -75,7 +46,7 @@ class UnderstandProjectBuilderTest: Spek({
 
         context("reading csv lines from Understand with LF breaks") {
             val project = understandProjectBuilder
-                    .parseCSVStream(this.javaClass.classLoader.getResourceAsStream("understand_lf.csv"))
+                    .parseCSVStream(this.javaClass.classLoader.getResourceAsStream("understand_lf.csv")!!)
                     .build()
 
             it("project has number number of files in csv") {

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/ProjectBuilder.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/ProjectBuilder.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.model
 
 import de.maibornwolff.codecharta.attributeTypes.AttributeTypes
@@ -34,12 +5,13 @@ import de.maibornwolff.codecharta.translator.MetricNameTranslator
 import mu.KotlinLogging
 
 open class ProjectBuilder(
-        val projectName: String,
         private val nodes: List<MutableNode> = listOf(MutableNode("root", NodeType.Folder)),
         private var edges: MutableList<Edge> = mutableListOf(),
         private var attributeTypes: MutableMap<String, MutableList<Map<String, AttributeType>>> = mutableMapOf(),
         private var blacklist: MutableList<BlacklistItem> = mutableListOf()
 ) {
+
+    val DUMMY_PROJECT_NAME = ""
 
     init {
         if (nodes.size != 1) throw IllegalStateException("No unique root node was found, instead ${nodes.size} candidates identified.")
@@ -53,12 +25,6 @@ open class ProjectBuilder(
     val size: Int
         get() = rootNode.size
 
-    /**
-     * Inserts the node as child of the element at the specified position in the tree.
-     *
-     * @param position absolute path to the parent element of the node that has to be inserted
-     * @param node     that has to be inserted
-     */
     fun insertByPath(position: Path, node: MutableNode): ProjectBuilder {
         rootNode.insertAt(position, node)
         return this
@@ -93,7 +59,7 @@ open class ProjectBuilder(
         filterEmptyFolders()
 
         val project = Project(
-                projectName,
+                DUMMY_PROJECT_NAME,
                 nodes.map { it.toNode() }.toList(),
                 edges = edges.toList(),
                 attributeTypes = attributeTypes.toMap(),
@@ -120,6 +86,6 @@ open class ProjectBuilder(
     }
 
     override fun toString(): String {
-        return "Project{projectName='$projectName', nodes=$nodes, edges=$edges, attributeTypes=$attributeTypes, blacklist=$blacklist}"
+        return "Project{nodes=$nodes, edges=$edges, attributeTypes=$attributeTypes, blacklist=$blacklist}"
     }
 }

--- a/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/model/ProjectBuilderTest.kt
+++ b/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/model/ProjectBuilderTest.kt
@@ -38,7 +38,7 @@ import org.spekframework.spek2.style.specification.describe
 class ProjectBuilderTest: Spek({
 
     describe("ProjectBuilder without root node") {
-        val projectBuilder = ProjectBuilder("someName")
+        val projectBuilder = ProjectBuilder()
 
         context("inserting new node") {
             val nodeForInsertion = MutableNode("someNode", NodeType.File)
@@ -54,7 +54,7 @@ class ProjectBuilderTest: Spek({
 
     describe("ProjectBuilder with root node") {
         val root = MutableNode("root", NodeType.Folder)
-        val projectBuilder = ProjectBuilder("someName", listOf(root))
+        val projectBuilder = ProjectBuilder(listOf(root))
 
         context("inserting new node") {
             val nodeForInsertion = MutableNode("someNode", NodeType.File)
@@ -70,7 +70,7 @@ class ProjectBuilderTest: Spek({
     }
 
     describe("ProjectBuilder with empty folders") {
-        val projectBuilder = ProjectBuilder("someName")
+        val projectBuilder = ProjectBuilder()
         val nodeForInsertion = MutableNode("someNode", NodeType.Folder)
         projectBuilder.insertByPath(Path.trivialPath(), nodeForInsertion)
 

--- a/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/model/ProjectMatcher.kt
+++ b/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/model/ProjectMatcher.kt
@@ -63,7 +63,6 @@ object ProjectMatcher {
 
     fun matchUpToVersion(p1: Project, p2: Project): Boolean {
         return NodeMatcher.match(p1.rootNode, p2.rootNode)
-               && p1.projectName == p2.projectName
                && match(p1.edges, p2.edges)
     }
 

--- a/analysis/test/golden_test.sh
+++ b/analysis/test/golden_test.sh
@@ -107,9 +107,9 @@ check_tokei() {
 check_pipe() {
    echo " -- expect pipes to work"
    sh "${CCSH}" tokeiimporter data/codecharta/tokei_results.json --pathSeparator \\ \
-        | sh "${CCSH}" sourcecodeparser data/codecharta/ -p projectName1 \
+        | sh "${CCSH}" sourcecodeparser data/codecharta/ \
         | sh "${CCSH}" scmlogparser --svn data/codecharta/SVNTestLog.txt \
-        | sh "${CCSH}" modify --moveFrom=root/src --moveTo=root/bar -n projectName2 \
+        | sh "${CCSH}" modify --moveFrom=root/src --moveTo=root/bar \
             -o ${INSTALL_DIR}/piped_out.json 2> ${INSTALL_DIR}/piped_out_log.json
     validate ${INSTALL_DIR}/piped_out.json
     if ! grep -q "Created Project with 9 leaves." ${INSTALL_DIR}/piped_out_log.json; then

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -70,7 +70,7 @@ class Ccsh: Callable<Void?> {
             return arrayOf(
                     Ccsh::class.java.`package`.implementationTitle + "\n"
                     + "version \"" + Ccsh::class.java.`package`.implementationVersion + "\"\n"
-                    + "Copyright(c) 2018, MaibornWolff GmbH"
+                            + "Copyright(c) 2020, MaibornWolff GmbH"
             )
         }
     }

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2018, MaibornWolff GmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *  * Neither the name of  nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific
- *    prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 package de.maibornwolff.codecharta.tools.ccsh
 
 import de.maibornwolff.codecharta.exporter.csv.CSVExporter
@@ -69,7 +40,7 @@ import java.util.concurrent.Callable
             TokeiImporter::class
         ],
         versionProvider = Ccsh.ManifestVersionProvider::class,
-        footer = ["Copyright(c) 2018, MaibornWolff GmbH"]
+        footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
 class Ccsh: Callable<Void?> {
 


### PR DESCRIPTION
# Feature/773/remove project name

closes #771, #773

## Description

- Removed projectName; it is no longer necesarry or possible to specify a project name. Yet, in order not to cause a breaking change in the .cc.json schema, all projects are now generated with an emty string as project name. **However: the APIs for the ccsh tools obviously change**
- Years in Copyright notices in ccsh

**This PR does not yet address the kebab-case vs camelCase command line parameters**

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
