### PR TITLE
Feature/767/edges in demo part two

### DIFF
--- a/script/build_gh_pages.sh
+++ b/script/build_gh_pages.sh
@@ -7,10 +7,6 @@ cp -R visualization/dist/webpack/ gh-pages/visualization/app/
 
 analysis/gradlew -p analysis/ installDist
 
-# old demo file
-analysis/build/install/codecharta-analysis/bin/ccsh sonarimport -o gh-pages/visualization/app/codecharta.cc.json https://sonarcloud.io de.maibornwolff.codecharta:visualization
-
-# new demo file with edges
 mkdir gh-pages/demo_files
 cd gh-pages/demo_files
 CCSH=../../analysis/build/install/codecharta-analysis/bin/ccsh
@@ -22,7 +18,7 @@ $CCSH modify --setRoot /root/visualization -o codecharta_git_mod.cc.json codecha
 $CCSH sonarimport -o codecharta_sonar.cc.json https://sonarcloud.io de.maibornwolff.codecharta:visualization
 $CCSH modify --setRoot /root/de.maibornwolff.codecharta/visualization -o codecharta_sonar_mod.cc.json codecharta_sonar.cc.json
 
-$CCSH merge -o ../visualization/app/codecharta_with_edges.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json
+$CCSH merge -o ../visualization/app/codecharta.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json
 
 cd ../..
 rm -r gh-pages/demo_files

--- a/script/build_gh_pages.sh
+++ b/script/build_gh_pages.sh
@@ -13,12 +13,21 @@ CCSH=../../analysis/build/install/codecharta-analysis/bin/ccsh
 
 git log --numstat --raw --topo-order > git.log
 $CCSH scmlogparser -o codecharta_git.cc.json --input-format GIT_LOG_NUMSTAT_RAW git.log
-$CCSH modify --setRoot /root/visualization -o codecharta_git_mod.cc.json codecharta_git.cc.json
+
+# Map for visualization
+$CCSH modify --setRoot root/visualization -o codecharta_git_mod.cc.json codecharta_git.cc.json
 
 $CCSH sonarimport -o codecharta_sonar.cc.json https://sonarcloud.io de.maibornwolff.codecharta:visualization
-$CCSH modify --setRoot /root/de.maibornwolff.codecharta/visualization -o codecharta_sonar_mod.cc.json codecharta_sonar.cc.json
+$CCSH modify --setRoot root/de.maibornwolff.codecharta/visualization -o codecharta_sonar_mod.cc.json codecharta_sonar.cc.json
 
 $CCSH merge -o ../visualization/app/codecharta.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json
+
+# Map for analysis
+$CCSH sonarimport -o codecharta_sonar_analysis.cc.json https://sonarcloud.io de.maibornwolff.codecharta:analysis
+$CCSH modify --setRoot root/de.maibornwolff.codecharta/analysis -o codecharta_sonar_mod.cc.json codecharta_sonar_analysis.cc.json
+$CCSH modify --setRoot root/analysis -o codecharta_git_mod.cc.json codecharta_git.cc.json
+$CCSH merge -o ../visualization/app/codecharta_analysis.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json
+
 
 cd ../..
 rm -r gh-pages/demo_files


### PR DESCRIPTION
# Feature/767/edges in demo part two

## Description

- Replaces the generated map `codecharta.cc.json` with the content of `codecharta_with_edges.cc.json`
- This means the demo will show the map with edges as `codecharta.cc.json`
- The gh-pages demo will be updated with the next release

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
