### PR TITLE
Tech/Fix plop generator

### DIFF
--- a/visualization/plopfile.js
+++ b/visualization/plopfile.js
@@ -183,14 +183,14 @@ module.exports = function(plop) {
 				type: "modify",
 				path: "app/codeCharta/state/store/{{camelCase subreducer}}/{{camelCase subreducer}}.splitter.ts",
 				pattern: /(\/\/ Plop: Append action splitter import here)/gi,
-				template: '$1\r\n\t import { split{{properCase name}}Action } from "./{{camelCase name}}/{{camelCase name}}.splitter"}'
+				template: '$1\r\nimport { split{{properCase name}}Action } from "./{{camelCase name}}/{{camelCase name}}.splitter"'
 			},
 			{
 				type: "modify",
 				path: "app/codeCharta/state/store/{{camelCase subreducer}}/{{camelCase subreducer}}.splitter.ts",
 				pattern: /(\/\/ Plop: Append action split here)/gi,
 				template:
-					"$1\r\n\t\tif (payload.{{camelCase name}} !== undefined) {\n\t\t\t\t\tactions.push(split{{properCase name}}Action(payload.{{camelCase name}}))\n\n\t\t}\n"
+					"$1\r\n\tif (payload.{{camelCase name}} !== undefined) {\n\t\tactions.push(split{{properCase name}}Action(payload.{{camelCase name}}))\n\t}\n"
 			},
 			{
 				type: "modify",


### PR DESCRIPTION
# Tech/Fix plop generator

## Description

- Fix plop generator for modifying the `<subreducer>.splitter` file
  - Indentations
  - Wrong `}` character

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
