### PR TITLE
Bug/845/gc limit scmlog analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- GC Overhead Limit (OutOfMemory Exception) during analysis of large SCMLogs fixed #845
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.42.0] - 2020-01-31

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
@@ -21,6 +21,7 @@ class ProjectConverter(private val containsAuthors: Boolean) {
                 versionControlledFile.actualFilename.substringBeforeLast(PATH_SEPARATOR, ""))
         projectBuilder.insertByPath(path, newNode)
         edges.forEach { projectBuilder.insertEdge(addRootToEdgePaths(it)) }
+        versionControlledFile.freeMemory()
     }
 
     private fun extractAttributes(versionControlledFile: VersionControlledFile): Map<String, Any> {

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/converter/ProjectConverter.kt
@@ -21,7 +21,7 @@ class ProjectConverter(private val containsAuthors: Boolean) {
                 versionControlledFile.actualFilename.substringBeforeLast(PATH_SEPARATOR, ""))
         projectBuilder.insertByPath(path, newNode)
         edges.forEach { projectBuilder.insertEdge(addRootToEdgePaths(it)) }
-        versionControlledFile.freeMemory()
+        versionControlledFile.removeMetricsToFreeMemory()
     }
 
     private fun extractAttributes(versionControlledFile: VersionControlledFile): Map<String, Any> {

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
@@ -86,7 +86,7 @@ class VersionControlledFile internal constructor(
         return metrics.first { it.metricName() == metricName }.value()
     }
 
-    fun freeMemory() {
+    fun removeMetricsToFreeMemory() {
         metrics = listOf()
     }
 }

--- a/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
+++ b/analysis/import/SCMLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/scmlogparser/input/VersionControlledFile.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 class VersionControlledFile internal constructor(
         filename: String,
-        private val metrics: List<Metric>
+        private var metrics: List<Metric>
 ) {
 
     // actual filename
@@ -84,5 +84,9 @@ class VersionControlledFile internal constructor(
 
     fun getMetricValue(metricName: String): Number {
         return metrics.first { it.metricName() == metricName }.value()
+    }
+
+    fun freeMemory() {
+        metrics = listOf()
     }
 }


### PR DESCRIPTION
# Bug/845/gc limit scmlog analysis

closes #845

## Description

- Free memory during analysis of SCMLogs (remove Metric objects after they are not needed anymore)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
