### PR TITLE
Tech/node type as enum

### DIFF
--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -46,7 +46,7 @@ export interface CCFile {
 
 export interface CodeMapNode {
 	name: string
-	type: string
+	type: NodeType
 	children?: CodeMapNode[]
 	attributes: KeyValuePair
 	edgeAttributes?: {
@@ -58,6 +58,11 @@ export interface CodeMapNode {
 	deltas?: {
 		[key: string]: number
 	}
+}
+
+export enum NodeType {
+	FILE = "File",
+	FOLDER = "Folder"
 }
 
 export interface FileMeta {

--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -4,7 +4,7 @@ import { CodeChartaService } from "./codeCharta.service"
 import { getService, instantiateModule } from "../../mocks/ng.mockhelper"
 import { FileStateService } from "./state/fileState.service"
 import { TEST_FILE_CONTENT } from "./util/dataMocks"
-import { CCFile, BlacklistType } from "./codeCharta.model"
+import { CCFile, BlacklistType, NodeType } from "./codeCharta.model"
 import _ from "lodash"
 
 describe("codeChartaService", () => {
@@ -38,7 +38,7 @@ describe("codeChartaService", () => {
 						link: "http://www.google.de",
 						name: "big leaf",
 						path: "/root/big leaf",
-						type: "File"
+						type: NodeType.FILE
 					},
 					{
 						attributes: {},
@@ -47,23 +47,23 @@ describe("codeChartaService", () => {
 								attributes: { functions: 100, mcc: 100, rloc: 30 },
 								name: "small leaf",
 								path: "/root/Parent Leaf/small leaf",
-								type: "File"
+								type: NodeType.FILE
 							},
 							{
 								attributes: { functions: 1000, mcc: 10, rloc: 70 },
 								name: "other small leaf",
 								path: "/root/Parent Leaf/other small leaf",
-								type: "File"
+								type: NodeType.FILE
 							}
 						],
 						name: "Parent Leaf",
 						path: "/root/Parent Leaf",
-						type: "Folder"
+						type: NodeType.FOLDER
 					}
 				],
 				name: "root",
 				path: "/root",
-				type: "Folder"
+				type: NodeType.FOLDER
 			},
 			settings: { fileSettings: { attributeTypes: { nodes: [], edges: [] }, blacklist: [], edges: [], markedPackages: [] } }
 		}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
@@ -6,6 +6,7 @@ import { IRootScopeService, ITimeoutService } from "angular"
 import { NodeContextMenuController } from "../nodeContextMenu/nodeContextMenu.component"
 import { AttributeSideBarService, AttributeSideBarVisibilitySubscriber } from "../attributeSideBar/attributeSideBar.service"
 import { IsLoadingFileService, IsLoadingFileSubscriber } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.service"
+import { NodeType } from "../../codeCharta.model"
 
 export class CodeMapController
 	implements BuildingRightClickedEventSubscriber, AttributeSideBarVisibilitySubscriber, IsLoadingFileSubscriber {
@@ -39,7 +40,7 @@ export class CodeMapController
 	public onBuildingRightClicked(building: CodeMapBuilding, x: number, y: number) {
 		NodeContextMenuController.broadcastHideEvent(this.$rootScope)
 		if (building) {
-			const nodeType = building.node.isLeaf ? "File" : "Folder"
+			const nodeType = building.node.isLeaf ? NodeType.FILE : NodeType.FOLDER
 			NodeContextMenuController.broadcastShowEvent(this.$rootScope, building.node.path, nodeType, x, y)
 		}
 	}

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../../util/dataMocks"
 import { FileExtensionCalculator, MetricDistribution } from "../../util/fileExtensionCalculator"
 import { FileExtensionBarController } from "./fileExtensionBar.component"
-import { BlacklistType } from "../../codeCharta.model"
+import { BlacklistType, NodeType } from "../../codeCharta.model"
 import { StoreService } from "../../state/store.service"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
@@ -154,7 +154,7 @@ describe("FileExtensionBarController", () => {
 			const map = _.cloneDeep(VALID_NODE_WITH_PATH_AND_EXTENSION)
 			map.children.push({
 				name: "README.md",
-				type: "File",
+				type: NodeType.FILE,
 				path: "/root/README.md",
 				attributes: { rloc: 120, functions: 20, mcc: 2 }
 			})

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
@@ -5,7 +5,7 @@ import { CodeMapHelper } from "../../util/codeMapHelper"
 import { IRootScopeService } from "angular"
 import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
-import { CodeMapNode, BlacklistType, MarkedPackage } from "../../codeCharta.model"
+import { CodeMapNode, BlacklistType, MarkedPackage, NodeType } from "../../codeCharta.model"
 import {
 	VALID_NODE_WITH_PATH,
 	CODE_MAP_BUILDING,
@@ -98,7 +98,7 @@ describe("MapTreeViewLevelController", () => {
 
 	describe("getMarkingColor", () => {
 		it("should return black color if no folder", () => {
-			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: "File" } as CodeMapNode
+			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: NodeType.FILE } as CodeMapNode
 
 			const result = mapTreeViewLevelController.getMarkingColor()
 
@@ -106,7 +106,7 @@ describe("MapTreeViewLevelController", () => {
 		})
 
 		it("should return the markingColor if the matching markedPackage", () => {
-			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: "Folder" } as CodeMapNode
+			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: NodeType.FOLDER } as CodeMapNode
 			const markedMackages = [
 				{
 					path: "/root/node/path",
@@ -121,7 +121,7 @@ describe("MapTreeViewLevelController", () => {
 		})
 
 		it("should return black if no markingColor in node", () => {
-			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: "Folder" } as CodeMapNode
+			mapTreeViewLevelController["node"] = { path: "/root/node/path", type: NodeType.FOLDER } as CodeMapNode
 			storeService.dispatch(setMarkedPackages([]))
 
 			const result = mapTreeViewLevelController.getMarkingColor()
@@ -148,7 +148,11 @@ describe("MapTreeViewLevelController", () => {
 
 	describe("onRightClick", () => {
 		it("should broadcast node context menu events", () => {
-			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "Folder", VALID_NODE_WITH_PATH)
+			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
+				"/root/Parent Leaf",
+				NodeType.FOLDER,
+				VALID_NODE_WITH_PATH
+			)
 			let context = {
 				path: mapTreeViewLevelController["node"].path,
 				type: mapTreeViewLevelController["node"].type,
@@ -192,7 +196,11 @@ describe("MapTreeViewLevelController", () => {
 
 	describe("onEyeClick", () => {
 		beforeEach(() => {
-			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "Folder", VALID_NODE_WITH_PATH)
+			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
+				"/root/Parent Leaf",
+				NodeType.FOLDER,
+				VALID_NODE_WITH_PATH
+			)
 		})
 
 		it("should add flattened blacklistItem", () => {
@@ -224,7 +232,7 @@ describe("MapTreeViewLevelController", () => {
 		it("should be a leaf", () => {
 			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
 				"/root/Parent Leaf/small leaf",
-				"File",
+				NodeType.FILE,
 				VALID_NODE_WITH_PATH
 			)
 
@@ -232,7 +240,11 @@ describe("MapTreeViewLevelController", () => {
 		})
 
 		it("should not be a leaf", () => {
-			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "Folder", VALID_NODE_WITH_PATH)
+			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
+				"/root/Parent Leaf",
+				NodeType.FOLDER,
+				VALID_NODE_WITH_PATH
+			)
 
 			const result = mapTreeViewLevelController.isLeaf(mapTreeViewLevelController["node"])
 
@@ -246,7 +258,7 @@ describe("MapTreeViewLevelController", () => {
 
 			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
 				"/root/Parent Leaf/empty folder",
-				"Folder",
+				NodeType.FOLDER,
 				VALID_NODE_WITH_PATH
 			)
 
@@ -272,7 +284,7 @@ describe("MapTreeViewLevelController", () => {
 		it("should be searched", () => {
 			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
 				"/root/Parent Leaf/empty folder",
-				"Folder",
+				NodeType.FOLDER,
 				VALID_NODE_WITH_PATH
 			)
 			storeService.dispatch(setSearchedNodePaths(["/root/Parent Leaf/", "/root/Parent Leaf/empty folder"]))
@@ -285,7 +297,7 @@ describe("MapTreeViewLevelController", () => {
 		it("should not be searched", () => {
 			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
 				"/root/Parent Leaf/empty folder",
-				"Folder",
+				NodeType.FOLDER,
 				VALID_NODE_WITH_PATH
 			)
 			storeService.dispatch(setSearchedNodePaths(["/root/Parent Leaf"]))
@@ -306,7 +318,7 @@ describe("MapTreeViewLevelController", () => {
 		it("should sort leaf", () => {
 			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
 				"/root/Parent Leaf/small leaf",
-				"File",
+				NodeType.FILE,
 				VALID_NODE_WITH_PATH
 			)
 
@@ -316,7 +328,11 @@ describe("MapTreeViewLevelController", () => {
 		})
 
 		it("should sort folder", () => {
-			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "Folder", VALID_NODE_WITH_PATH)
+			mapTreeViewLevelController["node"] = CodeMapHelper.getCodeMapNodeFromPath(
+				"/root/Parent Leaf",
+				NodeType.FOLDER,
+				VALID_NODE_WITH_PATH
+			)
 
 			const result = mapTreeViewLevelController.sortByFolder(mapTreeViewLevelController["node"])
 

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
@@ -9,7 +9,7 @@ import { TEST_DELTA_MAP_A, VALID_NODE_WITH_PATH, withMockedEventMethods } from "
 import { CodeMapPreRenderService } from "../codeMap/codeMap.preRender.service"
 import { StoreService } from "../../state/store.service"
 import { setMarkedPackages } from "../../state/store/fileSettings/markedPackages/markedPackages.actions"
-import { BlacklistType, MarkedPackage } from "../../codeCharta.model"
+import { BlacklistType, MarkedPackage, NodeType } from "../../codeCharta.model"
 import { addBlacklistItem, setBlacklist } from "../../state/store/fileSettings/blacklist/blacklist.actions"
 
 describe("nodeContextMenuController", () => {
@@ -152,9 +152,9 @@ describe("nodeContextMenuController", () => {
 
 		it("should set the correct building after some timeout", () => {
 			const path = "/root"
-			const nodeType = "Folder"
+			const nodeType = NodeType.FOLDER
 
-			nodeContextMenuController.onShowNodeContextMenu("/root", "Folder", 42, 24)
+			nodeContextMenuController.onShowNodeContextMenu("/root", NodeType.FOLDER, 42, 24)
 			$timeout.flush(100)
 			expect(nodeContextMenuController["_viewModel"].contextMenuBuilding).toEqual(TEST_DELTA_MAP_A.map)
 			expect(CodeMapHelper.getCodeMapNodeFromPath).toHaveBeenCalledWith(path, nodeType, TEST_DELTA_MAP_A.map)

--- a/visualization/app/codeCharta/util/aggregationGenerator.spec.ts
+++ b/visualization/app/codeCharta/util/aggregationGenerator.spec.ts
@@ -1,4 +1,4 @@
-import { CCFile, Settings } from "../codeCharta.model"
+import { CCFile, NodeType, Settings } from "../codeCharta.model"
 import { AggregationGenerator } from "./aggregationGenerator"
 
 describe("AggregationGenerator", () => {
@@ -10,26 +10,26 @@ describe("AggregationGenerator", () => {
 		},
 		map: {
 			name: "root",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			path: "/root",
 			attributes: { rloc: 170, functions: 1010, mcc: 11 },
 			children: [
 				{
 					name: "big leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/big leaf",
 					attributes: { rloc: 100, functions: 10, mcc: 1 },
 					link: "http://www.google.de"
 				},
 				{
 					name: "Parent Leaf",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					path: "/root/Parent Leaf",
 					attributes: { rloc: 70, functions: 1000, mcc: 10 },
 					children: [
 						{
 							name: "other small leaf",
-							type: "File",
+							type: NodeType.FILE,
 							path: "/root/Parent Leaf/other small leaf",
 							attributes: { rloc: 70, functions: 1000, mcc: 10 }
 						}
@@ -48,26 +48,26 @@ describe("AggregationGenerator", () => {
 		},
 		map: {
 			name: "root",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			path: "/root",
 			attributes: { rloc: 260, functions: 220, mcc: 202, customMetric: 7 },
 			children: [
 				{
 					name: "big leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/big leaf",
 					attributes: { rloc: 200, functions: 20, mcc: 2 },
 					link: "http://www.google.de"
 				},
 				{
 					name: "Parent Leaf",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					path: "/root/Parent Leaf",
 					attributes: { rloc: 60, functions: 200, mcc: 200 },
 					children: [
 						{
 							name: "small leaf",
-							type: "File",
+							type: NodeType.FILE,
 							path: "/root/Parent Leaf/small leaf",
 							attributes: { rloc: 60, functions: 200, mcc: 200 }
 						}

--- a/visualization/app/codeCharta/util/aggregationGenerator.ts
+++ b/visualization/app/codeCharta/util/aggregationGenerator.ts
@@ -1,4 +1,4 @@
-import { CodeMapNode, CCFile } from "../codeCharta.model"
+import { CodeMapNode, CCFile, NodeType } from "../codeCharta.model"
 import { CodeChartaService } from "../codeCharta.service"
 import { FileNameHelper } from "./fileNameHelper"
 import { getUpdatedPath } from "./nodePathHelper"
@@ -30,7 +30,7 @@ export class AggregationGenerator {
 			},
 			map: {
 				name: CodeChartaService.ROOT_NAME,
-				type: "Folder",
+				type: NodeType.FOLDER,
 				children: [],
 				attributes: {},
 				path: CodeChartaService.ROOT_PATH,

--- a/visualization/app/codeCharta/util/codeMapHelper.spec.ts
+++ b/visualization/app/codeCharta/util/codeMapHelper.spec.ts
@@ -1,5 +1,5 @@
 import { CodeMapHelper } from "./codeMapHelper"
-import { BlacklistItem, BlacklistType, CodeMapNode, MarkedPackage } from "../codeCharta.model"
+import { BlacklistItem, BlacklistType, CodeMapNode, MarkedPackage, NodeType } from "../codeCharta.model"
 import { instantiateModule } from "../../../mocks/ng.mockhelper"
 import { TEST_FILE_WITH_PATHS, VALID_NODE_WITH_PATH_AND_EXTENSION } from "./dataMocks"
 
@@ -33,7 +33,7 @@ describe("codeMapHelper", () => {
 		it("should return the root if path matches path of root", () => {
 			const expected = testRoot
 
-			const result = CodeMapHelper.getCodeMapNodeFromPath("/root", "Folder", testRoot)
+			const result = CodeMapHelper.getCodeMapNodeFromPath("/root", NodeType.FOLDER, testRoot)
 
 			expect(result).toEqual(expected)
 		})
@@ -41,19 +41,19 @@ describe("codeMapHelper", () => {
 		it("should return the node that matches path and type", () => {
 			const expected = testRoot.children[1]
 
-			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "Folder", testRoot)
+			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", NodeType.FOLDER, testRoot)
 
 			expect(result).toEqual(expected)
 		})
 
 		it("should return null if no node matches path and type", () => {
-			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Uncle Leaf", "Folder", testRoot)
+			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Uncle Leaf", NodeType.FOLDER, testRoot)
 
 			expect(result).toBeNull()
 		})
 
 		it("should return null if a node only matches path", () => {
-			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", "File", testRoot)
+			const result = CodeMapHelper.getCodeMapNodeFromPath("/root/Parent Leaf", NodeType.FILE, testRoot)
 
 			expect(result).toBeNull()
 		})
@@ -65,7 +65,7 @@ describe("codeMapHelper", () => {
 
 			CodeMapHelper.getAnyCodeMapNodeFromPath("/root", testRoot)
 
-			expect(CodeMapHelper.getCodeMapNodeFromPath).toHaveBeenCalledWith("/root", "File", testRoot)
+			expect(CodeMapHelper.getCodeMapNodeFromPath).toHaveBeenCalledWith("/root", NodeType.FILE, testRoot)
 		})
 
 		it("should call getCodeMapNodeFromPath with type Folder when no file was found and return null", () => {
@@ -73,7 +73,7 @@ describe("codeMapHelper", () => {
 
 			const result = CodeMapHelper.getAnyCodeMapNodeFromPath("/root", testRoot)
 
-			expect(CodeMapHelper.getCodeMapNodeFromPath).toHaveBeenCalledWith("/root", "Folder", testRoot)
+			expect(CodeMapHelper.getCodeMapNodeFromPath).toHaveBeenCalledWith("/root", NodeType.FOLDER, testRoot)
 			expect(result).toBeNull()
 		})
 

--- a/visualization/app/codeCharta/util/codeMapHelper.ts
+++ b/visualization/app/codeCharta/util/codeMapHelper.ts
@@ -1,13 +1,13 @@
 import { hierarchy } from "d3-hierarchy"
-import { MarkedPackage } from "../codeCharta.model"
+import { MarkedPackage, NodeType } from "../codeCharta.model"
 import ignore from "ignore"
 import { CodeMapNode, BlacklistItem, BlacklistType } from "../codeCharta.model"
 
 export class CodeMapHelper {
 	public static getAnyCodeMapNodeFromPath(path: string, root: CodeMapNode): CodeMapNode {
-		const firstTryNode = this.getCodeMapNodeFromPath(path, "File", root)
+		const firstTryNode = this.getCodeMapNodeFromPath(path, NodeType.FILE, root)
 		if (!firstTryNode) {
-			return this.getCodeMapNodeFromPath(path, "Folder", root)
+			return this.getCodeMapNodeFromPath(path, NodeType.FOLDER, root)
 		}
 		return firstTryNode
 	}

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -9,7 +9,8 @@ import {
 	Node,
 	BlacklistType,
 	EdgeVisibility,
-	State
+	State,
+	NodeType
 } from "../codeCharta.model"
 import { CodeMapBuilding } from "../ui/codeMap/rendering/codeMapBuilding"
 import { MetricDistribution } from "./fileExtensionCalculator"
@@ -20,27 +21,27 @@ import { IRootScopeService } from "angular"
 export const VALID_NODE: CodeMapNode = {
 	name: "root",
 	attributes: {},
-	type: "Folder",
+	type: NodeType.FOLDER,
 	children: [
 		{
 			name: "big leaf",
-			type: "File",
+			type: NodeType.FILE,
 			attributes: { rloc: 100, functions: 10, mcc: 1 },
 			link: "http://www.google.de"
 		},
 		{
 			name: "Parent Leaf",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			children: [
 				{
 					name: "small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					attributes: { rloc: 30, functions: 100, mcc: 100 }
 				},
 				{
 					name: "other small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					attributes: { rloc: 70, functions: 1000, mcc: 10 }
 				}
 			]
@@ -51,37 +52,37 @@ export const VALID_NODE: CodeMapNode = {
 export const VALID_NODE_WITH_PATH: CodeMapNode = {
 	name: "root",
 	attributes: {},
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "big leaf",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/big leaf",
 			attributes: { rloc: 100, functions: 10, mcc: 1 },
 			link: "http://www.google.de"
 		},
 		{
 			name: "Parent Leaf",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			path: "/root/Parent Leaf",
 			children: [
 				{
 					name: "small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/small leaf",
 					attributes: { rloc: 30, functions: 100, mcc: 100 }
 				},
 				{
 					name: "other small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/other small leaf",
 					attributes: { rloc: 70, functions: 1000, mcc: 10 }
 				},
 				{
 					name: "empty folder",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					path: "/root/Parent Leaf/empty folder",
 					attributes: {},
 					children: []
@@ -94,18 +95,18 @@ export const VALID_NODE_WITH_PATH: CodeMapNode = {
 export const VALID_NODE_WITH_ROOT_UNARY: CodeMapNode = {
 	name: "root",
 	attributes: { unary: 200 },
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "first leaf",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/first leaf",
 			attributes: { unary: 100, functions: 10, mcc: 1 }
 		},
 		{
 			name: "second leaf",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/second leaf",
 			attributes: { unary: 100, functions: 5, mcc: 1 }
 		}
@@ -115,31 +116,31 @@ export const VALID_NODE_WITH_ROOT_UNARY: CodeMapNode = {
 export const VALID_NODE_DECORATED: CodeMapNode = {
 	name: "root",
 	attributes: { rloc: 100, functions: 10, mcc: 1, unary: 5 },
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "big leaf",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/big leaf",
 			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
 			link: "http://www.google.de"
 		},
 		{
 			name: "Parent Leaf",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
 			path: "/root/Parent Leaf",
 			children: [
 				{
 					name: "small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/small leaf",
 					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
 				},
 				{
 					name: "other small leaf",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/other small leaf",
 					attributes: { rloc: 70, functions: 1000, mcc: 10, unary: 1 },
 					edgeAttributes: { Imports: { incoming: 12, outgoing: 13 } },
@@ -152,7 +153,7 @@ export const VALID_NODE_DECORATED: CodeMapNode = {
 
 export const VALID_NODE_WITH_METRICS: CodeMapNode = {
 	name: "root",
-	type: "Folder",
+	type: NodeType.FOLDER,
 	attributes: { rloc: 100, functions: 10, mcc: 1 }
 }
 
@@ -243,38 +244,38 @@ export const TEST_FILE_WITH_PATHS: CCFile = {
 	fileMeta: FILE_META,
 	map: {
 		name: "root",
-		type: "Folder",
+		type: NodeType.FOLDER,
 		path: "/root",
 		attributes: {},
 		children: [
 			{
 				name: "big leaf",
-				type: "File",
+				type: NodeType.FILE,
 				path: "/root/big leaf",
 				attributes: { rloc: 100, functions: 10, mcc: 1 },
 				link: "http://www.google.de"
 			},
 			{
 				name: "Parent Leaf",
-				type: "Folder",
+				type: NodeType.FOLDER,
 				attributes: {},
 				path: "/root/Parent Leaf",
 				children: [
 					{
 						name: "small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						path: "/root/Parent Leaf/small leaf",
 						attributes: { rloc: 30, functions: 100, mcc: 100 }
 					},
 					{
 						name: "other small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						path: "/root/Parent Leaf/other small leaf",
 						attributes: { rloc: 70, functions: 1000, mcc: 10 }
 					},
 					{
 						name: "empty folder",
-						type: "Folder",
+						type: NodeType.FOLDER,
 						path: "/root/Parent Leaf/empty folder",
 						attributes: {},
 						children: []
@@ -314,49 +315,49 @@ export const NONE_METRIC_DISTRIBUTION: MetricDistribution[] = [
 export const VALID_NODE_WITH_PATH_AND_EXTENSION: CodeMapNode = {
 	name: "root",
 	attributes: {},
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "big leaf.jpg",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/big leaf.jpg",
 			attributes: { rloc: 100, functions: 10, mcc: 1 }
 		},
 		{
 			name: "another big leaf.java",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/another big leaf.java",
 			attributes: { rloc: 120, functions: 20, mcc: 2 }
 		},
 		{
 			name: "Parent Leaf",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			path: "/root/Parent Leaf",
 			children: [
 				{
 					name: "small leaf.jpg",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/small leaf.json",
 					attributes: { rloc: 30, functions: 100, mcc: 100 }
 				},
 				{
 					name: "other small leaf.json",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/other small leaf.json",
 					attributes: { rloc: 70, functions: 1000, mcc: 10 }
 				},
 				{
 					name: "another leaf.java",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/another leaf.java",
 					attributes: { rloc: 42, functions: 330, mcc: 45 },
 					children: []
 				},
 				{
 					name: "leaf without extension",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/leaf without extension",
 					attributes: { rloc: 15, functions: 23, mcc: 33 },
 					children: []
@@ -370,40 +371,40 @@ export const VALID_NODE_WITH_PATH_AND_DELTAS: CodeMapNode = {
 	name: "root",
 	attributes: {},
 	deltas: {},
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "big leaf.jpg",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/big leaf.jpg",
 			attributes: { rloc: 100, functions: 10, mcc: 1 },
 			deltas: { rloc: 300, functions: -15, mcc: 12 }
 		},
 		{
 			name: "another big leaf.java",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/another big leaf.java",
 			attributes: { rloc: 120, functions: 20, mcc: 2 },
 			deltas: { rloc: -150, functions: 9, mcc: 33 }
 		},
 		{
 			name: "Parent Leaf",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			deltas: {},
 			path: "/root/Parent Leaf",
 			children: [
 				{
 					name: "small leaf.jpg",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/small leaf.json",
 					attributes: { rloc: 30, functions: 100, mcc: 100 },
 					deltas: { rloc: -55, functions: 38, mcc: -40 }
 				},
 				{
 					name: "other small leaf.json",
-					type: "File",
+					type: NodeType.FILE,
 					path: "/root/Parent Leaf/other small leaf.json",
 					attributes: { rloc: 70, functions: 1000, mcc: 10 },
 					deltas: { rloc: 200, functions: -27, mcc: 65 }
@@ -416,18 +417,18 @@ export const VALID_NODE_WITH_PATH_AND_DELTAS: CodeMapNode = {
 export const VALID_NODE_WITHOUT_RLOC_METRIC: CodeMapNode = {
 	name: "root",
 	attributes: {},
-	type: "Folder",
+	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
 		{
 			name: "big leaf.jpg",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/big leaf.jpg",
 			attributes: { rloc: 0, functions: 10, mcc: 1 }
 		},
 		{
 			name: "another big leaf.java",
-			type: "File",
+			type: NodeType.FILE,
 			path: "/root/another big leaf.java",
 			attributes: { rloc: 0, functions: 20, mcc: 2 }
 		}
@@ -442,28 +443,28 @@ export const TEST_DELTA_MAP_A: CCFile = {
 	},
 	map: {
 		name: "root",
-		type: "Folder",
+		type: NodeType.FOLDER,
 		attributes: {},
 		children: [
 			{
 				name: "big leaf",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: { rloc: 100, functions: 10, mcc: 1 },
 				link: "http://www.google.de"
 			},
 			{
 				name: "Parent Leaf",
-				type: "Folder",
+				type: NodeType.FOLDER,
 				attributes: {},
 				children: [
 					{
 						name: "small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						attributes: { rloc: 30, functions: 100, mcc: 100 }
 					},
 					{
 						name: "other small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						attributes: { rloc: 70, functions: 1000, mcc: 10 }
 					}
 				]
@@ -488,39 +489,39 @@ export const TEST_DELTA_MAP_B: CCFile = {
 	},
 	map: {
 		name: "root",
-		type: "Folder",
+		type: NodeType.FOLDER,
 		attributes: {},
 		children: [
 			{
 				name: "big leaf",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: { rloc: 20, functions: 10, mcc: 1 },
 				link: "http://www.google.de"
 			},
 			{
 				name: "additional leaf",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: { rloc: 10, functions: 11, mcc: 5 },
 				link: "http://www.google.de"
 			},
 			{
 				name: "Parent Leaf",
-				type: "Folder",
+				type: NodeType.FOLDER,
 				attributes: {},
 				children: [
 					{
 						name: "small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						attributes: { rloc: 30, functions: 100, mcc: 100, more: 20 }
 					},
 					{
 						name: "other small leaf",
-						type: "File",
+						type: NodeType.FILE,
 						attributes: { rloc: 70, functions: 1000 }
 					},
 					{
 						name: "big leaf",
-						type: "File",
+						type: NodeType.FILE,
 						attributes: { rloc: 20, functions: 10, mcc: 1 },
 						link: "http://www.google.de"
 					}
@@ -573,7 +574,7 @@ export const TEST_FILE_DATA_DOWNLOADED = {
 					},
 					link: "http://www.google.de",
 					name: "big leaf",
-					type: "File"
+					type: NodeType.FILE
 				},
 				{
 					attributes: {},
@@ -585,7 +586,7 @@ export const TEST_FILE_DATA_DOWNLOADED = {
 								rloc: 30
 							},
 							name: "small leaf",
-							type: "File"
+							type: NodeType.FILE
 						},
 						{
 							attributes: {
@@ -594,15 +595,15 @@ export const TEST_FILE_DATA_DOWNLOADED = {
 								rloc: 70
 							},
 							name: "other small leaf",
-							type: "File"
+							type: NodeType.FILE
 						}
 					],
 					name: "Parent Leaf",
-					type: "Folder"
+					type: NodeType.FOLDER
 				}
 			],
 			name: "root",
-			type: "Folder"
+			type: NodeType.FOLDER
 		}
 	],
 	projectName: "Sample Project"

--- a/visualization/app/codeCharta/util/deltaGenerator.spec.ts
+++ b/visualization/app/codeCharta/util/deltaGenerator.spec.ts
@@ -1,7 +1,7 @@
 import _ from "lodash"
 import { DeltaGenerator } from "./deltaGenerator"
 import { TEST_DELTA_MAP_A, TEST_DELTA_MAP_B } from "./dataMocks"
-import { CCFile } from "../codeCharta.model"
+import { CCFile, NodeType } from "../codeCharta.model"
 import { NodeDecorator } from "./nodeDecorator"
 
 describe("deltaGenerator", () => {
@@ -19,19 +19,19 @@ describe("deltaGenerator", () => {
 
 		fileA.map.children.push({
 			name: "onlyA",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			path: "/root/onlyA",
 			children: [
 				{
 					name: "special",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					path: "/root/onlyA/special",
 					children: [
 						{
 							name: "unicorn",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: { special: 42 },
 							path: "/root/onlyA/special/unicorn"
 						}
@@ -42,19 +42,19 @@ describe("deltaGenerator", () => {
 
 		fileB.map.children.push({
 			name: "onlyA",
-			type: "Folder",
+			type: NodeType.FOLDER,
 			attributes: {},
 			path: "/root/onlyA",
 			children: [
 				{
 					name: "special",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					path: "/root/onlyA/special",
 					children: [
 						{
 							name: "Narwal",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: { monster: 666 },
 							path: "/root/onlyA/special/Narwal"
 						}

--- a/visualization/app/codeCharta/util/fileDownloader.ts
+++ b/visualization/app/codeCharta/util/fileDownloader.ts
@@ -1,6 +1,16 @@
 import angular from "angular"
 import * as d3 from "d3"
-import { CodeMapNode, BlacklistType, BlacklistItem, FileSettings, ExportCCFile, FileMeta, AttributeTypes, Edge } from "../codeCharta.model"
+import {
+	CodeMapNode,
+	BlacklistType,
+	BlacklistItem,
+	FileSettings,
+	ExportCCFile,
+	FileMeta,
+	AttributeTypes,
+	Edge,
+	NodeType
+} from "../codeCharta.model"
 import { DownloadCheckboxNames } from "../ui/dialog/dialog.download.component"
 import { CodeChartaService } from "../codeCharta.service"
 import { stringify } from "querystring"
@@ -71,7 +81,7 @@ export class FileDownloader {
 			delete node.data.visible
 			delete node.data.edgeAttributes
 			delete node.data.path
-			if (node.data.type === "Folder") {
+			if (node.data.type === NodeType.FOLDER) {
 				node.data.attributes = {}
 			} else {
 				delete node.data.attributes["unary"]

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
@@ -1,6 +1,6 @@
 import _ from "lodash"
 import { FileExtensionCalculator, MetricDistribution } from "./fileExtensionCalculator"
-import { BlacklistType, CodeMapNode, State } from "../codeCharta.model"
+import { BlacklistType, CodeMapNode, NodeType, State } from "../codeCharta.model"
 import { STATE, VALID_NODE_WITH_PATH_AND_EXTENSION, VALID_NODE_WITHOUT_RLOC_METRIC } from "./dataMocks"
 import { HSL } from "./color/hsl"
 
@@ -123,10 +123,10 @@ describe("FileExtensionCalculator", () => {
 
 		it("should get correct distribution of file-extensions for given metric using other-grouping", () => {
 			const additionalChildren: CodeMapNode[] = [
-				{ name: "child1.txt", type: "File", path: "/root/child1.txt", attributes: { rloc: 2 } },
-				{ name: "child2.kt", type: "File", path: "/root/child2.kt", attributes: { rloc: 4 } },
-				{ name: "child3.ts", type: "File", path: "/root/child3.ts", attributes: { rloc: 6 } },
-				{ name: "child4.xml", type: "File", path: "/root/child4.xml", attributes: { rloc: 8 } }
+				{ name: "child1.txt", type: NodeType.FILE, path: "/root/child1.txt", attributes: { rloc: 2 } },
+				{ name: "child2.kt", type: NodeType.FILE, path: "/root/child2.kt", attributes: { rloc: 4 } },
+				{ name: "child3.ts", type: NodeType.FILE, path: "/root/child3.ts", attributes: { rloc: 6 } },
+				{ name: "child4.xml", type: NodeType.FILE, path: "/root/child4.xml", attributes: { rloc: 8 } }
 			]
 			const expected: MetricDistribution[] = [
 				{

--- a/visualization/app/codeCharta/util/fileValidator.spec.ts
+++ b/visualization/app/codeCharta/util/fileValidator.spec.ts
@@ -1,5 +1,6 @@
 import { FileValidator } from "./fileValidator"
 import { TEST_FILE_CONTENT } from "./dataMocks"
+import { NodeType } from "../codeCharta.model"
 
 describe("FileValidator", () => {
 	let file
@@ -56,9 +57,9 @@ describe("FileValidator", () => {
 
 	it("should reject when children are not unique in name+type", () => {
 		file.nodes[0].children[0].name = "same"
-		file.nodes[0].children[0].type = "File"
+		file.nodes[0].children[0].type = NodeType.FILE
 		file.nodes[0].children[1].name = "same"
-		file.nodes[0].children[1].type = "File"
+		file.nodes[0].children[1].type = NodeType.FILE
 		const errors = FileValidator.validate(file)
 		expectFileToBeInvalid(errors)
 	})

--- a/visualization/app/codeCharta/util/mapBuilder.spec.ts
+++ b/visualization/app/codeCharta/util/mapBuilder.spec.ts
@@ -1,5 +1,5 @@
 import { VALID_NODE_WITH_PATH } from "./dataMocks"
-import { CodeMapNode } from "../codeCharta.model"
+import { CodeMapNode, NodeType } from "../codeCharta.model"
 import { MapBuilder } from "./mapBuilder"
 
 describe("mapBuilder", () => {
@@ -30,7 +30,7 @@ describe("mapBuilder", () => {
 		it("should find child node", () => {
 			const expected: CodeMapNode = {
 				name: "big leaf",
-				type: "File",
+				type: NodeType.FILE,
 				path: "/root/big leaf",
 				children: [],
 				attributes: { rloc: 100, functions: 10, mcc: 1 },
@@ -42,7 +42,7 @@ describe("mapBuilder", () => {
 		it("should find grand-child node", () => {
 			const expected: CodeMapNode = {
 				name: "other small leaf",
-				type: "File",
+				type: NodeType.FILE,
 				path: "/root/Parent Leaf/other small leaf",
 				children: [],
 				attributes: { rloc: 70, functions: 1000, mcc: 10 }

--- a/visualization/app/codeCharta/util/mapBuilder.ts
+++ b/visualization/app/codeCharta/util/mapBuilder.ts
@@ -1,4 +1,4 @@
-import { CodeMapNode } from "../codeCharta.model"
+import { CodeMapNode, NodeType } from "../codeCharta.model"
 import { CodeChartaService } from "../codeCharta.service"
 
 export class MapBuilder {
@@ -21,7 +21,7 @@ export class MapBuilder {
 		return {
 			name: CodeChartaService.ROOT_NAME,
 			path: CodeChartaService.ROOT_PATH,
-			type: "Folder",
+			type: NodeType.FOLDER,
 			children: [],
 			attributes: {}
 		}

--- a/visualization/app/codeCharta/util/nodeDecorator.spec.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.spec.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3"
 import { STATE, TEST_DELTA_MAP_A, VALID_NODE_WITH_PATH_AND_DELTAS } from "./dataMocks"
-import { CCFile, MetricData, BlacklistItem, CodeMapNode, FileMeta } from "../codeCharta.model"
+import { CCFile, MetricData, BlacklistItem, CodeMapNode, FileMeta, NodeType } from "../codeCharta.model"
 import { NodeDecorator } from "./nodeDecorator"
 import { CodeMapHelper } from "./codeMapHelper"
 import _ from "lodash"
@@ -83,17 +83,17 @@ describe("nodeDecorator", () => {
 			map.children = [
 				{
 					name: "middle",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					children: [
 						{
 							name: "a",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						},
 						{
 							name: "b",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						}
 					]
@@ -111,18 +111,18 @@ describe("nodeDecorator", () => {
 			map.children = [
 				{
 					name: "middle",
-					type: "File",
+					type: NodeType.FILE,
 					attributes: {},
 					link: "link1",
 					children: [
 						{
 							name: "a",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						},
 						{
 							name: "b",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						}
 					]
@@ -138,18 +138,18 @@ describe("nodeDecorator", () => {
 				{
 					name: "middle",
 					path: "/root/middle",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					children: [
 						{
 							name: "a",
-							type: "File",
+							type: NodeType.FILE,
 							path: "/root/middle/a",
 							attributes: {}
 						},
 						{
 							name: "b",
-							type: "File",
+							type: NodeType.FILE,
 							path: "/root/middle/b",
 							attributes: {}
 						}
@@ -164,12 +164,12 @@ describe("nodeDecorator", () => {
 			map.children = [
 				{
 					name: "middle",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					children: [
 						{
 							name: "singleLeaf",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						}
 					]
@@ -185,27 +185,27 @@ describe("nodeDecorator", () => {
 			map.children = [
 				{
 					name: "start",
-					type: "Folder",
+					type: NodeType.FOLDER,
 					attributes: {},
 					children: [
 						{
 							name: "middle",
-							type: "Folder",
+							type: NodeType.FOLDER,
 							attributes: {},
 							children: [
 								{
 									name: "middle2",
-									type: "Folder",
+									type: NodeType.FOLDER,
 									attributes: {},
 									children: [
 										{
 											name: "a",
-											type: "File",
+											type: NodeType.FILE,
 											attributes: {}
 										},
 										{
 											name: "b",
-											type: "File",
+											type: NodeType.FILE,
 											attributes: {}
 										}
 									]
@@ -214,7 +214,7 @@ describe("nodeDecorator", () => {
 						},
 						{
 							name: "c",
-							type: "File",
+							type: NodeType.FILE,
 							attributes: {}
 						}
 					]

--- a/visualization/app/codeCharta/util/treeMapHelper.spec.ts
+++ b/visualization/app/codeCharta/util/treeMapHelper.spec.ts
@@ -1,6 +1,6 @@
 import { TreeMapHelper } from "./treeMapHelper"
 import { SquarifiedValuedCodeMapNode } from "./treeMapGenerator"
-import { CodeMapNode, EdgeVisibility, BlacklistType, State } from "../codeCharta.model"
+import { BlacklistType, CodeMapNode, EdgeVisibility, NodeType, State } from "../codeCharta.model"
 import { CODE_MAP_BUILDING, STATE } from "./dataMocks"
 
 describe("treeMapHelper", () => {
@@ -17,7 +17,7 @@ describe("treeMapHelper", () => {
 			codeMapNode = {
 				name: "Anode",
 				path: "/root/Anode",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: { theHeight: 100 }
 			} as CodeMapNode
 
@@ -136,7 +136,7 @@ describe("treeMapHelper", () => {
 			codeMapNode = {
 				name: "Anode",
 				path: "/root/Anode",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: {},
 				edgeAttributes: { pairingRate: { incoming: 42, outgoing: 23 } }
 			}
@@ -223,7 +223,7 @@ describe("treeMapHelper", () => {
 			node = {
 				name: "Anode",
 				path: "/root/Anode",
-				type: "File",
+				type: NodeType.FILE,
 				attributes: {}
 			} as CodeMapNode
 


### PR DESCRIPTION
# Tech/node type as enum

## Description

- Use enum `NodeType` (`File` or `Folder`) for `CodeMapNode.type` instead of a string
- Replace all occurrences within the code

After #860 is merged, we should regenerate the `generatedSchema.json` with `npm run schema:generate` in order to validate the type correctly as well.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
