### PR TITLE
Bug/invert files when none are selected

### DIFF
--- a/visualization/app/codeCharta/codeCharta.component.ts
+++ b/visualization/app/codeCharta/codeCharta.component.ts
@@ -10,6 +10,7 @@ import { StoreService } from "./state/store.service"
 import { setState } from "./state/store/state.actions"
 import { setAppSettings } from "./state/store/appSettings/appSettings.actions"
 import { setIsLoadingFile } from "./state/store/appSettings/isLoadingFile/isLoadingFile.actions"
+import { setDelta, setMultiple, setMultipleByNames, setSingle } from "./state/store/files/files.actions"
 
 export class CodeChartaController {
 	private _viewModel: {
@@ -87,11 +88,11 @@ export class CodeChartaController {
 		const files = this.storeService.getState().files.getCCFiles()
 
 		if (renderState === "Delta" && files.length >= 2) {
-			this.storeService.getState().files.setDelta(files[0], files[1])
+			this.storeService.dispatch(setDelta(files[0], files[1]))
 		} else if (renderState === "Multiple") {
-			this.storeService.getState().files.setMultiple(files)
+			this.storeService.dispatch(setMultiple(files))
 		} else {
-			this.storeService.getState().files.setSingle(files[0])
+			this.storeService.dispatch(setSingle(files[0]))
 		}
 	}
 

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.ts
@@ -11,6 +11,7 @@ import { CodeChartaService } from "../../codeCharta.service"
 import { NameDataPair } from "../../codeCharta.model"
 import { StoreService } from "../../state/store.service"
 import { setIsLoadingFile } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.actions"
+import { resetFiles } from "../../state/store/files/files.actions"
 
 export class FileChooserController {
 	/* @ngInject */
@@ -23,7 +24,7 @@ export class FileChooserController {
 
 	public onImportNewFiles(element) {
 		this.$scope.$apply(() => {
-			this.storeService.getState().files.reset()
+			this.storeService.dispatch(resetFiles())
 			for (let file of element.files) {
 				let reader = new FileReader()
 				reader.onloadstart = () => {

--- a/visualization/app/codeCharta/ui/filePanel/filePanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/filePanel/filePanel.component.spec.ts
@@ -129,6 +129,21 @@ describe("filePanelController", () => {
 		})
 	})
 
+	describe("onPartialSelectionClosed", () => {
+		it("should set the filenames of the maps that are visible again", () => {
+			storeService.dispatch(setMultiple([TEST_DELTA_MAP_A, TEST_DELTA_MAP_B]))
+			filePanelController.onFilesSelectionChanged(storeService.getState().files)
+			filePanelController["_viewModel"].selectedFileNames.partial = []
+
+			filePanelController.onPartialSelectionClosed()
+
+			expect(filePanelController["_viewModel"].selectedFileNames.partial).toEqual([
+				TEST_DELTA_MAP_A.fileMeta.fileName,
+				TEST_DELTA_MAP_B.fileMeta.fileName
+			])
+		})
+	})
+
 	describe("onSingleFileChange", () => {
 		it("should set a single file in state", () => {
 			filePanelController.onSingleFileChange(TEST_DELTA_MAP_B.fileMeta.fileName)
@@ -160,8 +175,8 @@ describe("filePanelController", () => {
 		})
 	})
 
-	describe("onPartialFileChange", () => {
-		it("should set multiple files in multiple mode", () => {
+	describe("onPartialFilesChange", () => {
+		it("should set multiple files in multiple mode when at least one is selected", () => {
 			filePanelController.onPartialFilesChange([TEST_DELTA_MAP_A.fileMeta.fileName, TEST_DELTA_MAP_B.fileMeta.fileName])
 
 			expect(storeService.getState().files.isPartialState()).toBeTruthy()
@@ -183,7 +198,7 @@ describe("filePanelController", () => {
 			expect(filePanelController.onSingleFileChange).toHaveBeenCalledWith("fileA")
 		})
 
-		it("should update the viewModel with the last visible filename and call selectAllPartialFiles if partial mode is active", () => {
+		it("should update the viewModel with the last visible filename and call Files if partial mode is active", () => {
 			filePanelController.selectAllPartialFiles = jest.fn()
 
 			filePanelController.onPartialStateSelected()
@@ -217,15 +232,16 @@ describe("filePanelController", () => {
 	})
 
 	describe("selectZeroPartialFiles", () => {
-		it("should should set the viewModel mode to multiple and deselect all files", () => {
-			storeService.dispatch(setMultiple([TEST_DELTA_MAP_A]))
+		it("should only set the viewModel to prevent rendering of an empty map when nothing is selected", () => {
+			storeService.dispatch(setMultiple([TEST_DELTA_MAP_A, TEST_DELTA_MAP_B]))
 			filePanelController.onFilesSelectionChanged(storeService.getState().files)
-			storeService.dispatch = jest.fn()
 
 			filePanelController.selectZeroPartialFiles()
 
+			expect(storeService.getState().files.isPartialState()).toBeTruthy()
+			expect(storeService.getState().files.getVisibleFileStates()[0].selectedAs).toEqual(FileSelectionState.Partial)
+			expect(storeService.getState().files.getVisibleFileStates()[1].selectedAs).toEqual(FileSelectionState.Partial)
 			expect(filePanelController["_viewModel"].selectedFileNames.partial).toHaveLength(0)
-			expect(storeService.dispatch).not.toHaveBeenCalled()
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/filePanel/filePanel.component.ts
+++ b/visualization/app/codeCharta/ui/filePanel/filePanel.component.ts
@@ -3,7 +3,7 @@ import { FileSelectionState } from "../../codeCharta.model"
 import { IRootScopeService } from "angular"
 import { StoreService } from "../../state/store.service"
 import { setDeltaByNames, setMultipleByNames, setSingleByName } from "../../state/store/files/files.actions"
-import { FilesService, FilesSelectionSubscriber } from "../../state/store/files/files.service"
+import { FilesSelectionSubscriber, FilesService } from "../../state/store/files/files.service"
 import { Files } from "../../model/files"
 
 interface SelectedFileNames {
@@ -63,7 +63,6 @@ export class FilePanelController implements FilesSelectionSubscriber {
 	}
 
 	public onPartialSelectionClosed() {
-		this._viewModel.files = this.storeService.getState().files
 		this.updateSelectedFileNamesInViewModel()
 	}
 
@@ -113,7 +112,7 @@ export class FilePanelController implements FilesSelectionSubscriber {
 		if (partialFileNames.length > 0) {
 			this.storeService.dispatch(setMultipleByNames(partialFileNames))
 		} else {
-			this._viewModel.selectedFileNames.partial = partialFileNames
+			this._viewModel.selectedFileNames.partial = []
 		}
 	}
 
@@ -143,8 +142,8 @@ export class FilePanelController implements FilesSelectionSubscriber {
 	public invertPartialFileSelection() {
 		const invertedFileNames: string[] = this._viewModel.files
 			.getFiles()
-			.filter(x => x.selectedAs === FileSelectionState.None)
 			.map(x => x.file.fileMeta.fileName)
+			.filter(x => !this._viewModel.selectedFileNames.partial.includes(x))
 
 		this.onPartialFilesChange(invertedFileNames)
 	}

--- a/visualization/jest.config.json
+++ b/visualization/jest.config.json
@@ -13,7 +13,7 @@
 		"\\.(css|less|scss)$": "<rootDir>/mocks/styleMock.js"
 	},
 	"roots": ["<rootDir>/app"],
-	"testRegex": "(/__tests__/.*|\\.(spec|e2e))\\.(ts|tsx)$",
+	"testMatch": ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|e2e).[jt]s?(x)"],
 	"moduleFileExtensions": ["ts", "tsx", "js", "json"],
 	"moduleDirectories": ["node_modules", "<rootDir>/app"],
 	"globals": {


### PR DESCRIPTION
# Fix inverting files when non are selected

## Description

- Fixes issue with multiple node when clicking "NONE" and then clicking "INVERT"
- Refactored some statements that retrieved the state and mutated it without actions
- Fixes jest not running in intellij due to outdated config

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
