### PR TITLE
Bug/only show metrics of visible maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Changed
 
+- Selectable metrics will only contain metrics from the visible maps
+
 ### Removed 🗑
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -198,7 +198,6 @@ export interface MarkedPackage {
 export interface MetricData {
 	name: string
 	maxValue: number
-	availableInVisibleMaps: boolean
 }
 
 export interface Scenario {

--- a/visualization/app/codeCharta/state/edgeMetricData.service.ts
+++ b/visualization/app/codeCharta/state/edgeMetricData.service.ts
@@ -158,7 +158,7 @@ export class EdgeMetricDataService implements FilesSelectionSubscriber, Blacklis
 					maximumMetricValue = combinedValue
 				}
 			})
-			metricData.push({ name: edgeMetric, maxValue: maximumMetricValue, availableInVisibleMaps: true })
+			metricData.push({ name: edgeMetric, maxValue: maximumMetricValue })
 		})
 
 		return metricData
@@ -178,7 +178,7 @@ export class EdgeMetricDataService implements FilesSelectionSubscriber, Blacklis
 	}
 
 	private addNoneMetric() {
-		this.edgeMetricData.push({ name: "None", maxValue: 0, availableInVisibleMaps: false })
+		this.edgeMetricData.push({ name: "None", maxValue: 0 })
 	}
 
 	private notifyEdgeMetricDataUpdated() {

--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -41,11 +41,7 @@ describe("MetricService", () => {
 		storeService.dispatch(addFile(deltaA))
 		storeService.dispatch(addFile(deltaB))
 
-		metricData = [
-			{ name: "rloc", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "functions", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "mcc", maxValue: 999999, availableInVisibleMaps: true }
-		]
+		metricData = [{ name: "rloc", maxValue: 999999 }, { name: "functions", maxValue: 999999 }, { name: "mcc", maxValue: 999999 }]
 		state = _.cloneDeep(STATE)
 	}
 
@@ -184,11 +180,7 @@ describe("MetricService", () => {
 
 		it("should return an array of metricData sorted by name calculated from visibleFileStates", () => {
 			storeService.dispatch(setSingle(TEST_DELTA_MAP_A))
-			const expected = [
-				{ availableInVisibleMaps: true, maxValue: 1000, name: "functions" },
-				{ availableInVisibleMaps: true, maxValue: 100, name: "mcc" },
-				{ availableInVisibleMaps: true, maxValue: 100, name: "rloc" }
-			]
+			const expected = [{ maxValue: 1000, name: "functions" }, { maxValue: 100, name: "mcc" }, { maxValue: 100, name: "rloc" }]
 
 			const result = metricService["calculateMetrics"]()
 

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -24,7 +24,6 @@ export interface MetricServiceSubscriber {
 
 interface MaxMetricValuePair {
 	maxValue: number
-	availableInVisibleMaps: boolean
 }
 
 export class MetricService implements FilesSelectionSubscriber, BlacklistSubscriber {
@@ -55,7 +54,7 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 	}
 
 	public isMetricAvailable(metricName: string) {
-		return this.metricData.find(x => x.name == metricName && x.availableInVisibleMaps)
+		return this.metricData.find(x => x.name == metricName)
 	}
 
 	public getMaxMetricByMetricName(metricName: string): number {
@@ -99,44 +98,38 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 			return []
 		} else {
 			//TODO: keep track of these metrics in service
-			const metricsFromVisibleMaps = this.getUniqueMetricNames()
-			const hashMap = this.buildHashMapFromMetrics(metricsFromVisibleMaps)
+			const hashMap = this.buildHashMapFromMetrics()
 			return this.getMetricDataFromHashMap(hashMap)
 		}
 	}
 
-	private buildHashMapFromMetrics(metricsFromVisibleMaps) {
+	private buildHashMapFromMetrics() {
 		const hashMap: Map<string, MaxMetricValuePair> = new Map()
 
 		this.storeService
 			.getState()
 			.files.getVisibleFileStates()
 			.forEach((fileState: FileState) => {
-				let nodes: HierarchyNode<CodeMapNode>[] = hierarchy(fileState.file.map).leaves()
+				const nodes: HierarchyNode<CodeMapNode>[] = hierarchy(fileState.file.map).leaves()
 				nodes.forEach((node: HierarchyNode<CodeMapNode>) => {
 					if (
 						node.data.path &&
 						!CodeMapHelper.isBlacklisted(node.data, this.storeService.getState().fileSettings.blacklist, BlacklistType.exclude)
 					) {
-						this.addMaxMetricValuesToHashMap(node, hashMap, metricsFromVisibleMaps)
+						this.addMaxMetricValuesToHashMap(node, hashMap)
 					}
 				})
 			})
 		return hashMap
 	}
 
-	private addMaxMetricValuesToHashMap(
-		node: HierarchyNode<CodeMapNode>,
-		hashMap: Map<string, MaxMetricValuePair>,
-		metricsFromVisibleMaps
-	) {
+	private addMaxMetricValuesToHashMap(node: HierarchyNode<CodeMapNode>, hashMap: Map<string, MaxMetricValuePair>) {
 		const attributes: string[] = Object.keys(node.data.attributes)
 
 		attributes.forEach((metric: string) => {
 			if (!hashMap.has(metric) || hashMap.get(metric).maxValue <= node.data.attributes[metric]) {
 				hashMap.set(metric, {
-					maxValue: node.data.attributes[metric],
-					availableInVisibleMaps: this.isAvailableInVisibleMaps(metricsFromVisibleMaps, metric)
+					maxValue: node.data.attributes[metric]
 				})
 			}
 		})
@@ -148,34 +141,10 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 		hashMap.forEach((value: MaxMetricValuePair, key: string) => {
 			metricData.push({
 				name: key,
-				maxValue: value.maxValue,
-				availableInVisibleMaps: value.availableInVisibleMaps
+				maxValue: value.maxValue
 			})
 		})
 		return this.sortByAttributeName(metricData)
-	}
-
-	private isAvailableInVisibleMaps(metricsFromVisibleMaps: string[], metric: string): boolean {
-		return !!metricsFromVisibleMaps.find(metricName => metricName === metric)
-	}
-
-	private getUniqueMetricNames(): string[] {
-		const files = this.storeService.getState().files
-		if (!files.fileStatesAvailable()) {
-			return []
-		}
-
-		let leaves: HierarchyNode<CodeMapNode>[] = []
-		files.getVisibleFileStates().forEach((fileState: FileState) => {
-			leaves = leaves.concat(hierarchy<CodeMapNode>(fileState.file.map).leaves())
-		})
-		const attributeList: string[][] = leaves.map((d: HierarchyNode<CodeMapNode>) => {
-			return d.data.attributes ? Object.keys(d.data.attributes) : []
-		})
-		const attributes: string[] = attributeList.reduce((left: string[], right: string[]) => {
-			return left.concat(right.filter(el => left.indexOf(el) === -1))
-		})
-		return attributes.sort()
 	}
 
 	private sortByAttributeName(metricData: MetricData[]): MetricData[] {
@@ -186,8 +155,7 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 		if (!this.metricData.find(x => x.name === "unary")) {
 			this.metricData.push({
 				name: "unary",
-				maxValue: 1,
-				availableInVisibleMaps: true
+				maxValue: 1
 			})
 		}
 	}

--- a/visualization/app/codeCharta/state/store/dynamicSettings/areaMetric/areaMetric.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/areaMetric/areaMetric.service.spec.ts
@@ -70,10 +70,10 @@ describe("AreaMetricService", () => {
 	describe("onMetricDataAdded", () => {
 		it("should update areaMetric if current areaMetric is not available", () => {
 			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "c", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "d", maxValue: 2, availableInVisibleMaps: true }
+				{ name: "a", maxValue: 1 },
+				{ name: "b", maxValue: 2 },
+				{ name: "c", maxValue: 2 },
+				{ name: "d", maxValue: 2 }
 			]
 
 			areaMetricService.onMetricDataAdded(metricData)
@@ -84,10 +84,7 @@ describe("AreaMetricService", () => {
 		it("should not update if current areaMetric is available", () => {
 			storeService.dispatch(setAreaMetric("rloc"))
 			storeService.dispatch = jest.fn()
-			const metricData = [
-				{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "mcc", maxValue: 1 }, { name: "rloc", maxValue: 2 }]
 
 			areaMetricService.onMetricDataAdded(metricData)
 
@@ -96,7 +93,7 @@ describe("AreaMetricService", () => {
 
 		it("should not update areaMetric, if no metric is available", () => {
 			storeService.dispatch = jest.fn()
-			const metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
+			const metricData = []
 
 			areaMetricService.onMetricDataAdded(metricData)
 

--- a/visualization/app/codeCharta/state/store/dynamicSettings/colorMetric/colorMetric.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/colorMetric/colorMetric.service.spec.ts
@@ -70,10 +70,10 @@ describe("ColorMetricService", () => {
 	describe("onMetricDataAdded", () => {
 		it("should update colorMetric if current colorMetric is not available", () => {
 			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "c", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "d", maxValue: 2, availableInVisibleMaps: true }
+				{ name: "a", maxValue: 1 },
+				{ name: "b", maxValue: 2 },
+				{ name: "c", maxValue: 2 },
+				{ name: "d", maxValue: 2 }
 			]
 
 			colorMetricService.onMetricDataAdded(metricData)
@@ -82,10 +82,7 @@ describe("ColorMetricService", () => {
 		})
 
 		it("should use first available metric, if less than 2 metrics are available", () => {
-			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 1, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "a", maxValue: 1 }]
 
 			colorMetricService.onMetricDataAdded(metricData)
 
@@ -95,10 +92,7 @@ describe("ColorMetricService", () => {
 		it("should not update if current colorMetric is available", () => {
 			storeService.dispatch(setColorMetric("mcc"))
 			storeService.dispatch = jest.fn()
-			const metricData = [
-				{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "mcc", maxValue: 1 }, { name: "rloc", maxValue: 2 }]
 
 			colorMetricService.onMetricDataAdded(metricData)
 
@@ -107,7 +101,7 @@ describe("ColorMetricService", () => {
 
 		it("should not update colorMetric, if no metric is available", () => {
 			storeService.dispatch = jest.fn()
-			const metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
+			const metricData = []
 
 			colorMetricService.onMetricDataAdded(metricData)
 

--- a/visualization/app/codeCharta/state/store/dynamicSettings/distributionMetric/distributionMetric.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/distributionMetric/distributionMetric.service.spec.ts
@@ -72,10 +72,10 @@ describe("DistributionMetricService", () => {
 	describe("onMetricDataAdded", () => {
 		it("should update distributionMetric if current distributionMetric is not available", () => {
 			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "c", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "d", maxValue: 2, availableInVisibleMaps: true }
+				{ name: "a", maxValue: 1 },
+				{ name: "b", maxValue: 2 },
+				{ name: "c", maxValue: 2 },
+				{ name: "d", maxValue: 2 }
 			]
 
 			distributionMetricService.onMetricDataAdded(metricData)
@@ -86,10 +86,7 @@ describe("DistributionMetricService", () => {
 		it("should not update if current distributionMetric is available", () => {
 			storeService.dispatch(setDistributionMetric("mcc"))
 			storeService.dispatch = jest.fn()
-			const metricData = [
-				{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "mcc", maxValue: 1 }, { name: "rloc", maxValue: 2 }]
 
 			distributionMetricService.onMetricDataAdded(metricData)
 
@@ -98,7 +95,7 @@ describe("DistributionMetricService", () => {
 
 		it("should not update distributionMetric, if no metric is available", () => {
 			storeService.dispatch = jest.fn()
-			const metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
+			const metricData = []
 
 			distributionMetricService.onMetricDataAdded(metricData)
 

--- a/visualization/app/codeCharta/state/store/dynamicSettings/edgeMetric/edgeMetric.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/edgeMetric/edgeMetric.service.spec.ts
@@ -69,10 +69,7 @@ describe("EdgeMetricService", () => {
 
 	describe("onEdgeMetricDataUpdated", () => {
 		it("should not reset edgeMetric because current edgeMetric exists in metricData", () => {
-			const metricData = [
-				{ name: "validEdgeMetric", maxValue: 22, availableInVisibleMaps: true },
-				{ name: "None", maxValue: 1, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "validEdgeMetric", maxValue: 22 }, { name: "None", maxValue: 1 }]
 			storeService.dispatch(setEdgeMetric("validEdgeMetric"))
 
 			edgeMetricService.onEdgeMetricDataUpdated(metricData)
@@ -80,10 +77,7 @@ describe("EdgeMetricService", () => {
 			expect(storeService.getState().dynamicSettings.edgeMetric).toEqual("validEdgeMetric")
 		})
 		it("should reset edgeMetric because current edgeMetric does not exists in metricData", () => {
-			const metricData = [
-				{ name: "someNewMetric", maxValue: 22, availableInVisibleMaps: true },
-				{ name: "None", maxValue: 1, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "someNewMetric", maxValue: 22 }, { name: "None", maxValue: 1 }]
 			storeService.dispatch(setEdgeMetric("invalidEdgeMetric"))
 
 			edgeMetricService.onEdgeMetricDataUpdated(metricData)

--- a/visualization/app/codeCharta/state/store/dynamicSettings/heightMetric/heightMetric.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/heightMetric/heightMetric.service.spec.ts
@@ -70,10 +70,10 @@ describe("HeightMetricService", () => {
 	describe("onMetricDataAdded", () => {
 		it("should update heightMetric if current heightMetric is not available", () => {
 			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "c", maxValue: 2, availableInVisibleMaps: true },
-				{ name: "d", maxValue: 2, availableInVisibleMaps: true }
+				{ name: "a", maxValue: 1 },
+				{ name: "b", maxValue: 2 },
+				{ name: "c", maxValue: 2 },
+				{ name: "d", maxValue: 2 }
 			]
 
 			heightMetricService.onMetricDataAdded(metricData)
@@ -82,10 +82,7 @@ describe("HeightMetricService", () => {
 		})
 
 		it("should use first available metric, if less than 3 metrics are available", () => {
-			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 1, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "a", maxValue: 1 }]
 
 			heightMetricService.onMetricDataAdded(metricData)
 
@@ -95,10 +92,7 @@ describe("HeightMetricService", () => {
 		it("should not update if current heightMetric is available", () => {
 			storeService.dispatch(setHeightMetric("mcc"))
 			storeService.dispatch = jest.fn()
-			const metricData = [
-				{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-			]
+			const metricData = [{ name: "mcc", maxValue: 1 }, { name: "rloc", maxValue: 2 }]
 
 			heightMetricService.onMetricDataAdded(metricData)
 
@@ -107,7 +101,7 @@ describe("HeightMetricService", () => {
 
 		it("should not update heightMetric, if no metric is available", () => {
 			storeService.dispatch = jest.fn()
-			const metricData = [{ name: "b", maxValue: 2, availableInVisibleMaps: false }]
+			const metricData = []
 
 			heightMetricService.onMetricDataAdded(metricData)
 

--- a/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.spec.ts
@@ -80,10 +80,7 @@ describe("EdgeChooserController", () => {
 
 	describe("onEdgeMetricDataUpdated", () => {
 		it("should store edge data", () => {
-			const metricData = [
-				{ name: "metric1", maxValue: 22, availableInVisibleMaps: true },
-				{ name: "metric2", maxValue: 1, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "metric1", maxValue: 22 }, { name: "metric2", maxValue: 1 }]
 
 			edgeChooserController.onEdgeMetricDataUpdated(metricData)
 
@@ -167,10 +164,7 @@ describe("EdgeChooserController", () => {
 
 	describe("filterMetricData()", () => {
 		it("should return the all entries if search term is empty", () => {
-			let metricData = [
-				{ name: "metric1", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "metric2", maxValue: 2, availableInVisibleMaps: false }
-			]
+			let metricData = [{ name: "metric1", maxValue: 1 }, { name: "metric2", maxValue: 2 }]
 			edgeChooserController["_viewModel"].searchTerm = ""
 			edgeChooserController.onEdgeMetricDataUpdated(metricData)
 
@@ -180,25 +174,17 @@ describe("EdgeChooserController", () => {
 		})
 
 		it("should return only metrics that include search term", () => {
-			let metricData = [
-				{ name: "metric1", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "metric2", maxValue: 2, availableInVisibleMaps: false }
-			]
+			let metricData = [{ name: "metric1", maxValue: 1 }, { name: "metric2", maxValue: 2 }]
 			edgeChooserController["_viewModel"].searchTerm = "ic2"
 			edgeChooserController.onEdgeMetricDataUpdated(metricData)
 
 			edgeChooserController.filterMetricData()
 
-			expect(edgeChooserController["_viewModel"].edgeMetricData).toEqual([
-				{ name: "metric2", maxValue: 2, availableInVisibleMaps: false }
-			])
+			expect(edgeChooserController["_viewModel"].edgeMetricData).toEqual([{ name: "metric2", maxValue: 2 }])
 		})
 
 		it("should return an empty metric list if it doesn't have the searchTerm as substring", () => {
-			let metricData = [
-				{ name: "metric1", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "metric2", maxValue: 2, availableInVisibleMaps: false }
-			]
+			let metricData = [{ name: "metric1", maxValue: 1 }, { name: "metric2", maxValue: 2 }]
 			edgeChooserController["_viewModel"].searchTerm = "fooBar"
 			edgeChooserController.onEdgeMetricDataUpdated(metricData)
 
@@ -217,7 +203,7 @@ describe("EdgeChooserController", () => {
 		})
 
 		it("should return the the metricData Array with all Elements, when function is called", () => {
-			let metricData = [{ name: "metric1", maxValue: 1, availableInVisibleMaps: true }]
+			let metricData = [{ name: "metric1", maxValue: 1 }]
 			edgeChooserController["_viewModel"].searchTerm = "rlo"
 			edgeChooserController.onEdgeMetricDataUpdated(metricData)
 

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
@@ -115,10 +115,7 @@ describe("MetricChooserController", () => {
 
 	describe("onMetricDataAdded", () => {
 		it("metric data should be updated", () => {
-			const metricData = [
-				{ name: "a", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 2, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "a", maxValue: 1 }, { name: "b", maxValue: 2 }]
 
 			metricChooserController.onMetricDataAdded(metricData)
 
@@ -168,10 +165,7 @@ describe("MetricChooserController", () => {
 
 	describe("filterMetricData", () => {
 		it("should return the default MetricData list", () => {
-			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "rloc", maxValue: 1 }, { name: "mcc", maxValue: 2 }]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = ""
 
@@ -180,71 +174,65 @@ describe("MetricChooserController", () => {
 			expect(metricChooserController["_viewModel"].metricData).toEqual(metricData)
 		})
 		it("should return only metric mcc from MetricData list, when its the searchTerm", () => {
-			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "rloc", maxValue: 1 }, { name: "mcc", maxValue: 2 }]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "mcc"
 
 			metricChooserController.filterMetricData()
 
-			expect(metricChooserController["_viewModel"].metricData).toEqual([{ name: "mcc", maxValue: 2, availableInVisibleMaps: false }])
+			expect(metricChooserController["_viewModel"].metricData).toEqual([
+				{
+					name: "mcc",
+					maxValue: 2
+				}
+			])
 		})
 
 		it("should return rloc metric when searchTerm is only 'rl'", () => {
-			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "rloc", maxValue: 1 }, { name: "mcc", maxValue: 2 }]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "rl"
 
 			metricChooserController.filterMetricData()
 
-			expect(metricChooserController["_viewModel"].metricData).toEqual([{ name: "rloc", maxValue: 1, availableInVisibleMaps: true }])
+			expect(metricChooserController["_viewModel"].metricData).toEqual([
+				{
+					name: "rloc",
+					maxValue: 1
+				}
+			])
 		})
 
 		it("should return the metrics which contains the metrics with 'c' in it", () => {
-			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false },
-				{ name: "avg", maxValue: 3, availableInVisibleMaps: false }
-			]
+			const metricData = [{ name: "rloc", maxValue: 1 }, { name: "mcc", maxValue: 2 }, { name: "avg", maxValue: 3 }]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "c"
 
 			metricChooserController.filterMetricData()
 
-			expect(metricChooserController["_viewModel"].metricData).toEqual([
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false }
-			])
+			expect(metricChooserController["_viewModel"].metricData).toEqual([{ name: "rloc", maxValue: 1 }, { name: "mcc", maxValue: 2 }])
 		})
 
 		it("should return the metrics which contains substrings with 'mc' as prefix", () => {
 			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false },
-				{ name: "avg", maxValue: 3, availableInVisibleMaps: false },
-				{ name: "cmc", maxValue: 4, availableInVisibleMaps: true }
+				{ name: "rloc", maxValue: 1 },
+				{ name: "mcc", maxValue: 2 },
+				{ name: "avg", maxValue: 3 },
+				{ name: "cmc", maxValue: 4 }
 			]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "mc"
 
 			metricChooserController.filterMetricData()
 
-			expect(metricChooserController["_viewModel"].metricData).toEqual([
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false },
-				{ name: "cmc", maxValue: 4, availableInVisibleMaps: true }
-			])
+			expect(metricChooserController["_viewModel"].metricData).toEqual([{ name: "mcc", maxValue: 2 }, { name: "cmc", maxValue: 4 }])
 		})
 		it("should return an empty metric list if it doesn't have the searchTerm as substring", () => {
 			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false },
-				{ name: "avg", maxValue: 3, availableInVisibleMaps: false },
-				{ name: "cmc", maxValue: 4, availableInVisibleMaps: true }
+				{ name: "rloc", maxValue: 1 },
+				{ name: "mcc", maxValue: 2 },
+				{ name: "avg", maxValue: 3 },
+				{ name: "cmc", maxValue: 4 }
 			]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "rla"
@@ -266,10 +254,10 @@ describe("MetricChooserController", () => {
 
 		it("should return the metricData array with all elements, when function is called", () => {
 			const metricData = [
-				{ name: "rloc", maxValue: 1, availableInVisibleMaps: true },
-				{ name: "mcc", maxValue: 2, availableInVisibleMaps: false },
-				{ name: "avg", maxValue: 3, availableInVisibleMaps: false },
-				{ name: "cmc", maxValue: 4, availableInVisibleMaps: true }
+				{ name: "rloc", maxValue: 1 },
+				{ name: "mcc", maxValue: 2 },
+				{ name: "avg", maxValue: 3 },
+				{ name: "cmc", maxValue: 4 }
 			]
 			setMetricData(metricData)
 			metricChooserController["_viewModel"].searchTerm = "rlo"

--- a/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.spec.ts
+++ b/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.spec.ts
@@ -28,11 +28,7 @@ describe("ScenarioDropDownController", () => {
 		storeService = getService<StoreService>("storeService")
 		threeOrbitControlsService = getService<ThreeOrbitControlsService>("threeOrbitControlsService")
 
-		metricData = [
-			{ name: "rloc", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "functions", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "mcc", maxValue: 999999, availableInVisibleMaps: true }
-		]
+		metricData = [{ name: "rloc", maxValue: 999999 }, { name: "functions", maxValue: 999999 }, { name: "mcc", maxValue: 999999 }]
 	}
 
 	function withMockedThreeOrbitControlsService() {

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -868,10 +868,7 @@ export const CODE_MAP_BUILDING_TS_NODE: CodeMapBuilding = new CodeMapBuilding(
 	DEFAULT_STATE.appSettings.mapColors.neutral
 )
 
-export const METRIC_DATA: MetricData[] = [
-	{ name: "mcc", maxValue: 1, availableInVisibleMaps: true },
-	{ name: "rloc", maxValue: 2, availableInVisibleMaps: true }
-]
+export const METRIC_DATA: MetricData[] = [{ name: "mcc", maxValue: 1 }, { name: "rloc", maxValue: 2 }]
 
 export const BLACKLIST: BlacklistItem[] = [
 	{

--- a/visualization/app/codeCharta/util/metricHelper.ts
+++ b/visualization/app/codeCharta/util/metricHelper.ts
@@ -1,15 +1,14 @@
 import { MetricData } from "../codeCharta.model"
 
 export function isAnyMetricAvailable(metricData: MetricData[]) {
-	const availableMetrics: MetricData[] = metricData.filter(x => x.availableInVisibleMaps && x.maxValue > 0)
-	return metricData.length > 1 && availableMetrics.length > 0
+	return metricData.filter(x => x.maxValue > 0).length > 0
 }
 
 export function isMetricUnavailable(metricData: MetricData[], metricName: string): boolean {
-	return !metricData.find(x => x.availableInVisibleMaps && x.maxValue > 0 && x.name == metricName)
+	return !metricData.find(x => x.maxValue > 0 && x.name == metricName)
 }
 
 export function getMetricNameFromIndexOrLast(metricData: MetricData[], index: number): string {
-	const availableMetrics = metricData.filter(x => x.availableInVisibleMaps && x.maxValue > 0)
+	const availableMetrics = metricData.filter(x => x.maxValue > 0)
 	return availableMetrics[Math.min(index, availableMetrics.length - 1)].name
 }

--- a/visualization/app/codeCharta/util/metricHelper.ts
+++ b/visualization/app/codeCharta/util/metricHelper.ts
@@ -1,11 +1,11 @@
 import { MetricData } from "../codeCharta.model"
 
 export function isAnyMetricAvailable(metricData: MetricData[]) {
-	return metricData.filter(x => x.maxValue > 0).length > 0
+	return metricData.some(x => x.maxValue > 0)
 }
 
 export function isMetricUnavailable(metricData: MetricData[], metricName: string): boolean {
-	return !metricData.find(x => x.maxValue > 0 && x.name == metricName)
+	return !metricData.some(x => x.maxValue > 0 && x.name == metricName)
 }
 
 export function getMetricNameFromIndexOrLast(metricData: MetricData[], index: number): string {

--- a/visualization/app/codeCharta/util/nodeDecorator.spec.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.spec.ts
@@ -18,11 +18,7 @@ describe("nodeDecorator", () => {
 		map = _.cloneDeep(TEST_DELTA_MAP_A.map)
 		deltaMap = _.cloneDeep(VALID_NODE_WITH_PATH_AND_DELTAS)
 		fileMeta = _.cloneDeep(TEST_DELTA_MAP_A.fileMeta)
-		metricData = [
-			{ name: "rloc", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "functions", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "mcc", maxValue: 999999, availableInVisibleMaps: true }
-		]
+		metricData = [{ name: "rloc", maxValue: 999999 }, { name: "functions", maxValue: 999999 }, { name: "mcc", maxValue: 999999 }]
 		blacklist = _.cloneDeep(STATE.fileSettings.blacklist)
 	})
 
@@ -41,7 +37,7 @@ describe("nodeDecorator", () => {
 		})
 
 		it("should aggregate missing metrics correctly", () => {
-			metricData.push({ name: "some", maxValue: 999999, availableInVisibleMaps: true })
+			metricData.push({ name: "some", maxValue: 999999 })
 			NodeDecorator.decorateMap(map, fileMeta, metricData)
 			NodeDecorator.decorateParentNodesWithSumAttributes(map, blacklist, metricData, [], false)
 
@@ -51,7 +47,7 @@ describe("nodeDecorator", () => {
 		})
 
 		it("leaves should have all metrics", () => {
-			metricData.push({ name: "some", maxValue: 999999, availableInVisibleMaps: true })
+			metricData.push({ name: "some", maxValue: 999999 })
 			NodeDecorator.decorateMap(map, fileMeta, metricData)
 
 			const h = d3.hierarchy(map)
@@ -66,7 +62,7 @@ describe("nodeDecorator", () => {
 
 		it("leaves should have all metrics even if some attributesLists are undefined", () => {
 			map.children[0].attributes = undefined
-			metricData.push({ name: "some", maxValue: 999999, availableInVisibleMaps: true })
+			metricData.push({ name: "some", maxValue: 999999 })
 
 			NodeDecorator.decorateMap(map, fileMeta, metricData)
 			const h = d3.hierarchy(map)
@@ -249,7 +245,7 @@ describe("nodeDecorator", () => {
 		it("all nodes should have an attribute list with all possible metrics", () => {
 			map.children[0].attributes = undefined
 			map.children[1].attributes = { some: 1 }
-			metricData.push({ name: "some", maxValue: 999999, availableInVisibleMaps: true })
+			metricData.push({ name: "some", maxValue: 999999 })
 
 			NodeDecorator.decorateMap(map, fileMeta, metricData)
 			NodeDecorator.decorateParentNodesWithSumAttributes(map, blacklist, metricData, [], false)

--- a/visualization/app/codeCharta/util/scenarioHelper.spec.ts
+++ b/visualization/app/codeCharta/util/scenarioHelper.spec.ts
@@ -10,11 +10,7 @@ describe("scenarioHelper", () => {
 	})
 
 	beforeEach(() => {
-		metricData = [
-			{ name: "rloc", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "functions", maxValue: 999999, availableInVisibleMaps: true },
-			{ name: "mcc", maxValue: 999999, availableInVisibleMaps: true }
-		]
+		metricData = [{ name: "rloc", maxValue: 999999 }, { name: "functions", maxValue: 999999 }, { name: "mcc", maxValue: 999999 }]
 	})
 
 	describe("importScenarios", () => {
@@ -48,11 +44,7 @@ describe("scenarioHelper", () => {
 		})
 
 		it("should return false for an impossible scenario", () => {
-			metricData = [
-				{ name: "some", maxValue: 999999, availableInVisibleMaps: true },
-				{ name: "weird", maxValue: 999999, availableInVisibleMaps: true },
-				{ name: "metrics", maxValue: 999999, availableInVisibleMaps: true }
-			]
+			metricData = [{ name: "some", maxValue: 999999 }, { name: "weird", maxValue: 999999 }, { name: "metrics", maxValue: 999999 }]
 			const result = ScenarioHelper.isScenarioPossible(scenarios[0], metricData)
 
 			expect(result).toBeFalsy()

--- a/visualization/app/codeCharta/util/treeMapGenerator.spec.ts
+++ b/visualization/app/codeCharta/util/treeMapGenerator.spec.ts
@@ -60,10 +60,7 @@ describe("treeMapGenerator", () => {
 			state.dynamicSettings.areaMetric = "myArea"
 			state.dynamicSettings.heightMetric = "myHeight"
 			state.treeMap.mapSize = 1000
-			metricData = [
-				{ name: "myArea", maxValue: 42, availableInVisibleMaps: true },
-				{ name: "myHeight", maxValue: 99, availableInVisibleMaps: true }
-			]
+			metricData = [{ name: "myArea", maxValue: 42 }, { name: "myHeight", maxValue: 99 }]
 
 			let nodes: Node[] = TreeMapGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
 
@@ -92,10 +89,7 @@ describe("treeMapGenerator", () => {
 		it("attribute do not exists, multiple children with non existant attributes", () => {
 			state.dynamicSettings.heightMetric = "b"
 			state.dynamicSettings.areaMetric = "b"
-			metricData = [
-				{ name: "a", maxValue: 42, availableInVisibleMaps: true },
-				{ name: "b", maxValue: 99, availableInVisibleMaps: true }
-			]
+			metricData = [{ name: "a", maxValue: 42 }, { name: "b", maxValue: 99 }]
 
 			let nodes: Node[] = TreeMapGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
 
@@ -106,7 +100,7 @@ describe("treeMapGenerator", () => {
 			state.dynamicSettings.areaMetric = "unknown"
 			state.dynamicSettings.heightMetric = "unknown"
 			state.fileSettings.edges = VALID_EDGES
-			metricData = [{ name: "unknown", maxValue: 100, availableInVisibleMaps: true }]
+			metricData = [{ name: "unknown", maxValue: 100 }]
 
 			let nodes: Node[] = TreeMapGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
 


### PR DESCRIPTION
# Selectable metrics only contain metrics from visible maps

## Description

We decided that the selectable metrics should only contain metrics of the visible maps
- Removed availableInVisibleMaps property completely
- Methods that checked if a metric was available now only has to iterate the metricData without checking for the removed property

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
