### PR TITLE
Tech/plop append redux default property

### DIFF
--- a/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
@@ -1,4 +1,6 @@
 import { AppSettings, CCAction, RecursivePartial } from "../../../codeCharta.model"
+
+// Plop: Append default property import here
 import { defaultAmountOfEdgePreviews } from "./amountOfEdgePreviews/amountOfEdgePreviews.actions"
 import { defaultAmountOfTopLabels } from "./amountOfTopLabels/amountOfTopLabels.actions"
 import { defaultEdgeHeight } from "./edgeHeight/edgeHeight.actions"
@@ -38,6 +40,7 @@ export function setAppSettings(appSettings: RecursivePartial<AppSettings> = defa
 }
 
 export const defaultAppSettings: AppSettings = {
+	// Plop: Append default property here
 	amountOfTopLabels: defaultAmountOfTopLabels,
 	amountOfEdgePreviews: defaultAmountOfEdgePreviews,
 	edgeHeight: defaultEdgeHeight,

--- a/visualization/app/codeCharta/state/store/dynamicSettings/dynamicSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/dynamicSettings.actions.ts
@@ -1,4 +1,6 @@
 import { CCAction, DynamicSettings, RecursivePartial } from "../../../codeCharta.model"
+
+// Plop: Append default property import here
 import { defaultAreaMetric } from "./areaMetric/areaMetric.actions"
 import { defaultColorMetric } from "./colorMetric/colorMetric.actions"
 import { defaultColorRange } from "./colorRange/colorRange.actions"

--- a/visualization/app/codeCharta/state/store/dynamicSettings/dynamicSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/dynamicSettings.actions.ts
@@ -29,6 +29,7 @@ export function setDynamicSettings(dynamicSettings: RecursivePartial<DynamicSett
 }
 
 export const defaultDynamicSettings: DynamicSettings = {
+	// Plop: Append default property here
 	areaMetric: defaultAreaMetric,
 	heightMetric: defaultHeightMetric,
 	colorMetric: defaultColorMetric,

--- a/visualization/app/codeCharta/state/store/fileSettings/fileSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/fileSettings.actions.ts
@@ -1,4 +1,6 @@
 import { CCAction, FileSettings, RecursivePartial } from "../../../codeCharta.model"
+
+// Plop: Append default property import here
 import { defaultAttributeTypes } from "./attributeTypes/attributeTypes.actions"
 import { defaultBlacklist } from "./blacklist/blacklist.actions"
 import { defaultEdges } from "./edges/edges.actions"
@@ -23,6 +25,7 @@ export function setFileSettings(fileSettings: RecursivePartial<FileSettings> = d
 }
 
 export const defaultFileSettings: FileSettings = {
+	// Plop: Append default property here
 	attributeTypes: defaultAttributeTypes,
 	blacklist: defaultBlacklist,
 	edges: defaultEdges,

--- a/visualization/app/codeCharta/state/store/treeMap/treeMap.actions.ts
+++ b/visualization/app/codeCharta/state/store/treeMap/treeMap.actions.ts
@@ -1,4 +1,6 @@
 import { CCAction, RecursivePartial, TreeMapSettings } from "../../../codeCharta.model"
+
+// Plop: Append default property import here
 import { defaultMapSize } from "./mapSize/mapSize.actions"
 
 export enum TreeMapSettingsActions {
@@ -20,5 +22,6 @@ export function setTreeMapSettings(treeMapSettings: RecursivePartial<TreeMapSett
 }
 
 export const defaultTreeMapSettings: TreeMapSettings = {
+	// Plop: Append default property here
 	mapSize: defaultMapSize
 }

--- a/visualization/plop-templates/redux-subreducer/actions.ts.hbs
+++ b/visualization/plop-templates/redux-subreducer/actions.ts.hbs
@@ -1,5 +1,7 @@
 import { CCAction, RecursivePartial, {{properCase name}} } from "../../../codeCharta.model"
 
+// Plop: Append default property import here
+
 export enum {{properCase name}}Actions {
 	SET_{{constantCase name}} = "SET_{{constantCase name}}"
 }
@@ -19,4 +21,5 @@ export function set{{properCase name}}({{camelCase name}}: RecursivePartial<{{pr
 }
 
 export const default{{properCase name}}: {{properCase name}} = {
+    // Plop: Append default property here
 }

--- a/visualization/plopfile.js
+++ b/visualization/plopfile.js
@@ -197,6 +197,18 @@ module.exports = function(plop) {
 				path: "app/codeCharta/state/store/{{camelCase subreducer}}/{{camelCase subreducer}}.reducer.ts",
 				pattern: /(\/\/ Plop: Append action forwarding here)/gi,
 				template: "$1\r\n\t\t{{camelCase name}}: {{camelCase name}}(state.{{camelCase name}}, {{camelCase name}}Action),"
+			},
+			{
+				type: "modify",
+				path: "app/codeCharta/state/store/{{camelCase subreducer}}/{{camelCase subreducer}}.actions.ts",
+				pattern: /(\/\/ Plop: Append default property here)/gi,
+				template: "$1\r\n\t{{camelCase name}}: default{{properCase name}},"
+			},
+			{
+				type: "modify",
+				path: "app/codeCharta/state/store/{{camelCase subreducer}}/{{camelCase subreducer}}.actions.ts",
+				pattern: /(\/\/ Plop: Append default property import here)/gi,
+				template: `$1\r\nimport { default{{properCase name}} } from "./{{camelCase name}}/{{camelCase name}}.actions"`
 			}
 		]
 	})


### PR DESCRIPTION
# Tech/plop append redux default property

## Description

- When creating a redux property, the default value is appended to the sub reducer default object
- When creating a redux sub reducer, the comment `// Plop: Append ...` is added to the `<subreducer>.actions.ts` files

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
