### PR TITLE
Bug fix/898/buildings sorted differently after map render

### DIFF
--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.spec.ts
@@ -2,14 +2,13 @@ import "./mapTreeView.module"
 import { MapTreeViewController } from "./mapTreeView.component"
 import { CodeMapPreRenderService } from "../codeMap/codeMap.preRender.service"
 import { IRootScopeService, ITimeoutService } from "angular"
-import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
+import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { CodeMapNode, SortingOption } from "../../codeCharta.model"
 import {
 	VALID_NODE_WITH_MULTIPLE_FOLDERS,
 	VALID_NODE_WITH_MULTIPLE_FOLDERS_REVERSED,
 	VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_NAME,
-	VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_UNARY,
-	VALID_NODE_WITH_PATH
+	VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_UNARY
 } from "../../util/dataMocks"
 import _ from "lodash"
 import { StoreService } from "../../state/store.service"
@@ -21,7 +20,6 @@ describe("MapTreeViewController", () => {
 	let $rootScope: IRootScopeService
 	let $timeout: ITimeoutService
 	let storeService = getService<StoreService>("storeService")
-	let map: CodeMapNode
 	let mapWithMultipleFolders: CodeMapNode
 
 	beforeEach(() => {
@@ -36,7 +34,6 @@ describe("MapTreeViewController", () => {
 		$timeout = getService<ITimeoutService>("$timeout")
 		storeService = getService<StoreService>("storeService")
 
-		map = _.cloneDeep(VALID_NODE_WITH_PATH)
 		mapWithMultipleFolders = _.cloneDeep(VALID_NODE_WITH_MULTIPLE_FOLDERS)
 	}
 
@@ -101,12 +98,14 @@ describe("MapTreeViewController", () => {
 
 	describe("onRenderMapChanged", () => {
 		it("should update viewModel.rootNode after timeout", () => {
-			mapTreeViewController["_viewModel"] = { rootNode: null }
+			const testNode = VALID_NODE_WITH_MULTIPLE_FOLDERS
 
-			mapTreeViewController.onRenderMapChanged(map)
+			mapTreeViewController["_viewModel"].rootNode = null
+
+			mapTreeViewController.onRenderMapChanged(testNode)
 			$timeout.flush(100)
 
-			expect(mapTreeViewController["_viewModel"].rootNode).toBe(map)
+			expect(mapTreeViewController["_viewModel"].rootNode).toEqual(VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_NAME)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.ts
@@ -7,6 +7,8 @@ import {
 	SortingOrderAscendingSubscriber
 } from "../../state/store/appSettings/sortingOrderAscending/sortingOrderAscending.service"
 import { SortingOptionService, SortingOptionSubscriber } from "../../state/store/dynamicSettings/sortingOption/sortingOption.service"
+import _ from "lodash"
+const clone = require("rfdc")()
 
 export class MapTreeViewController implements CodeMapPreRenderServiceSubscriber, SortingOptionSubscriber, SortingOrderAscendingSubscriber {
 	private _viewModel: {
@@ -74,7 +76,11 @@ export class MapTreeViewController implements CodeMapPreRenderServiceSubscriber,
 			// needed to prevent flashing since event is triggered 4 times
 			return
 		}
-		this._viewModel.rootNode = map
+
+		if (!_.isMatch(this._viewModel.rootNode, map)) {
+			this._viewModel.rootNode = clone(map)
+		}
+
 		this.synchronizeAngularTwoWayBinding()
 
 		this.onSortingOptionChanged(this.storeService.getState().dynamicSettings.sortingOption)


### PR DESCRIPTION
## Buildings are sorted differently after map rendering
closes #898

## Description

After switch between to a metric and back the resulting map would change due to changes to the TreeView, this should no longer happen.

## Definition of Done
Map is not affected by switching a to a metric and back again.


A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
