### PR TITLE
Tech/use constant for unary name

### DIFF
--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -87,7 +87,7 @@ describe("MetricService", () => {
 		it("should add unary metric to metricData", () => {
 			metricService.onFilesSelectionChanged(undefined)
 
-			expect(metricService.getMetricData().filter(x => x.name === "unary").length).toBe(1)
+			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBe(1)
 		})
 	})
 
@@ -111,7 +111,7 @@ describe("MetricService", () => {
 		it("should add unary metric to metricData", () => {
 			metricService.onBlacklistChanged([])
 
-			expect(metricService.getMetricData().filter(x => x.name === "unary").length).toBeGreaterThan(0)
+			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBeGreaterThan(0)
 		})
 	})
 

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -16,6 +16,7 @@ interface MaxMetricValuePair {
 }
 
 export class MetricService implements FilesSelectionSubscriber, BlacklistSubscriber {
+	public static UNARY_METRIC = "unary"
 	private static METRIC_DATA_ADDED_EVENT = "metric-data-added"
 
 	//TODO MetricData should contain attributeType
@@ -120,9 +121,9 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 	}
 
 	private addUnaryMetric() {
-		if (!this.metricData.some(x => x.name === "unary")) {
+		if (!this.metricData.some(x => x.name === MetricService.UNARY_METRIC)) {
 			this.metricData.push({
-				name: "unary",
+				name: MetricService.UNARY_METRIC,
 				maxValue: 1
 			})
 		}

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.ts
@@ -8,6 +8,7 @@ import {
 } from "../../state/store/appSettings/sortingOrderAscending/sortingOrderAscending.service"
 import { SortingOptionService, SortingOptionSubscriber } from "../../state/store/dynamicSettings/sortingOption/sortingOption.service"
 import _ from "lodash"
+import { MetricService } from "../../state/metric.service"
 const clone = require("rfdc")()
 
 export class MapTreeViewController implements CodeMapPreRenderServiceSubscriber, SortingOptionSubscriber, SortingOrderAscendingSubscriber {
@@ -28,7 +29,7 @@ export class MapTreeViewController implements CodeMapPreRenderServiceSubscriber,
 		if (sortingOption === SortingOption.NUMBER_OF_FILES) {
 			this._viewModel.rootNode = this.applySortOrderChange(
 				this._viewModel.rootNode,
-				(a, b) => b.attributes["unary"] - a.attributes["unary"],
+				(a, b) => b.attributes[MetricService.UNARY_METRIC] - a.attributes[MetricService.UNARY_METRIC],
 				false
 			)
 		} else {

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
@@ -19,6 +19,7 @@ import { StoreService } from "../../state/store.service"
 import { setMarkedPackages } from "../../state/store/fileSettings/markedPackages/markedPackages.actions"
 import { setSearchedNodePaths } from "../../state/store/dynamicSettings/searchedNodePaths/searchedNodePaths.actions"
 import { setBlacklist } from "../../state/store/fileSettings/blacklist/blacklist.actions"
+import { MetricService } from "../../state/metric.service"
 
 describe("MapTreeViewLevelController", () => {
 	let mapTreeViewLevelController: MapTreeViewLevelController
@@ -343,7 +344,7 @@ describe("MapTreeViewLevelController", () => {
 
 			const result = mapTreeViewLevelController.getNodeUnaryValue()
 
-			expect(result).toBe(VALID_NODE_WITH_METRICS.attributes["unary"])
+			expect(result).toBe(VALID_NODE_WITH_METRICS.attributes[MetricService.UNARY_METRIC])
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.ts
@@ -8,6 +8,7 @@ import { CodeMapPreRenderService } from "../codeMap/codeMap.preRender.service"
 import { StoreService } from "../../state/store.service"
 import { addBlacklistItem, removeBlacklistItem } from "../../state/store/fileSettings/blacklist/blacklist.actions"
 import { focusNode } from "../../state/store/dynamicSettings/focusedNodePath/focusedNodePath.actions"
+import { MetricService } from "../../state/metric.service"
 
 export interface MapTreeViewHoverEventSubscriber {
 	onShouldHoverNode(node: CodeMapNode)
@@ -113,11 +114,11 @@ export class MapTreeViewLevelController implements BuildingHoveredSubscriber, Bu
 	}
 
 	public getNodeUnaryValue() {
-		return this.node.attributes["unary"]
+		return this.node.attributes[MetricService.UNARY_METRIC]
 	}
 
 	public getUnaryPercentage() {
-		const rootUnary = this.codeMapPreRenderService.getRenderMap().attributes["unary"]
+		const rootUnary = this.codeMapPreRenderService.getRenderMap().attributes[MetricService.UNARY_METRIC]
 		return ((100 * this.getNodeUnaryValue()) / rootUnary).toFixed(0)
 	}
 

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -21,6 +21,7 @@ import { MetricDistribution } from "./fileExtensionCalculator"
 import { Box3, Vector3 } from "three"
 import { IRootScopeService } from "angular"
 import { Files } from "../model/files"
+import { MetricService } from "../state/metric.service"
 
 export const VALID_NODE: CodeMapNode = {
 	name: "root",
@@ -55,36 +56,36 @@ export const VALID_NODE: CodeMapNode = {
 
 export const VALID_NODE_WITH_MULTIPLE_FOLDERS: CodeMapNode = {
 	name: "root",
-	attributes: { unary: 200 },
+	attributes: { [MetricService.UNARY_METRIC]: 200 },
 	type: NodeType.FOLDER,
 	children: [
 		{
 			name: "big leaf",
 			type: NodeType.FILE,
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			link: "http://www.google.de"
 		},
 		{
 			name: "Folder1",
 			type: NodeType.FOLDER,
-			attributes: { unary: 60 },
+			attributes: { [MetricService.UNARY_METRIC]: 60 },
 			children: []
 		},
 		{
 			name: "Folder2",
 			type: NodeType.FOLDER,
-			attributes: { unary: 40 },
+			attributes: { [MetricService.UNARY_METRIC]: 40 },
 			children: []
 		},
 		{
 			name: "Folder3",
 			type: NodeType.FOLDER,
-			attributes: { unary: 160 },
+			attributes: { [MetricService.UNARY_METRIC]: 160 },
 			children: [
 				{
 					name: "small leaf",
 					type: NodeType.FILE,
-					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
+					attributes: { rloc: 30, functions: 100, mcc: 100, [MetricService.UNARY_METRIC]: 1 }
 				}
 			]
 		}
@@ -93,37 +94,37 @@ export const VALID_NODE_WITH_MULTIPLE_FOLDERS: CodeMapNode = {
 
 export const VALID_NODE_WITH_MULTIPLE_FOLDERS_REVERSED: CodeMapNode = {
 	name: "root",
-	attributes: { unary: 200 },
+	attributes: { [MetricService.UNARY_METRIC]: 200 },
 	type: NodeType.FOLDER,
 	children: [
 		{
 			name: "Folder3",
 			type: NodeType.FOLDER,
-			attributes: { unary: 160 },
+			attributes: { [MetricService.UNARY_METRIC]: 160 },
 			children: [
 				{
 					name: "small leaf",
 					type: NodeType.FILE,
-					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
+					attributes: { rloc: 30, functions: 100, mcc: 100, [MetricService.UNARY_METRIC]: 1 }
 				}
 			]
 		},
 		{
 			name: "Folder2",
 			type: NodeType.FOLDER,
-			attributes: { unary: 40 },
+			attributes: { [MetricService.UNARY_METRIC]: 40 },
 			children: []
 		},
 		{
 			name: "Folder1",
 			type: NodeType.FOLDER,
-			attributes: { unary: 60 },
+			attributes: { [MetricService.UNARY_METRIC]: 60 },
 			children: []
 		},
 		{
 			name: "big leaf",
 			type: NodeType.FILE,
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			link: "http://www.google.de"
 		}
 	]
@@ -131,37 +132,37 @@ export const VALID_NODE_WITH_MULTIPLE_FOLDERS_REVERSED: CodeMapNode = {
 
 export const VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_UNARY: CodeMapNode = {
 	name: "root",
-	attributes: { unary: 200 },
+	attributes: { [MetricService.UNARY_METRIC]: 200 },
 	type: NodeType.FOLDER,
 	children: [
 		{
 			name: "Folder3",
 			type: NodeType.FOLDER,
-			attributes: { unary: 160 },
+			attributes: { [MetricService.UNARY_METRIC]: 160 },
 			children: [
 				{
 					name: "small leaf",
 					type: NodeType.FILE,
-					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
+					attributes: { rloc: 30, functions: 100, mcc: 100, [MetricService.UNARY_METRIC]: 1 }
 				}
 			]
 		},
 		{
 			name: "Folder1",
 			type: NodeType.FOLDER,
-			attributes: { unary: 60 },
+			attributes: { [MetricService.UNARY_METRIC]: 60 },
 			children: []
 		},
 		{
 			name: "Folder2",
 			type: NodeType.FOLDER,
-			attributes: { unary: 40 },
+			attributes: { [MetricService.UNARY_METRIC]: 40 },
 			children: []
 		},
 		{
 			name: "big leaf",
 			type: NodeType.FILE,
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			link: "http://www.google.de"
 		}
 	]
@@ -169,37 +170,37 @@ export const VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_UNARY: CodeMapNode = {
 
 export const VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_NAME: CodeMapNode = {
 	name: "root",
-	attributes: { unary: 200 },
+	attributes: { [MetricService.UNARY_METRIC]: 200 },
 	type: NodeType.FOLDER,
 	children: [
 		{
 			name: "Folder1",
 			type: NodeType.FOLDER,
-			attributes: { unary: 60 },
+			attributes: { [MetricService.UNARY_METRIC]: 60 },
 			children: []
 		},
 		{
 			name: "Folder2",
 			type: NodeType.FOLDER,
-			attributes: { unary: 40 },
+			attributes: { [MetricService.UNARY_METRIC]: 40 },
 			children: []
 		},
 		{
 			name: "Folder3",
 			type: NodeType.FOLDER,
-			attributes: { unary: 160 },
+			attributes: { [MetricService.UNARY_METRIC]: 160 },
 			children: [
 				{
 					name: "small leaf",
 					type: NodeType.FILE,
-					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
+					attributes: { rloc: 30, functions: 100, mcc: 100, [MetricService.UNARY_METRIC]: 1 }
 				}
 			]
 		},
 		{
 			name: "big leaf",
 			type: NodeType.FILE,
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			link: "http://www.google.de"
 		}
 	]
@@ -250,7 +251,7 @@ export const VALID_NODE_WITH_PATH: CodeMapNode = {
 
 export const VALID_NODE_WITH_ROOT_UNARY: CodeMapNode = {
 	name: "root",
-	attributes: { unary: 200 },
+	attributes: { [MetricService.UNARY_METRIC]: 200 },
 	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
@@ -258,20 +259,20 @@ export const VALID_NODE_WITH_ROOT_UNARY: CodeMapNode = {
 			name: "first leaf",
 			type: NodeType.FILE,
 			path: "/root/first leaf",
-			attributes: { unary: 100, functions: 10, mcc: 1 }
+			attributes: { [MetricService.UNARY_METRIC]: 100, functions: 10, mcc: 1 }
 		},
 		{
 			name: "second leaf",
 			type: NodeType.FILE,
 			path: "/root/second leaf",
-			attributes: { unary: 100, functions: 5, mcc: 1 }
+			attributes: { [MetricService.UNARY_METRIC]: 100, functions: 5, mcc: 1 }
 		}
 	]
 }
 
 export const VALID_NODE_DECORATED: CodeMapNode = {
 	name: "root",
-	attributes: { rloc: 100, functions: 10, mcc: 1, unary: 5 },
+	attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 5 },
 	type: NodeType.FOLDER,
 	path: "/root",
 	children: [
@@ -279,26 +280,26 @@ export const VALID_NODE_DECORATED: CodeMapNode = {
 			name: "big leaf",
 			type: NodeType.FILE,
 			path: "/root/big leaf",
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			link: "http://www.google.de"
 		},
 		{
 			name: "Parent Leaf",
 			type: NodeType.FOLDER,
-			attributes: { rloc: 100, functions: 10, mcc: 1, unary: 1 },
+			attributes: { rloc: 100, functions: 10, mcc: 1, [MetricService.UNARY_METRIC]: 1 },
 			path: "/root/Parent Leaf",
 			children: [
 				{
 					name: "small leaf",
 					type: NodeType.FILE,
 					path: "/root/Parent Leaf/small leaf",
-					attributes: { rloc: 30, functions: 100, mcc: 100, unary: 1 }
+					attributes: { rloc: 30, functions: 100, mcc: 100, [MetricService.UNARY_METRIC]: 1 }
 				},
 				{
 					name: "other small leaf",
 					type: NodeType.FILE,
 					path: "/root/Parent Leaf/other small leaf",
-					attributes: { rloc: 70, functions: 1000, mcc: 10, unary: 1 },
+					attributes: { rloc: 70, functions: 1000, mcc: 10, [MetricService.UNARY_METRIC]: 1 },
 					edgeAttributes: { Imports: { incoming: 12, outgoing: 13 } },
 					visible: true
 				}

--- a/visualization/app/codeCharta/util/fileDownloader.ts
+++ b/visualization/app/codeCharta/util/fileDownloader.ts
@@ -14,6 +14,7 @@ import {
 import { DownloadCheckboxNames } from "../ui/dialog/dialog.download.component"
 import { CodeChartaService } from "../codeCharta.service"
 import { stringify } from "querystring"
+import { MetricService } from "../state/metric.service"
 const clone = require("rfdc")()
 
 export class FileDownloader {
@@ -84,7 +85,7 @@ export class FileDownloader {
 			if (node.data.type === NodeType.FOLDER) {
 				node.data.attributes = {}
 			} else {
-				delete node.data.attributes["unary"]
+				delete node.data.attributes[MetricService.UNARY_METRIC]
 			}
 		})
 		return copy

--- a/visualization/app/codeCharta/util/nodeDecorator.spec.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.spec.ts
@@ -4,6 +4,7 @@ import { CCFile, MetricData, BlacklistItem, CodeMapNode, FileMeta, NodeType, Att
 import { NodeDecorator } from "./nodeDecorator"
 import { CodeMapHelper } from "./codeMapHelper"
 import _ from "lodash"
+import { MetricService } from "../state/metric.service"
 
 describe("nodeDecorator", () => {
 	let file: CCFile
@@ -339,7 +340,7 @@ describe("nodeDecorator", () => {
 			const h = d3.hierarchy(map)
 
 			h.each(node => {
-				expect(node.data.attributes["unary"]).toBeDefined()
+				expect(node.data.attributes[MetricService.UNARY_METRIC]).toBeDefined()
 			})
 		})
 
@@ -348,7 +349,7 @@ describe("nodeDecorator", () => {
 			NodeDecorator.decorateMap(map, fileMeta, metricData)
 			const h = d3.hierarchy(map)
 			h.each(node => {
-				expect(node.data.attributes["unary"]).toBeDefined()
+				expect(node.data.attributes[MetricService.UNARY_METRIC]).toBeDefined()
 			})
 		})
 	})

--- a/visualization/app/codeCharta/util/nodeDecorator.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.ts
@@ -14,6 +14,7 @@ import {
 	AttributeTypeValue
 } from "../codeCharta.model"
 import { CodeMapHelper } from "./codeMapHelper"
+import { MetricService } from "../state/metric.service"
 
 export class NodeDecorator {
 	public static decorateMap(map: CodeMapNode, fileMeta: FileMeta, metricData: MetricData[]) {
@@ -84,7 +85,7 @@ export class NodeDecorator {
 				node.data.visible = true
 				node.data.attributes = !node.data.attributes ? {} : node.data.attributes
 				node.data.edgeAttributes = !node.data.edgeAttributes ? {} : node.data.edgeAttributes
-				Object.assign(node.data.attributes, { unary: 1 })
+				Object.assign(node.data.attributes, { [MetricService.UNARY_METRIC]: 1 })
 			})
 		}
 	}


### PR DESCRIPTION
# Tech/use constant for unary name

## Description

- Use constant `MetricService.UNARY_METRIC` instead of metric name `"unary"` as a string throughout the project

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
