### PR TITLE
Bugfix/travis deployment as stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,20 +50,10 @@ jobs:
       script: cd analysis; ./gradlew build integrationTest
 
 
-    - stage: prepare release
-      name: "Create Release Package"
-      before_script: cd visualization; npm run build:web
-      script: npm run package
-    - name: "Build docker image"
-      before_script: cd visualization; npm run build:web
-      script: docker build -t maibornwolff/codecharta-visualization .
-    - name: "Build gh-pages"
-      script: ./script/build_gh_pages.sh
-
-
     - stage: deploy
       name: "Release build packages on GitHub"
-      script: skip
+      before_script: cd visualization; npm run build:web
+      script: npm run package
       deploy:
         - provider: releases
           api_key: $GITHUB_TOKEN
@@ -76,7 +66,7 @@ jobs:
             tags: true
             branch: master
     - name: "Commits gh-pages directory to the gh-pages branch" # Does not ignore built ressources
-      script: skip
+      script: ./script/build_gh_pages.sh
       deploy:
         - provider: pages
           github_token: $GITHUB_TOKEN
@@ -120,7 +110,8 @@ jobs:
             tags: true
             branch: master
     - name: "Publishes visualization docker image"
-      script: skip
+      before_script: cd visualization; npm run build:web
+      script: docker build -t maibornwolff/codecharta-visualization .
       deploy:
         - provider: script
           script: visualization/script/docker-publish.sh
@@ -131,8 +122,6 @@ jobs:
 
 stages:
   - test
-  - name: prepare release
-    if: branch = master
   - name: deploy
     if: branch = master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ jobs:
       before_script: chmod +x ./analysis/gradlew
       script: cd analysis; ./gradlew build integrationTest
 
-    - stage: release
+
+    - stage: prepare release
       name: "Create Release Package"
       before_script: cd visualization; npm run build:web
       script: npm run package
@@ -59,9 +60,80 @@ jobs:
     - name: "Build gh-pages"
       script: ./script/build_gh_pages.sh
 
+
+    - stage: deploy
+      name: "Release build packages on GitHub"
+      script: skip
+      deploy:
+        - provider: releases
+          api_key: $GITHUB_TOKEN
+          file_glob: true
+          file:
+            - "visualization/dist/packages/*.zip"
+            - "analysis/build/distributions/*.tar"
+          skip_cleanup: true
+          on:
+            tags: true
+            branch: master
+    - name: "Commits gh-pages directory to the gh-pages branch" # Does not ignore built ressources
+      script: skip
+      deploy:
+        - provider: pages
+          github_token: $GITHUB_TOKEN
+          skip_cleanup: true
+          local_dir: "gh-pages"
+          on:
+            tags: true
+            branch: master
+    - name: "Publishes visualization sonar results"
+      script: skip
+      deploy:
+        - provider: script
+          script: visualization/script/sonar-publish.sh
+          skip_cleanup: true
+          on:
+            branch: master
+    - name: "Publishes analysis sonar results"
+      script: skip
+      deploy:
+        - provider: script
+          script: analysis/script/sonar-publish.sh
+          skip_cleanup: true
+          on:
+            branch: master
+    - name: "Publishes visualization npm package"
+      script: skip
+      deploy:
+        - provider: script
+          script: visualization/script/npm-publish.sh
+          skip_cleanup: true
+          on:
+            tags: true
+            branch: master
+    - name: "Publishes analysis npm package"
+      script: skip
+      deploy:
+        - provider: script
+          script: analysis/script/npm-publish.sh
+          skip_cleanup: true
+          on:
+            tags: true
+            branch: master
+    - name: "Publishes visualization docker image"
+      script: skip
+      deploy:
+        - provider: script
+          script: visualization/script/docker-publish.sh
+          skip_cleanup: true
+          on:
+            tags: true
+            branch: master
+
 stages:
   - test
-  - name: release
+  - name: prepare release
+    if: branch = master
+  - name: deploy
     if: branch = master
 
 before_cache:
@@ -73,63 +145,3 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - ./visualization/node_modules/nwjs-builder-phoenix/caches/
-
-deploy:
-  # releases the built packages on github when a commit is tagged
-  - provider: releases
-    api_key: $GITHUB_TOKEN
-    file_glob: true
-    file:
-      - "visualization/dist/packages/*.zip"
-      - "analysis/build/distributions/*.tar"
-    skip_cleanup: true
-    on:
-      tags: true
-      branch: master
-
-  # commits the gh-pages directory to the gh-pages branch. Does not ignore built ressources
-  - provider: pages
-    github_token: $GITHUB_TOKEN
-    skip_cleanup: true
-    local_dir: "gh-pages"
-    on:
-      tags: true
-      branch: master
-
-  # publishes visualization sonar results
-  - provider: script
-    script: visualization/script/sonar-publish.sh
-    skip_cleanup: true
-    on:
-      branch: master
-
-  # publishes analysis sonar results
-  - provider: script
-    script: analysis/script/sonar-publish.sh
-    skip_cleanup: true
-    on:
-      branch: master
-
-  # publishes visualization npm package
-  - provider: script
-    script: visualization/script/npm-publish.sh
-    skip_cleanup: true
-    on:
-      tags: true
-      branch: master
-
-  # publishes analysis npm package
-  - provider: script
-    script: analysis/script/npm-publish.sh
-    skip_cleanup: true
-    on:
-      tags: true
-      branch: master
-
-  # publishes visualization docker image
-  - provider: script
-    script: visualization/script/docker-publish.sh
-    skip_cleanup: true
-    on:
-      tags: true
-      branch: master


### PR DESCRIPTION
# Bugfix/travis deployment as stage

## Description

- #915 didn't rewrite the deploy steps, which seemed to deploy after every script (so within every stage and every job)
- Now all deploy steps run combined with the preparing scripts but separate in multiple jobs in a stage called `deploy`, which now should only run on tagged commits on master when the stage `test` succeeds.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
