### PR TITLE
Change move show complete map button under the viewcube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Changed
 
+- Moved the show-complete-map-button when having a node focused under the view-cube #642
+
 ### Removed 🗑
 
 ### Fixed 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Changed
 
-- Moved the show-complete-map-button when having a node focused under the view-cube #642
+- Rename the button Show-Complete-Map button to Unfocus #642
+- Move the Unfocus button (visible when a node is focused) below the view-cube #642
 
 ### Removed 🗑
 

--- a/visualization/app/codeCharta/codeCharta.component.html
+++ b/visualization/app/codeCharta/codeCharta.component.html
@@ -5,8 +5,6 @@
 	<ribbon-bar-component class="ribbon-bar-component"></ribbon-bar-component>
 </div>
 
-<unfocus-button-component></unfocus-button-component>
-
 <code-map-component></code-map-component>
 
 <legend-panel-component></legend-panel-component>

--- a/visualization/app/codeCharta/codeCharta.component.scss
+++ b/visualization/app/codeCharta/codeCharta.component.scss
@@ -99,26 +99,6 @@ code-charta-component {
 		margin: 0;
 	}
 
-	.action-buttons {
-		position: fixed;
-		bottom: 2em;
-		right: 2em;
-		z-index: 60;
-
-		.long-button {
-			width: inherit;
-			padding-left: 10px;
-			padding-right: 10px;
-			border-radius: 100px;
-		}
-
-		> * {
-			margin-left: 4px;
-			margin-right: 4px;
-			z-index: 60;
-		}
-	}
-
 	.state-selector-button {
 		height: 22px;
 		vertical-align: bottom;

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
@@ -1,4 +1,5 @@
 <div id="codeMap" ng-hide="$ctrl._viewModel.isLoadingFile">
 	<view-cube-component ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></view-cube-component>
+	<unfocus-button-component></unfocus-button-component>
 	<attribute-side-bar-component></attribute-side-bar-component>
 </div>

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -9,25 +9,4 @@ code-map-component {
 			right: 350px;
 		}
 	}
-
-	.action-buttons {
-		position: absolute;
-		top: 200px;
-		right: 15px;
-		z-index: 60;
-		width: 180px;
-
-		.long-button {
-			width: inherit;
-			padding-left: 10px;
-			padding-right: 10px;
-			border-radius: 100px;
-		}
-
-		> * {
-			margin-left: 4px;
-			margin-right: 4px;
-			z-index: 60;
-		}
-	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -9,4 +9,25 @@ code-map-component {
 			right: 350px;
 		}
 	}
+
+	.action-buttons {
+		position: absolute;
+		top: 200px;
+		right: 15px;
+		z-index: 60;
+		width: 180px;
+
+		.long-button {
+			width: inherit;
+			padding-left: 10px;
+			padding-right: 10px;
+			border-radius: 100px;
+		}
+
+		> * {
+			margin-left: 4px;
+			margin-right: 4px;
+			z-index: 60;
+		}
+	}
 }

--- a/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.html
+++ b/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.html
@@ -1,10 +1,9 @@
-<div class="action-buttons">
-	<md-button
-		ng-if="$ctrl._viewModel.isNodeFocused"
-		class="md-fab md-primary cc-shadow long-button"
-		aria-label="Remove Focus on node"
-		ng-click="$ctrl.removeFocusedNode()"
-	>
-		Show complete map
-	</md-button>
-</div>
+<md-button
+	ng-if="$ctrl._viewModel.isNodeFocused"
+	class="md-fab md-primary cc-shadow"
+	id="unfocus-button"
+	aria-label="Remove Focus on node"
+	ng-click="$ctrl.removeFocusedNode()"
+>
+	Unfocus
+</md-button>

--- a/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.scss
+++ b/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.scss
@@ -1,2 +1,12 @@
 unfocus-button-component {
+	#unfocus-button {
+		position: absolute;
+		top: 200px;
+		right: 40px;
+		z-index: 60;
+		width: 100px !important;
+		padding-left: 10px;
+		padding-right: 10px;
+		border-radius: 100px;
+	}
 }


### PR DESCRIPTION
# Move the show complete map button under the viewCube

closes #642 

## Description

- Moved the show complete map button under the viewcube

## Screenshots or gifs

### Before
![image](https://user-images.githubusercontent.com/12533626/80386845-37c8a100-88a8-11ea-8e74-8612e3ffaeb6.png)

### After
![image](https://user-images.githubusercontent.com/12533626/80386773-25e6fe00-88a8-11ea-82ac-10ba6e06604c.png)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
