### PR TITLE
Bug/730/delta mode broken with exported files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Generating a delta map with merged empty folders in between is now working correctly #730
+
 ### Chore 👨‍💻 👩‍💻
 
 - [Security] Bump jquery from 3.4.0 to 3.5.0 in /visualization #944

--- a/visualization/app/codeCharta/util/__snapshots__/mapBuilder.spec.ts.snap
+++ b/visualization/app/codeCharta/util/__snapshots__/mapBuilder.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mapBuilder createCodeMapFromHashMap 1`] = `
+exports[`mapBuilder createCodeMapFromHashMap should create a valid delta map 1`] = `
 Object {
   "attributes": Object {},
   "children": Array [
@@ -61,6 +61,78 @@ Object {
       "isFlattened": false,
       "name": "Parent Leaf",
       "path": "/root/Parent Leaf",
+      "type": "Folder",
+    },
+  ],
+  "isExcluded": false,
+  "isFlattened": false,
+  "name": "root",
+  "path": "/root",
+  "type": "Folder",
+}
+`;
+
+exports[`mapBuilder createCodeMapFromHashMap should create a valid delta map with empty folders in between 1`] = `
+Object {
+  "attributes": Object {},
+  "children": Array [
+    Object {
+      "attributes": Object {
+        "functions": 10,
+        "mcc": 1,
+        "rloc": 100,
+      },
+      "children": Array [],
+      "isExcluded": false,
+      "isFlattened": false,
+      "link": "http://www.google.de",
+      "name": "big leaf",
+      "path": "/root/in/between/big leaf",
+      "type": "File",
+    },
+    Object {
+      "attributes": Object {},
+      "children": Array [
+        Object {
+          "attributes": Object {
+            "functions": 100,
+            "mcc": 100,
+            "rloc": 30,
+          },
+          "children": Array [],
+          "isExcluded": false,
+          "isFlattened": false,
+          "name": "small leaf",
+          "path": "/root/in/between/Parent Leaf/small leaf",
+          "type": "File",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "isExcluded": false,
+          "isFlattened": false,
+          "name": "empty folder",
+          "path": "/root/in/between/Parent Leaf/empty folder",
+          "type": "Folder",
+        },
+        Object {
+          "attributes": Object {
+            "functions": 1000,
+            "mcc": 10,
+            "rloc": 70,
+          },
+          "children": Array [],
+          "isExcluded": false,
+          "isFlattened": false,
+          "name": "other small leaf",
+          "path": "/root/in/between/Parent Leaf/other small leaf",
+          "type": "File",
+        },
+      ],
+      "isExcluded": false,
+      "isFlattened": false,
+      "name": "Parent Leaf",
+      "path": "/root/in/between/Parent Leaf",
       "type": "Folder",
     },
   ],

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -320,6 +320,61 @@ export const VALID_NODE_WITH_PATH: CodeMapNode = {
 	]
 }
 
+export const VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH: CodeMapNode = {
+	name: "root",
+	attributes: {},
+	type: NodeType.FOLDER,
+	path: "/root",
+	isExcluded: false,
+	isFlattened: false,
+	children: [
+		{
+			name: "big leaf",
+			type: NodeType.FILE,
+			path: "/root/in/between/big leaf",
+			attributes: { rloc: 100, functions: 10, mcc: 1 },
+			link: "http://www.google.de",
+			isExcluded: false,
+			isFlattened: false
+		},
+		{
+			name: "Parent Leaf",
+			type: NodeType.FOLDER,
+			attributes: {},
+			path: "/root/in/between/Parent Leaf",
+			isExcluded: false,
+			isFlattened: false,
+			children: [
+				{
+					name: "small leaf",
+					type: NodeType.FILE,
+					path: "/root/in/between/Parent Leaf/small leaf",
+					attributes: { rloc: 30, functions: 100, mcc: 100 },
+					isExcluded: false,
+					isFlattened: false
+				},
+				{
+					name: "other small leaf",
+					type: NodeType.FILE,
+					path: "/root/in/between/Parent Leaf/other small leaf",
+					attributes: { rloc: 70, functions: 1000, mcc: 10 },
+					isExcluded: false,
+					isFlattened: false
+				},
+				{
+					name: "empty folder",
+					type: NodeType.FOLDER,
+					path: "/root/in/between/Parent Leaf/empty folder",
+					attributes: {},
+					isExcluded: false,
+					isFlattened: false,
+					children: []
+				}
+			]
+		}
+	]
+}
+
 export const VALID_NODE_WITH_ROOT_UNARY: CodeMapNode = {
 	name: "root",
 	attributes: { [MetricService.UNARY_METRIC]: 200 },

--- a/visualization/app/codeCharta/util/mapBuilder.spec.ts
+++ b/visualization/app/codeCharta/util/mapBuilder.spec.ts
@@ -1,16 +1,17 @@
-import { VALID_NODE_WITH_PATH } from "./dataMocks"
-import { CodeMapNode, NodeType } from "../codeCharta.model"
+import { VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH, VALID_NODE_WITH_PATH } from "./dataMocks"
+import { CodeMapNode } from "../codeCharta.model"
 import { MapBuilder } from "./mapBuilder"
+import _ from "lodash"
 
 describe("mapBuilder", () => {
 	let rootNode: CodeMapNode
 
 	beforeEach(() => {
-		rootNode = VALID_NODE_WITH_PATH
+		rootNode = _.cloneDeep(VALID_NODE_WITH_PATH)
 	})
 
-	it("createCodeMapFromHashMap", () => {
-		const hashMap: Map<string, CodeMapNode> = new Map([
+	function buildHashMap(rootNode: CodeMapNode): Map<string, CodeMapNode> {
+		return new Map([
 			[rootNode.path, rootNode],
 			[rootNode.children[0].path, rootNode.children[0]],
 			[rootNode.children[1].path, rootNode.children[1]],
@@ -18,40 +19,27 @@ describe("mapBuilder", () => {
 			[rootNode.children[1].children[1].path, rootNode.children[1].children[1]],
 			[rootNode.children[1].children[2].path, rootNode.children[1].children[2]]
 		])
-		expect(MapBuilder.createCodeMapFromHashMap(hashMap)).toMatchSnapshot()
-	})
+	}
 
-	it("getParentPath", () => {
-		expect(MapBuilder["getParentPath"]("/root/nodeA")).toEqual("/root")
-		expect(MapBuilder["getParentPath"]("/root/nodeA/nodeB")).toEqual("/root/nodeA")
-	})
+	describe("createCodeMapFromHashMap", () => {
+		it("should create a valid delta map", () => {
+			const hashMap = buildHashMap(rootNode)
 
-	describe("findNode", () => {
-		it("should find child node", () => {
-			const expected: CodeMapNode = {
-				name: "big leaf",
-				type: NodeType.FILE,
-				path: "/root/big leaf",
-				children: [],
-				attributes: { rloc: 100, functions: 10, mcc: 1 },
-				link: "http://www.google.de",
-				isExcluded: false,
-				isFlattened: false
-			}
-			expect(MapBuilder["findNode"](rootNode, "/root/big leaf")).toEqual(expected)
+			expect(MapBuilder.createCodeMapFromHashMap(hashMap)).toMatchSnapshot()
 		})
 
-		it("should find grand-child node", () => {
-			const expected: CodeMapNode = {
-				name: "other small leaf",
-				type: NodeType.FILE,
-				path: "/root/Parent Leaf/other small leaf",
-				children: [],
-				attributes: { rloc: 70, functions: 1000, mcc: 10 },
-				isExcluded: false,
-				isFlattened: false
-			}
-			expect(MapBuilder["findNode"](rootNode, "/root/Parent Leaf/other small leaf")).toEqual(expected)
+		it("should create a valid delta map with empty folders in between", () => {
+			rootNode = _.cloneDeep(VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH)
+			const hashMap = buildHashMap(rootNode)
+
+			expect(MapBuilder.createCodeMapFromHashMap(hashMap)).toMatchSnapshot()
+		})
+	})
+
+	describe("getParentPath", () => {
+		it("should cut the end of the last encountered slash", () => {
+			expect(MapBuilder["getParentPath"]("/root/nodeA")).toEqual("/root")
+			expect(MapBuilder["getParentPath"]("/root/nodeA/nodeB")).toEqual("/root/nodeA")
 		})
 	})
 })

--- a/visualization/app/codeCharta/util/mapBuilder.ts
+++ b/visualization/app/codeCharta/util/mapBuilder.ts
@@ -4,10 +4,11 @@ import { CodeChartaService } from "../codeCharta.service"
 export class MapBuilder {
 	public static createCodeMapFromHashMap(hashMapWithAllNodes: Map<string, CodeMapNode>): CodeMapNode {
 		let rootNode: CodeMapNode = this.getEmptyRootNode()
+		const sortedNodes = this.getHashMapSortedByPath(hashMapWithAllNodes)
 
-		this.getHashMapSortedByPath(hashMapWithAllNodes).forEach((node: CodeMapNode, path: string) => {
+		sortedNodes.forEach((node: CodeMapNode, path: string) => {
 			node.children = []
-			const parentNode: CodeMapNode = this.findNode(rootNode, this.getParentPath(path))
+			const parentNode: CodeMapNode = this.getParentNode(sortedNodes, path, rootNode)
 			if (node.path == CodeChartaService.ROOT_PATH) {
 				rootNode = node
 			} else {
@@ -32,23 +33,20 @@ export class MapBuilder {
 	}
 
 	private static getParentPath(path: string): string {
-		const parentPathArray = path.split("/")
-		parentPathArray.splice(parentPathArray.length - 1, 1)
-		return parentPathArray.length == 1 ? "/" : parentPathArray.join("/")
+		return path.substring(0, path.lastIndexOf("/"))
 	}
 
-	private static findNode(parent: CodeMapNode, path: string): CodeMapNode {
-		if (parent.path == path || path == "/") {
-			return parent
-		} else {
-			if (parent.children && parent.children.length > 0) {
-				for (const child of parent.children) {
-					const foundNode = this.findNode(child, path)
-					if (foundNode) {
-						return foundNode
-					}
-				}
-			}
+	private static getParentNode(sortedHashMap: Map<string, CodeMapNode>, path: string, rootNode: CodeMapNode): CodeMapNode {
+		if (path === CodeChartaService.ROOT_PATH) {
+			return rootNode
 		}
+
+		const parentPath = this.getParentPath(path)
+
+		if (sortedHashMap.has(parentPath)) {
+			return sortedHashMap.get(parentPath)
+		}
+
+		return this.getParentNode(sortedHashMap, parentPath, rootNode)
 	}
 }


### PR DESCRIPTION
# Delta mode not working with files including merged empty folders

closes #730

## Description

Before the algorithm only detected parent nodes by checking one level. With empty folders in between this resulted in an undefined return. We now look for the parentNode until we actually find one or until we reach the rootNode.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
