### PR TITLE
Fix unfocus-button blocking visibility of attribute side bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Attribute-Side-Bar being invisible
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.47.0] - 2020-05-02

--- a/visualization/app/codeCharta/codeCharta.component.scss
+++ b/visualization/app/codeCharta/codeCharta.component.scss
@@ -53,7 +53,8 @@ code-charta-component {
 	attribute-side-bar-component .side-bar-container,
 	legend-panel-component .block-wrapper,
 	legend-panel-component .panel-button,
-	view-cube-component {
+	view-cube-component,
+	unfocus-button-component {
 		transition: right 0.25s ease;
 	}
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
@@ -1,5 +1,5 @@
 <div id="codeMap" ng-hide="$ctrl._viewModel.isLoadingFile">
 	<view-cube-component ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></view-cube-component>
-	<unfocus-button-component></unfocus-button-component>
+	<unfocus-button-component ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></unfocus-button-component>
 	<attribute-side-bar-component></attribute-side-bar-component>
 </div>

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -9,4 +9,10 @@ code-map-component {
 			right: 350px;
 		}
 	}
+
+	unfocus-button-component {
+		&.sideBarVisible {
+			right: 390px;
+		}
+	}
 }

--- a/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.html
+++ b/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.html
@@ -1,7 +1,6 @@
 <md-button
 	ng-if="$ctrl._viewModel.isNodeFocused"
 	class="md-fab md-primary cc-shadow"
-	id="unfocus-button"
 	aria-label="Remove Focus on node"
 	ng-click="$ctrl.removeFocusedNode()"
 >

--- a/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.scss
+++ b/visualization/app/codeCharta/ui/unfocusButton/unfocusButton.component.scss
@@ -1,12 +1,13 @@
 unfocus-button-component {
-	#unfocus-button {
-		position: absolute;
-		top: 200px;
-		right: 40px;
-		z-index: 60;
+	position: absolute;
+	top: 200px;
+	right: 40px;
+	z-index: 60;
+
+	.md-button {
 		width: 100px !important;
 		padding-left: 10px;
 		padding-right: 10px;
-		border-radius: 100px;
+		border-radius: 100px !important;
 	}
 }


### PR DESCRIPTION
# Unfocus-button blocking visibility of attribute side bar

## Description

- Unfocus button overlapped with the attribute-side-bar making it invisible due to wrong div placement
- Added a transition to the unfocus button when opening the attribute-side-bar
- Unfocus button relocates when the attribute-side-bar is opened as the view cube does

## Screenshots or gifs

![focus_transition](https://user-images.githubusercontent.com/12533626/81236835-63612f00-8ffe-11ea-80b0-f8ef36f6f800.gif)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
