### PR TITLE
Height Component File Extension Bar

### DIFF
--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
@@ -31,7 +31,7 @@ file-extension-bar-component {
 	.bar-details {
 		display: block;
 		width: 100%;
-		height: 15px;
+		height: 0px;
 		text-align: center;
 		background-color: white;
 		overflow: hidden;
@@ -54,7 +54,7 @@ file-extension-bar-component {
 
 			.bar-details-text {
 				color: black;
-				font-size: 10px;
+				font-size: 15px;
 				margin-left: 30px;
 				margin-top: 3px;
 
@@ -68,7 +68,7 @@ file-extension-bar-component {
 
 				.metric-value {
 					color: gray;
-					font-size: 10px;
+					font-size: 15px;
 
 					&.hidden {
 						display: none;


### PR DESCRIPTION
# Sonar Code Changes File Extension Bar Bug

addresses changes brought in#747

## Description
In the Sonar code change we chose the wrong height, resulting in the bar being permanently shown.
This should change it back to being "closable" by the user.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
