### PR TITLE
Revert file-loader update #973

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -5913,12 +5913,12 @@
 			}
 		},
 		"file-loader": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.0.0.tgz",
-			"integrity": "sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.3.0.tgz",
+			"integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
 			"requires": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^2.6.5"
+				"loader-utils": "^1.2.3",
+				"schema-utils": "^2.5.0"
 			},
 			"dependencies": {
 				"ajv-keywords": {
@@ -5937,21 +5937,21 @@
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
 				},
 				"json5": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"requires": {
-						"minimist": "^1.2.5"
+						"minimist": "^1.2.0"
 					}
 				},
 				"loader-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 					"requires": {
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
-						"json5": "^2.1.2"
+						"json5": "^1.0.1"
 					}
 				},
 				"minimist": {
@@ -6580,7 +6580,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -7042,6 +7043,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7070,7 +7072,8 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
@@ -11193,6 +11196,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -11202,7 +11206,8 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -96,7 +96,7 @@
 		"angularjs-slider": "^7.0.0",
 		"color-convert": "^2.0.0",
 		"d3": "^5.9.2",
-		"file-loader": "^6.0.0",
+		"file-loader": "^4.2.0",
 		"font-awesome": "^4.7.0",
 		"ignore": "^5.0.2",
 		"inquirer-directory": "^2.2.0",


### PR DESCRIPTION
# Change file-loader version back from 6 to 4

## Description

This version update is removing our font-awesome-icons. Reverting this solves the issue for now.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
