### PR TITLE
Fix digest bottleneck

### DIFF
--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -90,6 +90,15 @@ describe("MetricService", () => {
 			expect($rootScope.$broadcast).toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())
 		})
 
+		it("should not broadcast a METRIC_DATA_ADDED_EVENT if metricData is still the same", () => {
+			const oldMetricData = metricService.getMetricData()
+
+			metricService.onFilesSelectionChanged(undefined)
+
+			expect($rootScope.$broadcast).not.toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())
+			expect(oldMetricData).toEqual(metricService.getMetricData())
+		})
+
 		it("should add unary metric to metricData", () => {
 			metricService.onFilesSelectionChanged(undefined)
 
@@ -114,6 +123,15 @@ describe("MetricService", () => {
 			metricService.onBlacklistChanged([])
 
 			expect($rootScope.$broadcast).toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())
+		})
+
+		it("should not broadcast a METRIC_DATA_ADDED_EVENT if metricData is still the same", () => {
+			const oldMetricData = metricService.getMetricData()
+
+			metricService.onFilesSelectionChanged(undefined)
+
+			expect($rootScope.$broadcast).not.toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())
+			expect(oldMetricData).toEqual(metricService.getMetricData())
 		})
 
 		it("should add unary metric to metricData", () => {

--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -82,7 +82,9 @@ describe("MetricService", () => {
 			expect(metricService["metricData"]).toEqual(metricData)
 		})
 
-		it("should broadcast a METRIC_DATA_ADDED_EVENT", () => {
+		it("should broadcast a METRIC_DATA_ADDED_EVENT if metricData changed", () => {
+			metricService["metricData"] = []
+
 			metricService.onFilesSelectionChanged(undefined)
 
 			expect($rootScope.$broadcast).toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())
@@ -106,7 +108,9 @@ describe("MetricService", () => {
 			expect(metricService["metricData"]).toEqual(metricData)
 		})
 
-		it("should broadcast a METRIC_DATA_ADDED_EVENT", () => {
+		it("should broadcast a METRIC_DATA_ADDED_EVENT if metricData changed", () => {
+			metricService["metricData"] = []
+
 			metricService.onBlacklistChanged([])
 
 			expect($rootScope.$broadcast).toHaveBeenCalledWith("metric-data-added", metricService.getMetricData())

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -8,6 +8,7 @@ import { FilesService, FilesSelectionSubscriber } from "./store/files/files.serv
 import { AttributeTypesSubscriber, AttributeTypesService } from "./store/fileSettings/attributeTypes/attributeTypes.service"
 import { fileStatesAvailable, getVisibleFileStates } from "../model/files/files.helper"
 import { FileState } from "../model/files/files"
+import _ from "lodash"
 
 export interface MetricServiceSubscriber {
 	onMetricDataAdded(metricData: MetricData[])
@@ -64,9 +65,12 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 	}
 
 	private setNewMetricData() {
-		this.metricData = this.calculateMetrics()
-		this.addUnaryMetric()
-		this.notifyMetricDataAdded()
+		const newMetricData = this.calculateMetrics()
+		this.addUnaryMetric(newMetricData)
+		if (!_.isEqual(this.metricData, newMetricData)) {
+			this.metricData = newMetricData
+			this.notifyMetricDataAdded()
+		}
 	}
 
 	private calculateMetrics(): MetricData[] {
@@ -128,13 +132,11 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 		return metricData.sort((a, b) => (a.name > b.name ? 1 : b.name > a.name ? -1 : 0))
 	}
 
-	private addUnaryMetric() {
-		if (!this.metricData.some(x => x.name === MetricService.UNARY_METRIC)) {
-			this.metricData.push({
-				name: MetricService.UNARY_METRIC,
-				maxValue: 1
-			})
-		}
+	private addUnaryMetric(metricData: MetricData[]) {
+		metricData.push({
+			name: MetricService.UNARY_METRIC,
+			maxValue: 1
+		})
 	}
 
 	private notifyMetricDataAdded() {

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
@@ -72,7 +72,7 @@
 			<div class="metric-box scrollable-content">
 				<table class="secondary-metrics" aria-hidden="true">
 					<th>Secondary Metrics</th>
-					<tr ng-repeat="attributekey in $ctrl._viewModel.secondaryMetricKeys">
+					<tr ng-repeat="attributekey in $ctrl._viewModel.secondaryMetricKeys track by $index">
 						<td>
 							<span class="metric-value">{{ $ctrl._viewModel.node.attributes[attributekey] | number: 0 }}</span>
 						</td>

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.exclude.component.html
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.exclude.component.html
@@ -17,7 +17,7 @@
 			</div>
 		</md-list-item>
 
-		<md-list-item ng-repeat="item in $ctrl._viewModel.exclude track by $index | orderBy: ['path']" title="{{::item.path}}">
+		<md-list-item ng-repeat="item in $ctrl._viewModel.exclude | orderBy: ['path'] track by $index" title="{{::item.path}}">
 			<md-button class="round-button" ng-click="$ctrl.removeBlacklistEntry(item)">
 				<i class="fa fa-minus-square" title="Remove list item"></i>
 			</md-button>

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.exclude.component.html
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.exclude.component.html
@@ -17,7 +17,7 @@
 			</div>
 		</md-list-item>
 
-		<md-list-item ng-repeat="item in $ctrl._viewModel.exclude | orderBy: ['path']" title="{{::item.path}}">
+		<md-list-item ng-repeat="item in $ctrl._viewModel.exclude track by $index | orderBy: ['path']" title="{{::item.path}}">
 			<md-button class="round-button" ng-click="$ctrl.removeBlacklistEntry(item)">
 				<i class="fa fa-minus-square" title="Remove list item"></i>
 			</md-button>

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.flatten.component.html
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.flatten.component.html
@@ -17,7 +17,7 @@
 			</div>
 		</md-list-item>
 
-		<md-list-item ng-repeat="item in $ctrl._viewModel.flatten track by $index | orderBy: ['path']" title="{{::item.path}}">
+		<md-list-item ng-repeat="item in $ctrl._viewModel.flatten | orderBy: ['path'] track by $index" title="{{::item.path}}">
 			<md-button class="round-button" ng-click="$ctrl.removeBlacklistEntry(item)">
 				<i class="fa fa-minus-square" title="Remove list item"></i>
 			</md-button>

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.flatten.component.html
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.flatten.component.html
@@ -17,7 +17,7 @@
 			</div>
 		</md-list-item>
 
-		<md-list-item ng-repeat="item in $ctrl._viewModel.flatten | orderBy: ['path']" title="{{::item.path}}">
+		<md-list-item ng-repeat="item in $ctrl._viewModel.flatten track by $index | orderBy: ['path']" title="{{::item.path}}">
 			<md-button class="round-button" ng-click="$ctrl.removeBlacklistEntry(item)">
 				<i class="fa fa-minus-square" title="Remove list item"></i>
 			</md-button>

--- a/visualization/app/codeCharta/ui/dialog/dialog.addScenarioSettings.component.html
+++ b/visualization/app/codeCharta/ui/dialog/dialog.addScenarioSettings.component.html
@@ -14,7 +14,11 @@
 
 			<p>The scenario includes:</p>
 
-			<md-input-container class="input-container md-block" ng-repeat="item in $ctrl._viewModel.scenarioContent" class="md-block">
+			<md-input-container
+				class="input-container md-block"
+				ng-repeat="item in $ctrl._viewModel.scenarioContent track by $index"
+				class="md-block"
+			>
 				<md-checkbox class="dialog-list md-primary" ng-disabled="::item.isDisabled" ng-model="::item.isSelected">
 					<span ng-if="item.metricType == 'Camera-Position'">{{::item.metricType}} </span>
 					<span ng-if="item.metricType != 'Camera-Position'">{{::item.metricType}} ({{::item.metricName}}) </span>

--- a/visualization/app/codeCharta/ui/dialog/dialog.download.component.html
+++ b/visualization/app/codeCharta/ui/dialog/dialog.download.component.html
@@ -16,7 +16,11 @@
 			>AttributeTypes ({{ $ctrl._viewModel.amountOfAttributeTypes }})</md-checkbox
 		>
 
-		<md-input-container class="input-container md-block" ng-repeat="item in $ctrl._viewModel.fileContent" class="md-block">
+		<md-input-container
+			class="input-container md-block"
+			ng-repeat="item in $ctrl._viewModel.fileContent track by $index"
+			class="md-block"
+		>
 			<md-checkbox class="dialog-list md-primary" ng-disabled="::item.isDisabled" ng-model="::item.isSelected">
 				<span>{{::item.name}} ({{::item.numberOfListItems}})</span>
 			</md-checkbox>

--- a/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.html
+++ b/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.html
@@ -24,7 +24,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.edgeMetricData" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.edgeMetricData track by $index" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="edges" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
@@ -7,7 +7,7 @@
 		<div
 			class="bar-section"
 			ng-click="$ctrl.toggleExtensiveMode()"
-			ng-repeat="item in $ctrl._viewModel.distribution"
+			ng-repeat="item in $ctrl._viewModel.distribution track by $index"
 			ng-style="{ width: item.relativeMetricValue + '%', background: item.color }"
 		>
 			<p
@@ -23,7 +23,7 @@
 		</div>
 	</div>
 	<div class="bar-details" ng-class="{ expanded: $ctrl._viewModel.isExtensiveMode }" ng-click="$ctrl.togglePercentageAbsoluteValues()">
-		<div class="bar-details-section" ng-repeat="item in $ctrl._viewModel.distribution">
+		<div class="bar-details-section" ng-repeat="item in $ctrl._viewModel.distribution track by $index">
 			<p class="bar-details-text">
 				<span class="dot" ng-style="{ background: item.color }"></span>{{ item.fileExtension }} :
 				<span class="metric-value" ng-class="{ hidden: $ctrl._viewModel.isAbsoluteValueVisible }"

--- a/visualization/app/codeCharta/ui/filePanel/filePanel.component.html
+++ b/visualization/app/codeCharta/ui/filePanel/filePanel.component.html
@@ -24,7 +24,10 @@
 		ng-model="$ctrl._viewModel.selectedFileNames.single"
 		ng-change="$ctrl.onSingleFileChange($ctrl._viewModel.selectedFileNames.single)"
 	>
-		<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
+		<md-option
+			ng-repeat="fileState in $ctrl._viewModel.files track by fileState.file.fileMeta.fileName"
+			value="{{::fileState.file.fileMeta.fileName}}"
+		>
 			<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 		</md-option>
 	</md-select>
@@ -41,7 +44,10 @@
 		<md-button ng-click="$ctrl.selectZeroPartialFiles()">None</md-button>
 		<md-button ng-click="$ctrl.invertPartialFileSelection()">Invert</md-button>
 
-		<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
+		<md-option
+			ng-repeat="fileState in $ctrl._viewModel.files track by fileState.file.fileMeta.fileName"
+			value="{{::fileState.file.fileMeta.fileName}}"
+		>
 			<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 		</md-option>
 	</md-select>
@@ -54,7 +60,10 @@
 			ng-model="$ctrl._viewModel.selectedFileNames.delta.reference"
 			ng-change="$ctrl.onDeltaReferenceFileChange($ctrl._viewModel.selectedFileNames.delta.reference)"
 		>
-			<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
+			<md-option
+				ng-repeat="fileState in $ctrl._viewModel.files track by fileState.file.fileMeta.fileName"
+				value="{{::fileState.file.fileMeta.fileName}}"
+			>
 				<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 			</md-option>
 		</md-select>
@@ -72,7 +81,10 @@
 			ng-model="$ctrl._viewModel.selectedFileNames.delta.comparison"
 			ng-change="$ctrl.onDeltaComparisonFileChange($ctrl._viewModel.selectedFileNames.delta.comparison)"
 		>
-			<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
+			<md-option
+				ng-repeat="fileState in $ctrl._viewModel.files track by fileState.file.fileMeta.fileName"
+				value="{{::fileState.file.fileMeta.fileName}}"
+			>
 				<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 			</md-option>
 		</md-select>

--- a/visualization/app/codeCharta/ui/filePanel/filePanel.component.html
+++ b/visualization/app/codeCharta/ui/filePanel/filePanel.component.html
@@ -24,7 +24,7 @@
 		ng-model="$ctrl._viewModel.selectedFileNames.single"
 		ng-change="$ctrl.onSingleFileChange($ctrl._viewModel.selectedFileNames.single)"
 	>
-		<md-option ng-repeat="fileState in $ctrl._viewModel.files" value="{{::fileState.file.fileMeta.fileName}}">
+		<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
 			<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 		</md-option>
 	</md-select>
@@ -41,7 +41,7 @@
 		<md-button ng-click="$ctrl.selectZeroPartialFiles()">None</md-button>
 		<md-button ng-click="$ctrl.invertPartialFileSelection()">Invert</md-button>
 
-		<md-option ng-repeat="fileState in $ctrl._viewModel.files" value="{{::fileState.file.fileMeta.fileName}}">
+		<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
 			<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 		</md-option>
 	</md-select>
@@ -54,7 +54,7 @@
 			ng-model="$ctrl._viewModel.selectedFileNames.delta.reference"
 			ng-change="$ctrl.onDeltaReferenceFileChange($ctrl._viewModel.selectedFileNames.delta.reference)"
 		>
-			<md-option ng-repeat="fileState in $ctrl._viewModel.files" value="{{::fileState.file.fileMeta.fileName}}">
+			<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
 				<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 			</md-option>
 		</md-select>
@@ -72,7 +72,7 @@
 			ng-model="$ctrl._viewModel.selectedFileNames.delta.comparison"
 			ng-change="$ctrl.onDeltaComparisonFileChange($ctrl._viewModel.selectedFileNames.delta.comparison)"
 		>
-			<md-option ng-repeat="fileState in $ctrl._viewModel.files" value="{{::fileState.file.fileMeta.fileName}}">
+			<md-option ng-repeat="fileState in $ctrl._viewModel.files track by $index" value="{{::fileState.file.fileMeta.fileName}}">
 				<md-truncate>{{::fileState.file.fileMeta.fileName}}</md-truncate>
 			</md-option>
 		</md-select>

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.component.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.component.html
@@ -47,11 +47,15 @@
 	</div>
 
 	<hr ng-show="$ctrl._viewModel.packageLists[0]" />
-	<div class="legend-block" ng-show="$ctrl._viewModel.packageLists" ng-repeat="packageList in $ctrl._viewModel.packageLists">
+	<div
+		class="legend-block"
+		ng-show="$ctrl._viewModel.packageLists"
+		ng-repeat="packageList in $ctrl._viewModel.packageLists track by $index"
+	>
 		<img ng-src="{{::packageList.colorPixel}}" alt="" />
 		<span
 			class="marked-package {{ $first ? '' : 'set-left-margin' }}"
-			ng-repeat="item in packageList.markedPackages"
+			ng-repeat="item in packageList.markedPackages track by $index"
 			title="{{::item.path}}"
 		>
 			{{::item.path}}{{ $last ? "" : ",&nbsp;" }}

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
@@ -52,7 +52,7 @@
 	</div>
 
 	<div class="tree-element-children tree-element-children-{{::$ctrl.depth?$ctrl.depth:0}}">
-		<div ng-if="$ctrl._viewModel.isFolderOpened" ng-repeat="node in $ctrl.node.children">
+		<div ng-if="$ctrl._viewModel.isFolderOpened" ng-repeat="node in $ctrl.node.children track by $index">
 			<map-tree-view-level-component node="::node" depth="::$ctrl.depth+1"></map-tree-view-level-component>
 		</div>
 	</div>

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.area.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by metric.name" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.color.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by metric.name" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.distribution.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.distribution.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 			</md-option>

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.distribution.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.distribution.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by metric.name" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 			</md-option>

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.height.component.html
@@ -20,7 +20,7 @@
 			/>
 		</md-select-header>
 		<md-content class="option-group">
-			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by $index" value="{{::metric.name}}">
+			<md-option ng-repeat="metric in $ctrl._viewModel.metricData track by metric.name" value="{{::metric.name}}">
 				{{::metric.name}}
 				<span class="metric-max-value">({{::metric.maxValue}})</span>
 				<attribute-type-selector-component class="attribute-type-select" type="nodes" metric="{{::metric.name}}">

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.html
@@ -2,7 +2,7 @@
 	<div ng-if="$ctrl.nodeIsFolder()">
 		<div layout="row" layout-align="center center">
 			<md-button
-				ng-repeat="color in $ctrl._viewModel.markingColors"
+				ng-repeat="color in $ctrl._viewModel.markingColors track by $index"
 				ng-style="{'background-color':'{{ color }}'}"
 				ng-disabled="primary === color && !isPrimary"
 				ng-click="$ctrl.clickColor(color)"

--- a/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.html
+++ b/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.html
@@ -20,7 +20,7 @@
 				ng-disabled="!scenario.isScenarioAppliable"
 				>{{ scenario.scenarioName }}</md-button
 			>
-			<span class="content-icons" ng-repeat="icon in scenario.icons">
+			<span class="content-icons" ng-repeat="icon in scenario.icons track by $index">
 				<i class="fa {{ icon.faIconClass }}" ng-class="{ 'is-saved': icon.isSaved }"></i>
 			</span>
 			<md-button ng-click="$ctrl.removeScenario(scenario.scenarioName)" class="action-button remove button-hovering">

--- a/visualization/app/codeCharta/ui/sortingOption/sortingOption.component.html
+++ b/visualization/app/codeCharta/ui/sortingOption/sortingOption.component.html
@@ -1,6 +1,6 @@
 <md-input-container class="box-rounded">
 	<md-select ng-model="$ctrl._viewModel.sortingOption" ng-class="{ 'md-select-fixed-width': true }" ng-change="$ctrl.onChange()">
-		<md-option ng-repeat="option in $ctrl._viewModel.sortingOptions" ng-value="option">
+		<md-option ng-repeat="option in $ctrl._viewModel.sortingOptions track by $index" ng-value="option">
 			{{ option }}
 		</md-option>
 	</md-select>

--- a/visualization/app/codeCharta/util/reduxHelper.ts
+++ b/visualization/app/codeCharta/util/reduxHelper.ts
@@ -1,10 +1,10 @@
-import angular from "angular"
+import _ from "lodash"
 
 const clone = require("rfdc")()
 
 export function removeItemFromArray(array: any[], item: any): any[] {
 	return array.filter(x => {
-		return !isEqualObject(x, item)
+		return !_.isEqual(x, item)
 	})
 }
 
@@ -22,9 +22,5 @@ export function isActionOfType(actionType: string, actions) {
 }
 
 function arrayContainsItem(array: any[], item: any): boolean {
-	return array.some(x => isEqualObject(x, item))
-}
-
-function isEqualObject(obj1: any, obj2: any): boolean {
-	return angular.toJson(obj1) === angular.toJson(obj2)
+	return array.some(x => _.isEqual(x, item))
 }

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -1154,7 +1154,7 @@
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 		},
 		"ansi-html": {
@@ -5688,7 +5688,7 @@
 		},
 		"external-editor": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
 			"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
 			"requires": {
 				"extend": "^3.0.0",
@@ -8675,7 +8675,7 @@
 		},
 		"inquirer": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+			"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
 			"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
 			"requires": {
 				"ansi-escapes": "^1.1.0",
@@ -8724,7 +8724,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				}
 			}
@@ -12319,7 +12319,7 @@
 		},
 		"onetime": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 		},
 		"opn": {

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -135,9 +135,9 @@
 			}
 		},
 		"@types/angular": {
-			"version": "1.6.54",
-			"resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.54.tgz",
-			"integrity": "sha512-xA1FuozWXeRQ7FClUbvk8ePL+dydBeDoCWRPFTHU5+8uvVtIIfLGiHA8CMkwsbddFCYnTDVbLxG85a/HBx7LtA==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.7.2.tgz",
+			"integrity": "sha512-UBEgZTFg+tAvGZrJpTfTrRbBHXdcA3GErBs+QfIM1K8Gnzl7WghYc7gsbWRQ7rXvpnxmbffAFLPkKl32XEx8IQ==",
 			"dev": true
 		},
 		"@types/angular-mocks": {

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -86,7 +86,7 @@
 	},
 	"dependencies": {
 		"ajv": "^6.12.2",
-		"angular": "^1.6.9",
+		"angular": "^1.8.0",
 		"angular-animate": "^1.6.9",
 		"angular-aria": "^1.6.9",
 		"angular-material": "^1.1.7",
@@ -112,7 +112,7 @@
 		"three-orbit-controls": "^82.1.0"
 	},
 	"devDependencies": {
-		"@types/angular": "^1.6.43",
+		"@types/angular": "^1.7.2",
 		"@types/angular-mocks": "^1.5.11",
 		"@types/color-convert": "^1.9.0",
 		"@types/d3": "^5.7.1",


### PR DESCRIPTION
# Fix digest bottleneck


## Description

This PR is a beast. It reduces all the watchers by using the `track by` feature. We went from 1.2s to 80ms when switching from single to delta mode. The tricky part here were the `md-select` and the `ng-repeats` with objects inside. You can't just simply use `track by $index` here. Instead you have to track it by a unique property. For files this is the fileName, for metrics it's the metricName.

This PR also updates angular to it's latest version.

Please review and merge this first before #999 since some of the discussions are adressed in this PR.

## Screenshots or gifs

Before:
![image](https://user-images.githubusercontent.com/12533626/85215069-90319180-b373-11ea-849b-76308840916d.png)

After:
![image](https://user-images.githubusercontent.com/12533626/85614316-0fb4ae80-b65b-11ea-99d5-6577f8005964.png)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
