### PR TITLE
Bug/863/color range updated when blacklisting buildings

### DIFF
--- a/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.spec.ts
+++ b/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.spec.ts
@@ -21,12 +21,13 @@ describe("RangeSliderController", () => {
 	let $timeout: ITimeoutService
 	let storeService: StoreService
 	let metricService: MetricService
+	let colorRangeService: ColorRangeService
 	let rangeSliderController: RangeSliderController
 
 	let mapColors: MapColors
 
 	function rebuildController() {
-		rangeSliderController = new RangeSliderController($rootScope, $timeout, storeService, metricService)
+		rangeSliderController = new RangeSliderController($rootScope, $timeout, storeService, metricService, colorRangeService)
 	}
 
 	function restartSystem() {
@@ -36,6 +37,7 @@ describe("RangeSliderController", () => {
 		$timeout = getService<ITimeoutService>("$timeout")
 		storeService = getService<StoreService>("storeService")
 		metricService = getService<MetricService>("metricService")
+		colorRangeService = getService<ColorRangeService>("colorRangeService")
 
 		mapColors = storeService.getState().appSettings.mapColors
 	}
@@ -104,6 +106,25 @@ describe("RangeSliderController", () => {
 			rebuildController()
 
 			expect(FilesService.subscribe).toHaveBeenCalledWith($rootScope, rangeSliderController)
+		})
+	})
+
+	describe("onBlacklistChanged", () => {
+		it("should call reset the colorRange", () => {
+			rangeSliderController["_viewModel"].sliderOptions.ceil = 19
+			colorRangeService.reset = jest.fn()
+
+			rangeSliderController.onBlacklistChanged()
+
+			expect(colorRangeService.reset).toHaveBeenCalled()
+		})
+		it("should not reset the colorRange if maxValue has not changed", () => {
+			rangeSliderController["_viewModel"].sliderOptions.ceil = 100
+			colorRangeService.reset = jest.fn()
+
+			rangeSliderController.onBlacklistChanged()
+
+			expect(colorRangeService.reset).not.toHaveBeenCalled()
 		})
 	})
 


### PR DESCRIPTION
# ColorRange slider is updated when maxValue building is excluded 

closes #863 and #926

## Description

The Color Range Slider is updated, when the max valued building is excluded. 
When a map, where the max valued color metric building is excluded is loaded, it now divides the color range correctly into 3 parts.

## Screenshots or gifs
When the max valued colorMetric building is excluded: 

![MaxValue_blacklisted](https://user-images.githubusercontent.com/50145538/85870781-d18bcc00-b7cd-11ea-9713-fc9b7f70f9df.gif)

When a map is loaded, where the buildings with the max valued colorMetric are excluded:

![loadmap_with_MaxValue_blacklisted](https://user-images.githubusercontent.com/50145538/85870903-f7b16c00-b7cd-11ea-964c-778f86ac5dca.gif)


## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
