### PR TITLE
Fix unary metric being added if cc.json already contains it

### DIFF
--- a/visualization/app/codeCharta/state/metric.service.spec.ts
+++ b/visualization/app/codeCharta/state/metric.service.spec.ts
@@ -104,6 +104,14 @@ describe("MetricService", () => {
 
 			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBe(1)
 		})
+
+		it("should not add unary metric a second time if the cc.json already contains unary", () => {
+			metricData.push({ name: MetricService.UNARY_METRIC, maxValue: 1 })
+
+			metricService.onFilesSelectionChanged(undefined)
+
+			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBe(1)
+		})
 	})
 
 	describe("onBlacklistChanged", () => {
@@ -138,6 +146,14 @@ describe("MetricService", () => {
 			metricService.onBlacklistChanged([])
 
 			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBeGreaterThan(0)
+		})
+
+		it("should not add unary metric a second time if the cc.json already contains unary", () => {
+			metricData.push({ name: MetricService.UNARY_METRIC, maxValue: 1 })
+
+			metricService.onFilesSelectionChanged(undefined)
+
+			expect(metricService.getMetricData().filter(x => x.name === MetricService.UNARY_METRIC).length).toBe(1)
 		})
 	})
 

--- a/visualization/app/codeCharta/state/metric.service.ts
+++ b/visualization/app/codeCharta/state/metric.service.ts
@@ -133,10 +133,12 @@ export class MetricService implements FilesSelectionSubscriber, BlacklistSubscri
 	}
 
 	private addUnaryMetric(metricData: MetricData[]) {
-		metricData.push({
-			name: MetricService.UNARY_METRIC,
-			maxValue: 1
-		})
+		if (!metricData.some(x => x.name === MetricService.UNARY_METRIC)) {
+			metricData.push({
+				name: MetricService.UNARY_METRIC,
+				maxValue: 1
+			})
+		}
 	}
 
 	private notifyMetricDataAdded() {


### PR DESCRIPTION
# Fix unary metric being added twice

## Description

I removed that check in another PR thinking it wasn't necessary. However I found some older cc.jsons back when we exported the metrics without removing the unary metric. That means, that there are cc.jsons out there with the unary metric in it. For those, adding the unary metric a second time in our metricData will result in an error, since metric names need to be unique.

I also added a test that should give enough documentation on why this check is necessary.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
