### PR TITLE
Bug/1034/Persist color conversions to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Improve render performance by persisting color conversions #1034
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.49.1] - 2020-07-03

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
@@ -78,11 +78,11 @@ export class CodeMapArrowService
 
 			if (buildingIsOriginNode) {
 				this.highlightBuilding(arrowTargetNode)
-				const color = ColorConverter.convertHexToNumber(state.appSettings.mapColors.outgoingEdge)
+				const color = ColorConverter.getNumber(state.appSettings.mapColors.outgoingEdge)
 				this.setCurveColor(curve, color)
 			} else {
 				this.highlightBuilding(arrowOriginNode)
-				const color = ColorConverter.convertHexToNumber(state.appSettings.mapColors.incomingEdge)
+				const color = ColorConverter.getNumber(state.appSettings.mapColors.incomingEdge)
 				this.setCurveColor(curve, color)
 			}
 		}
@@ -201,7 +201,7 @@ export class CodeMapArrowService
 			arrowColor = this.storeService.getState().appSettings.mapColors.outgoingEdge
 		}
 
-		return this.buildEdge(pointsPreviews, ColorConverter.convertHexToNumber(arrowColor))
+		return this.buildEdge(pointsPreviews, ColorConverter.getNumber(arrowColor))
 	}
 
 	private buildEdge(points: Vector3[], color: number): Object3D {

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
@@ -47,19 +47,19 @@ export class CodeMapBuilding {
 	}
 
 	public getColorVector(): Vector3 {
-		return ColorConverter.colorToVector3(this._color)
+		return ColorConverter.getVector3(this._color)
 	}
 
 	public getDefaultColorVector(): Vector3 {
-		return ColorConverter.colorToVector3(this._defaultColor)
+		return ColorConverter.getVector3(this._defaultColor)
 	}
 
 	public getDeltaColorVector(): Vector3 {
-		return ColorConverter.colorToVector3(this._deltaColor)
+		return ColorConverter.getVector3(this._deltaColor)
 	}
 
 	public getDefaultDeltaColorVector(): Vector3 {
-		return ColorConverter.colorToVector3(this._defaultDeltaColor)
+		return ColorConverter.getVector3(this._defaultDeltaColor)
 	}
 
 	public resetColor() {

--- a/visualization/app/codeCharta/ui/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/geometryGenerator.ts
@@ -91,7 +91,7 @@ export class GeometryGenerator {
 
 	private getMarkingColorWithGradient(n: Node) {
 		if (n.markingColor) {
-			const markingColorAsNumber = ColorConverter.convertHexToNumber(n.markingColor)
+			const markingColorAsNumber = ColorConverter.getNumber(n.markingColor)
 			const markingColorWithGradient = markingColorAsNumber & (n.depth % 2 === 0 ? 0xdddddd : 0xffffff)
 			return ColorConverter.convertNumberToHex(markingColorWithGradient)
 		} else {

--- a/visualization/app/codeCharta/ui/codeMap/rendering/geometryGenerator.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/geometryGenerator.ts
@@ -160,7 +160,7 @@ export class GeometryGenerator {
 			uvs[i * uvDimension + 0] = data.uvs[i].x
 			uvs[i * uvDimension + 1] = data.uvs[i].y
 
-			const color: THREE.Vector3 = ColorConverter.colorToVector3(data.colors[i])
+			const color: THREE.Vector3 = ColorConverter.getVector3(data.colors[i])
 
 			colors[i * dimension + 0] = color.x
 			colors[i * dimension + 1] = color.y

--- a/visualization/app/codeCharta/util/color/colorConverter.spec.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.spec.ts
@@ -4,6 +4,7 @@ import { Vector3 } from "three"
 describe("colorConverter", () => {
 	beforeEach(() => {
 		ColorConverter["colorToVector3Map"].clear()
+		ColorConverter["hexToNumberMap"].clear()
 	})
 
 	describe("convertHexToNumber", () => {
@@ -148,6 +149,26 @@ describe("colorConverter", () => {
 
 			expect(actual).toEqual(new Vector3(0.5098039215686274, 0.054901960784313725, 0.054901960784313725))
 			expect(ColorConverter["colorToVector3Map"].size).toBe(1)
+		})
+	})
+
+	describe("getNumber", () => {
+		it("should return the number from a hex", () => {
+			const expected = 8523278
+			ColorConverter["hexToNumberMap"].set("#820E0E", expected)
+
+			const actual = ColorConverter.getNumber("#820E0E")
+
+			expect(actual).toEqual(expected)
+		})
+
+		it("should add the hex if it's not in the map and return it", () => {
+			expect(ColorConverter["hexToNumberMap"].size).toBe(0)
+
+			const actual = ColorConverter.getNumber("#820E0E")
+
+			expect(actual).toEqual(8523278)
+			expect(ColorConverter["hexToNumberMap"].size).toBe(1)
 		})
 	})
 })

--- a/visualization/app/codeCharta/util/color/colorConverter.spec.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.spec.ts
@@ -2,6 +2,10 @@ import { ColorConverter } from "./colorConverter"
 import { Vector3 } from "three"
 
 describe("colorConverter", () => {
+	beforeEach(() => {
+		ColorConverter["colorToVector3Map"].clear()
+	})
+
 	describe("convertHexToNumber", () => {
 		it("should return that the input can't be a number", () => {
 			const result = ColorConverter.convertHexToNumber("string")
@@ -124,6 +128,26 @@ describe("colorConverter", () => {
 			expect(result.r).toBe(25)
 			expect(result.g).toBe(127)
 			expect(result.b).toBe(153)
+		})
+	})
+
+	describe("getVector3", () => {
+		it("should return the vector3 from a color", () => {
+			const expected = new Vector3(0.5098039215686274, 0.054901960784313725, 0.054901960784313725)
+			ColorConverter["colorToVector3Map"].set("#820E0E", expected)
+
+			const actual = ColorConverter.getVector3("#820E0E")
+
+			expect(actual).toEqual(expected)
+		})
+
+		it("should add the color if it's not in the map and return it", () => {
+			expect(ColorConverter["colorToVector3Map"].size).toBe(0)
+
+			const actual = ColorConverter.getVector3("#820E0E")
+
+			expect(actual).toEqual(new Vector3(0.5098039215686274, 0.054901960784313725, 0.054901960784313725))
+			expect(ColorConverter["colorToVector3Map"].size).toBe(1)
 		})
 	})
 })

--- a/visualization/app/codeCharta/util/color/colorConverter.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.ts
@@ -17,11 +17,13 @@ export class ColorConverter {
 	}
 
 	public static getNumber(hex: string): number {
-		if (!this.hexToNumberMap.has(hex)) {
-			this.hexToNumberMap.set(hex, ColorConverter.convertHexToNumber(hex))
+		let number = this.hexToNumberMap.get(hex)
+		if (number === undefined) {
+			number = ColorConverter.convertHexToNumber(hex)
+			this.hexToNumberMap.set(hex, number)
 		}
 
-		return this.hexToNumberMap.get(hex)
+		return number
 	}
 
 	public static convertHexToNumber(hex: string): number {

--- a/visualization/app/codeCharta/util/color/colorConverter.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.ts
@@ -3,6 +3,16 @@ import convert from "color-convert"
 import { HSL } from "./hsl"
 
 export class ColorConverter {
+	private static colorToVector3Map = new Map<string, Vector3>()
+
+	public static getVector3(color: string): Vector3 {
+		if (!this.colorToVector3Map.has(color)) {
+			this.colorToVector3Map.set(color, ColorConverter.colorToVector3(color))
+		}
+
+		return this.colorToVector3Map.get(color)
+	}
+
 	public static convertHexToNumber(hex: string): number {
 		return Number(hex.replace("#", "0x"))
 	}

--- a/visualization/app/codeCharta/util/color/colorConverter.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.ts
@@ -7,11 +7,13 @@ export class ColorConverter {
 	private static hexToNumberMap = new Map<string, number>()
 
 	public static getVector3(color: string): Vector3 {
-		if (!this.colorToVector3Map.has(color)) {
-			this.colorToVector3Map.set(color, ColorConverter.colorToVector3(color))
+		let vector = this.colorToVector3Map.get(color)
+		if (vector === undefined) {
+			vector = ColorConverter.colorToVector3(color)
+			this.colorToVector3Map.set(color, vector)
 		}
 
-		return this.colorToVector3Map.get(color)
+		return vector
 	}
 
 	public static getNumber(hex: string): number {

--- a/visualization/app/codeCharta/util/color/colorConverter.ts
+++ b/visualization/app/codeCharta/util/color/colorConverter.ts
@@ -4,6 +4,7 @@ import { HSL } from "./hsl"
 
 export class ColorConverter {
 	private static colorToVector3Map = new Map<string, Vector3>()
+	private static hexToNumberMap = new Map<string, number>()
 
 	public static getVector3(color: string): Vector3 {
 		if (!this.colorToVector3Map.has(color)) {
@@ -11,6 +12,14 @@ export class ColorConverter {
 		}
 
 		return this.colorToVector3Map.get(color)
+	}
+
+	public static getNumber(hex: string): number {
+		if (!this.hexToNumberMap.has(hex)) {
+			this.hexToNumberMap.set(hex, ColorConverter.convertHexToNumber(hex))
+		}
+
+		return this.hexToNumberMap.get(hex)
 	}
 
 	public static convertHexToNumber(hex: string): number {


### PR DESCRIPTION
# Persist color conversions to improve performance

closes #1034 

## Description

- Adds a map to store colorToVector3 conversions
- Adds a map to store hexToNumber conversions
- Replaces all occurences of conversions with checking the dedicated maps

@BridgeAR I wasn't able to notice a performance boost, but technically this should improve the performance by a lot. What map did you use to notice the huge amount of color conversions?

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
