### PR TITLE
Feature/1071/auto expand on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Changed
 
+- Search Panel will open now when clicking in the search field and collapse when clicking somewhere else #1071
+
 ### Removed 🗑
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/codeCharta.component.html
+++ b/visualization/app/codeCharta/codeCharta.component.html
@@ -1,23 +1,27 @@
-<tool-bar-component></tool-bar-component>
+<div ng-mousedown="$ctrl.onClick()">
+	<tool-bar-component></tool-bar-component>
 
-<file-extension-bar-component></file-extension-bar-component>
-<div class="ribbon-bar-wrapper">
-	<ribbon-bar-component class="ribbon-bar-component"></ribbon-bar-component>
-</div>
-
-<code-map-component></code-map-component>
-
-<legend-panel-component></legend-panel-component>
-
-<loading-gif-file-component></loading-gif-file-component>
-
-<div id="mw-logo">
-	<div class="logo">
-		<a href="https://www.maibornwolff.de" target="_blank"><img src="assets/logo.png" alt="MaibornWolff" rel="noopener noreferrer" /></a>
-		<h2>
-			<span>CodeCharta {{ $ctrl._viewModel.version }}</span>
-		</h2>
+	<file-extension-bar-component></file-extension-bar-component>
+	<div class="ribbon-bar-wrapper">
+		<ribbon-bar-component class="ribbon-bar-component"></ribbon-bar-component>
 	</div>
-</div>
 
-<node-context-menu-component></node-context-menu-component>
+	<code-map-component></code-map-component>
+
+	<legend-panel-component></legend-panel-component>
+
+	<loading-gif-file-component></loading-gif-file-component>
+
+	<div id="mw-logo">
+		<div class="logo">
+			<a href="https://www.maibornwolff.de" target="_blank"
+				><img src="assets/logo.png" alt="MaibornWolff" rel="noopener noreferrer"
+			/></a>
+			<h2>
+				<span>CodeCharta {{ $ctrl._viewModel.version }}</span>
+			</h2>
+		</div>
+	</div>
+
+	<node-context-menu-component></node-context-menu-component>
+</div>

--- a/visualization/app/codeCharta/codeCharta.component.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.component.spec.ts
@@ -1,17 +1,15 @@
 import "./codeCharta.module"
-import _ from "lodash"
 import { IHttpService, ILocationService } from "angular"
 import { DialogService } from "./ui/dialog/dialog.service"
 import { CodeChartaService } from "./codeCharta.service"
 import { CodeChartaController } from "./codeCharta.component"
 import { getService, instantiateModule } from "../../mocks/ng.mockhelper"
-import { State } from "./codeCharta.model"
-import { ScenarioHelper } from "./util/scenarioHelper"
 import { InjectorService } from "./state/injector.service"
 import { StoreService } from "./state/store.service"
-import { STATE } from "./util/dataMocks"
 import { setAppSettings } from "./state/store/appSettings/appSettings.actions"
 import { ThreeCameraService } from "./ui/codeMap/threeViewer/threeCameraService"
+import { setSearchPanelMode } from "./state/store/appSettings/searchPanelMode/searchPanelMode.actions"
+import { SearchPanelMode } from "./codeCharta.model"
 
 describe("codeChartaController", () => {
 	let codeChartaController: CodeChartaController
@@ -22,7 +20,6 @@ describe("codeChartaController", () => {
 	let dialogService: DialogService
 	let codeChartaService: CodeChartaService
 	let injectorService: InjectorService
-	let state: State
 
 	beforeEach(() => {
 		restartSystem()
@@ -31,7 +28,6 @@ describe("codeChartaController", () => {
 		withMockedUrlUtils()
 		withMockedCodeChartaService()
 		withMockedDialogService()
-		withMockedScenarioHelper()
 	})
 
 	function restartSystem() {
@@ -44,8 +40,6 @@ describe("codeChartaController", () => {
 		dialogService = getService<DialogService>("dialogService")
 		codeChartaService = getService<CodeChartaService>("codeChartaService")
 		injectorService = getService<InjectorService>("injectorService")
-
-		state = _.cloneDeep(STATE)
 	}
 
 	function rebuildController() {
@@ -78,10 +72,6 @@ describe("codeChartaController", () => {
 	function initThreeCameraService() {
 		// Has to be called, to initialize the camera
 		threeCameraService.init(1536, 754)
-	}
-
-	function withMockedScenarioHelper() {
-		ScenarioHelper.getDefaultScenario = jest.fn().mockReturnValue({ settings: state })
 	}
 
 	describe("constructor", () => {
@@ -151,6 +141,16 @@ describe("codeChartaController", () => {
 			codeChartaController.tryLoadingSampleFiles()
 
 			expect(codeChartaService.loadFiles).toHaveBeenCalledWith(expected)
+		})
+	})
+
+	describe("onClick", () => {
+		it("should minimize the search panel if it's expanded", () => {
+			storeService.dispatch(setSearchPanelMode(SearchPanelMode.exclude))
+
+			codeChartaController.onClick()
+
+			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.minimized)
 		})
 	})
 })

--- a/visualization/app/codeCharta/codeCharta.component.ts
+++ b/visualization/app/codeCharta/codeCharta.component.ts
@@ -4,7 +4,7 @@ import "./codeCharta.component.scss"
 import { CodeChartaService } from "./codeCharta.service"
 import { ScenarioHelper } from "./util/scenarioHelper"
 import { DialogService } from "./ui/dialog/dialog.service"
-import { NameDataPair } from "./codeCharta.model"
+import { NameDataPair, SearchPanelMode } from "./codeCharta.model"
 import { InjectorService } from "./state/injector.service"
 import { StoreService } from "./state/store.service"
 import { setState } from "./state/store/state.actions"
@@ -13,6 +13,7 @@ import { setIsLoadingFile } from "./state/store/appSettings/isLoadingFile/isLoad
 import * as codeCharta from "../../package.json"
 import { setDelta, setMultiple, setSingle } from "./state/store/files/files.actions"
 import { getCCFiles } from "./model/files/files.helper"
+import { setSearchPanelMode } from "./state/store/appSettings/searchPanelMode/searchPanelMode.actions"
 
 export class CodeChartaController {
 	private _viewModel: {
@@ -65,6 +66,12 @@ export class CodeChartaController {
 			{ fileName: "sample1.cc.json", content: require("./assets/sample1.cc.json") },
 			{ fileName: "sample2.cc.json", content: require("./assets/sample2.cc.json") }
 		])
+	}
+
+	public onClick() {
+		if (this.storeService.getState().appSettings.searchPanelMode !== SearchPanelMode.minimized) {
+			this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.minimized))
+		}
 	}
 
 	private tryLoadingFiles(values: NameDataPair[]) {

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
@@ -1,10 +1,10 @@
 <md-card ng-class="{ expanded: $ctrl._viewModel.isExpanded }" ng-attr-id="search-panel-card">
 	<div class="section">
 		<div class="section-header">
-			<search-bar-component></search-bar-component>
+			<search-bar-component ng-click="$ctrl.openSearchPanel(); ; $event.stopPropagation()"></search-bar-component>
 			<search-panel-mode-selector-component></search-panel-mode-selector-component>
 		</div>
-		<span class="section-title" ng-click="$ctrl.toggle()"> Search <i class="fa fa-angle-down"></i> </span>
+		<span class="section-title" ng-click="$ctrl.toggle(); $event.stopPropagation()"> Search <i class="fa fa-angle-down"></i> </span>
 		<div class="section-body">
 			<blacklist-panel-flatten-component ng-show="$ctrl._viewModel.searchPanelMode === 'flatten'"></blacklist-panel-flatten-component>
 			<blacklist-panel-exclude-component ng-show="$ctrl._viewModel.searchPanelMode === 'exclude'"></blacklist-panel-exclude-component>

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
@@ -1,10 +1,10 @@
-<md-card ng-class="{ expanded: $ctrl._viewModel.isExpanded }" ng-attr-id="search-panel-card">
+<md-card ng-class="{ expanded: $ctrl._viewModel.isExpanded }" ng-attr-id="search-panel-card" ng-mousedown="$event.stopPropagation()">
 	<div class="section">
 		<div class="section-header">
-			<search-bar-component ng-click="$ctrl.openSearchPanel(); ; $event.stopPropagation()"></search-bar-component>
+			<search-bar-component ng-click="$ctrl.openSearchPanel()"></search-bar-component>
 			<search-panel-mode-selector-component></search-panel-mode-selector-component>
 		</div>
-		<span class="section-title" ng-click="$ctrl.toggle(); $event.stopPropagation()"> Search <i class="fa fa-angle-down"></i> </span>
+		<span class="section-title" ng-click="$ctrl.toggle()"> Search <i class="fa fa-angle-down"></i> </span>
 		<div class="section-body">
 			<blacklist-panel-flatten-component ng-show="$ctrl._viewModel.searchPanelMode === 'flatten'"></blacklist-panel-flatten-component>
 			<blacklist-panel-exclude-component ng-show="$ctrl._viewModel.searchPanelMode === 'exclude'"></blacklist-panel-exclude-component>

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.spec.ts
@@ -67,4 +67,22 @@ describe("SearchPanelController", () => {
 			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.minimized)
 		})
 	})
+
+	describe("openSearchPanel", () => {
+		it("should open the search panel", () => {
+			searchPanelModeController["_viewModel"].isExpanded = false
+
+			searchPanelModeController.openSearchPanel()
+
+			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.treeView)
+		})
+
+		it("should open the search panel even though it's open already", () => {
+			searchPanelModeController["_viewModel"].isExpanded = true
+
+			searchPanelModeController.openSearchPanel()
+
+			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.treeView)
+		})
+	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.spec.ts
@@ -76,13 +76,5 @@ describe("SearchPanelController", () => {
 
 			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.treeView)
 		})
-
-		it("should open the search panel even though it's open already", () => {
-			searchPanelModeController["_viewModel"].isExpanded = true
-
-			searchPanelModeController.openSearchPanel()
-
-			expect(storeService.getState().appSettings.searchPanelMode).toEqual(SearchPanelMode.treeView)
-		})
 	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
@@ -38,9 +38,7 @@ export class SearchPanelController implements SearchPanelModeSubscriber {
 	}
 
 	public openSearchPanel() {
-		if (!this._viewModel.isExpanded) {
-			this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
-		}
+		this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
 	}
 }
 

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
@@ -36,6 +36,10 @@ export class SearchPanelController implements SearchPanelModeSubscriber {
 			this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
 		}
 	}
+
+	public openSearchPanel() {
+		this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
+	}
 }
 
 export const searchPanelComponent = {

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.ts
@@ -38,7 +38,9 @@ export class SearchPanelController implements SearchPanelModeSubscriber {
 	}
 
 	public openSearchPanel() {
-		this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
+		if (!this._viewModel.isExpanded) {
+			this.storeService.dispatch(setSearchPanelMode(SearchPanelMode.treeView))
+		}
 	}
 }
 

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.component.html
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.component.html
@@ -3,20 +3,20 @@
 		class="state-selector-button left"
 		id="tree-view"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'treeView' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('treeView'); $event.stopPropagation()"
+		ng-click="$ctrl.onToggleSearchPanelMode('treeView')"
 		><i class="fa fa-sitemap"></i
 	></md-button>
 	<md-button
 		class="state-selector-button middle"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'flatten' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('flatten'); $event.stopPropagation()"
+		ng-click="$ctrl.onToggleSearchPanelMode('flatten')"
 		><i class="fa fa-eye-slash"></i>
 		<div class="list-length-count" ng-show="$ctrl._viewModel.flattenListLength > 0"></div
 	></md-button>
 	<md-button
 		class="state-selector-button right"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'exclude' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('exclude'); $event.stopPropagation()"
+		ng-click="$ctrl.onToggleSearchPanelMode('exclude')"
 		><i class="fa fa-ban"></i>
 		<div class="list-length-count" ng-show="$ctrl._viewModel.excludeListLength > 0"></div
 	></md-button>

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.component.html
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.component.html
@@ -3,20 +3,20 @@
 		class="state-selector-button left"
 		id="tree-view"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'treeView' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('treeView')"
+		ng-click="$ctrl.onToggleSearchPanelMode('treeView'); $event.stopPropagation()"
 		><i class="fa fa-sitemap"></i
 	></md-button>
 	<md-button
 		class="state-selector-button middle"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'flatten' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('flatten')"
+		ng-click="$ctrl.onToggleSearchPanelMode('flatten'); $event.stopPropagation()"
 		><i class="fa fa-eye-slash"></i>
 		<div class="list-length-count" ng-show="$ctrl._viewModel.flattenListLength > 0"></div
 	></md-button>
 	<md-button
 		class="state-selector-button right"
 		ng-class="{ current: $ctrl._viewModel.searchPanelMode == 'exclude' }"
-		ng-click="$ctrl.onToggleSearchPanelMode('exclude')"
+		ng-click="$ctrl.onToggleSearchPanelMode('exclude'); $event.stopPropagation()"
 		><i class="fa fa-ban"></i>
 		<div class="list-length-count" ng-show="$ctrl._viewModel.excludeListLength > 0"></div
 	></md-button>


### PR DESCRIPTION
# Expand Search Panel when clicking in the search field

closes #1071 

## Description

- Expand Search Panel when clicking in the search field
- Collapse Search Panel when clicking somewhere else in the application 

## Screenshots or gifs

![search panel click](https://user-images.githubusercontent.com/12533626/86657550-9c128a00-bfe8-11ea-8921-ebbf863d07b6.gif)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
