### PR TITLE
Bug/1040/sorting not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Sorting in tree-view not being applied #1040
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.49.1] - 2020-07-03

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
@@ -52,7 +52,7 @@
 	</div>
 
 	<div class="tree-element-children tree-element-children-{{::$ctrl.depth?$ctrl.depth:0}}">
-		<div ng-if="$ctrl._viewModel.isFolderOpened" ng-repeat="node in $ctrl.node.children track by $index">
+		<div ng-if="$ctrl._viewModel.isFolderOpened" ng-repeat="node in $ctrl.node.children">
 			<map-tree-view-level-component node="::node" depth="::$ctrl.depth+1"></map-tree-view-level-component>
 		</div>
 	</div>


### PR DESCRIPTION
# Sorting Option not working without collapsing and reopening the folders

closes #1040 

## Description

- Removes the `track by $index` 

Please don't ask me why this fixes the issue. I have no idea and I accept this black magic.

## Screenshots or gifs

![sorting bug](https://user-images.githubusercontent.com/12533626/86663492-1265bb00-bfee-11ea-9f64-c43f75f6954b.gif)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
