### PR TITLE
Distinguish scenario indicator and remove button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
+- line between scenario indicator and remove button #1069
+
 ### Changed
 
 - Search Panel will open now when clicking in the search field and collapse when clicking somewhere else #1071

--- a/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.scss
+++ b/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.scss
@@ -41,7 +41,7 @@
 			}
 
 			&.remove {
-				border-left: 1px solid rgba(2, 27, 13, 0.31);
+				border-left: 1px solid rgba(0, 0, 0, 0.12);
 				display: inline-flex;
 				justify-content: center;
 				color: #b30000;

--- a/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.scss
+++ b/visualization/app/codeCharta/ui/scenarioDropDown/scenarioDropDown.component.scss
@@ -41,6 +41,7 @@
 			}
 
 			&.remove {
+				border-left: 1px solid rgba(2, 27, 13, 0.31);
 				display: inline-flex;
 				justify-content: center;
 				color: #b30000;


### PR DESCRIPTION
# Distinguish scenario indicator and remove button

closes #1069 

## Description

This adds a line between scenario indicator and the remove button.

## Screenshots or gifs

![image](https://user-images.githubusercontent.com/50145538/86768441-de21e700-c04d-11ea-9583-6fd0d7e93a5c.png)

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [x] **All** requirements mentioned in the issue are implemented
- [x] Does match the Code of Conduct and the Contribution file
- [x] Task has its own **GitHub issue** (something it is solving)
  - [x] Issue number is **included in the commit messages** for traceability
- [x] **Update the README.md** with any changes/additions made
- [x] **Update the CHANGELOG.md** with any changes/additions made
- [x] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [x] **All tests pass**
- [x] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [x] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [x] **Manual testing** did not fail
