### PR TITLE
File Chooser should only accept cc jsons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
+- file chooser now accept ".json" files only to avoid accidentally loading incorrect files.
+
 ### Changed
 
 ### Removed 🗑

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.html
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.html
@@ -2,4 +2,11 @@
 	<i class="fa fa-folder-open folder-icon"></i>
 </md-button>
 
-<input ng-show="false" id="input-file-id" multiple type="file" onchange="angular.element(this).scope().ctrl.onImportNewFiles(this)" />
+<input
+	ng-show="false"
+	id="input-file-id"
+	multiple
+	type="file"
+	accept=".json"
+	onchange="angular.element(this).scope().ctrl.onImportNewFiles(this)"
+/>

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
@@ -1,0 +1,39 @@
+import { goto, newPage, launch } from "../../../puppeteer.helper"
+import { FileChooserPageObject } from "./fileChooser.po"
+import { FilePanelPageObject } from "../filePanel/filePanel.po"
+
+jest.setTimeout(60000)
+
+describe("FileChooser", () => {
+	let browser, page
+	let fileChooser: FileChooserPageObject
+	let filePanel: FilePanelPageObject
+
+	beforeAll(async () => {
+		browser = await launch()
+	})
+
+	afterAll(async () => {
+		await browser.close()
+	})
+
+	beforeEach(async () => {
+		page = await newPage(browser)
+		fileChooser = new FileChooserPageObject(page)
+		filePanel = new FilePanelPageObject(page)
+
+		await goto(page)
+	})
+
+	it("should load cc.json file", async () => {
+		await fileChooser.openFile("./app/codeCharta/assets/sample2.cc.json")
+
+		expect(await filePanel.getSelectedName()).toEqual("sample2.cc.json")
+	})
+
+	it("should not load non json file", async () => {
+		await fileChooser.openFile("./app/codeCharta/assets/logo.png")
+
+		expect(await filePanel.getSelectedName()).toEqual("sample1.cc.json")
+	})
+})

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.po.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.po.ts
@@ -1,0 +1,17 @@
+import { Page } from "puppeteer"
+
+export class FileChooserPageObject {
+	constructor(private page: Page) {}
+
+	public async openFile(path: string) {
+		const [fileChooser] = await Promise.all([this.page.waitForFileChooser(), this.page.click("file-chooser-directive .toolbar-button")])
+
+		await fileChooser.accept([path])
+	}
+
+	public async cancelOpeningFile() {
+		const [fileChooser] = await Promise.all([this.page.waitForFileChooser(), this.page.click("file-chooser-directive .toolbar-button")])
+
+		await fileChooser.cancel()
+	}
+}

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -3836,7 +3836,7 @@
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 		},
 		"ansi-html": {
@@ -7861,7 +7861,7 @@
 		},
 		"external-editor": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
 			"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
 			"requires": {
 				"extend": "^3.0.0",
@@ -10746,7 +10746,7 @@
 		},
 		"inquirer": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+			"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
 			"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
 			"requires": {
 				"ansi-escapes": "^1.1.0",
@@ -10795,7 +10795,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				}
 			}
@@ -15670,7 +15670,7 @@
 		},
 		"onetime": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 		},
 		"opencollective-postinstall": {


### PR DESCRIPTION
File Chooser should only accept cc jsons

closes #1094

## Description

Now that 'accept' is supported by all major browsers, this filters the shown files to only include those with a '.json' ending.
Still needs tests.

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
