### PR TITLE
Tech/1101/move po functions

### DIFF
--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.html
@@ -2,7 +2,6 @@
 	ng-if="!$ctrl.node.isExcluded"
 	class="{{::$ctrl.depth?'':'tree-root'}} tree-element-{{::$ctrl.depth?$ctrl.depth:0}} {{::$ctrl.isLeaf()?'tree-leaf':'tree-parent'}}"
 	ng-init="$ctrl.openRootFolderByDefault($ctrl.depth)"
-	id="{{ ::$ctrl.node.path }}"
 >
 	<div
 		class="tree-element-label-{{::$ctrl.depth?$ctrl.depth:0}} tree-element-label"
@@ -11,6 +10,7 @@
 		ng-mouseleave="$ctrl.onMouseLeave()"
 		ng-right-click="$ctrl.openNodeContextMenu($event)"
 		ng-click="$ctrl.onClickNode()"
+		id="{{ ::$ctrl.node.path }}"
 	>
 		<span class="node-type-icon">
 			<span

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
@@ -31,7 +31,7 @@ describe("MapTreeViewLevel", () => {
 
 	describe("Blacklist", () => {
 		it("excluding a building should exclude it from the tree-view as well", async () => {
-			await searchPanelModeSelector.openTreeView()
+			await searchPanelModeSelector.toggleTreeView()
 			await mapTreeViewLevel.openContextMenu()
 			await nodeContextMenu.exclude()
 

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
@@ -31,12 +31,14 @@ describe("MapTreeViewLevel", () => {
 
 	describe("Blacklist", () => {
 		it("excluding a building should exclude it from the tree-view as well", async () => {
+			const nodePath = "/root/ParentLeaf/smallLeaf.html"
+
 			await searchPanelModeSelector.toggleTreeView()
 			await mapTreeViewLevel.openFolder("/root/ParentLeaf")
-			await mapTreeViewLevel.openContextMenu("/root/ParentLeaf/smallLeaf.html")
+			await mapTreeViewLevel.openContextMenu(nodePath)
 			await nodeContextMenu.exclude()
 
-			expect(await mapTreeViewLevel.nodeExists("/root/ParentLeaf/smallLeaf.html")).toBeFalsy()
+			expect(await mapTreeViewLevel.nodeExists(nodePath)).toBeFalsy()
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
@@ -32,10 +32,11 @@ describe("MapTreeViewLevel", () => {
 	describe("Blacklist", () => {
 		it("excluding a building should exclude it from the tree-view as well", async () => {
 			await searchPanelModeSelector.toggleTreeView()
-			await mapTreeViewLevel.openContextMenu()
+			await mapTreeViewLevel.openFolder("/root/ParentLeaf")
+			await mapTreeViewLevel.openContextMenu("/root/ParentLeaf/smallLeaf.html")
 			await nodeContextMenu.exclude()
 
-			expect(await mapTreeViewLevel.nodeExists()).toBeFalsy()
+			expect(await mapTreeViewLevel.nodeExists("/root/ParentLeaf/smallLeaf.html")).toBeFalsy()
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.e2e.ts
@@ -31,14 +31,14 @@ describe("MapTreeViewLevel", () => {
 
 	describe("Blacklist", () => {
 		it("excluding a building should exclude it from the tree-view as well", async () => {
-			const nodePath = "/root/ParentLeaf/smallLeaf.html"
+			const filePath = "/root/ParentLeaf/smallLeaf.html"
 
 			await searchPanelModeSelector.toggleTreeView()
 			await mapTreeViewLevel.openFolder("/root/ParentLeaf")
-			await mapTreeViewLevel.openContextMenu(nodePath)
+			await mapTreeViewLevel.openContextMenu(filePath)
 			await nodeContextMenu.exclude()
 
-			expect(await mapTreeViewLevel.nodeExists(nodePath)).toBeFalsy()
+			expect(await mapTreeViewLevel.nodeExists(filePath)).toBeFalsy()
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.po.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.po.ts
@@ -3,12 +3,19 @@ import { Page } from "puppeteer"
 export class MapTreeViewLevelPageObject {
 	constructor(private page: Page) {}
 
-	public async openContextMenu() {
-		await this.page.click("[id='/root/ParentLeaf']")
-		await this.page.click("[id='/root/ParentLeaf/smallLeaf.html']", { button: "right" })
+	public async openContextMenu(path: string) {
+		await this.page.click(`[id='${path}'] > div`, { button: "right" })
 	}
 
-	public async nodeExists() {
-		return !!(await this.page.$("[id='/root/ParentLeaf/smallLeaf.html']"))
+	public async openFolder(path: string) {
+		await this.page.click(`[id='${path}'] > div`)
+	}
+
+	public async hoverNode(path: string) {
+		await this.page.hover(`[id='${path}'] > div`)
+	}
+
+	public async nodeExists(path: string) {
+		return !!(await this.page.$(`[id='${path}'] > div`))
 	}
 }

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.po.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.po.ts
@@ -4,18 +4,18 @@ export class MapTreeViewLevelPageObject {
 	constructor(private page: Page) {}
 
 	public async openContextMenu(path: string) {
-		await this.page.click(`[id='${path}'] > div`, { button: "right" })
+		await this.page.click(`[id='${path}']`, { button: "right" })
 	}
 
 	public async openFolder(path: string) {
-		await this.page.click(`[id='${path}'] > div`)
+		await this.page.click(`[id='${path}']`)
 	}
 
 	public async hoverNode(path: string) {
-		await this.page.hover(`[id='${path}'] > div`)
+		await this.page.hover(`[id='${path}']`)
 	}
 
 	public async nodeExists(path: string) {
-		return !!(await this.page.$(`[id='${path}'] > div`))
+		return !!(await this.page.$(`[id='${path}']`))
 	}
 }

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.po.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.po.ts
@@ -1,0 +1,9 @@
+import { Page } from "puppeteer"
+
+export class MetricChooserPageObject {
+	constructor(private page: Page) {}
+
+	public async getAreaMetricValue(): Promise<number> {
+		return await this.page.$eval("area-metric-chooser-component .metric-value", el => el["innerText"])
+	}
+}

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.e2e.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.e2e.ts
@@ -1,14 +1,16 @@
 import { goto, launch, newPage } from "../../../puppeteer.helper"
 import { NodeContextMenuPageObject } from "./nodeContextMenu.po"
-import { SearchPanelPageObject } from "../searchPanel/searchPanel.po"
 import { Browser, Page } from "puppeteer"
+import { SearchPanelModeSelectorPageObject } from "../searchPanelModeSelector/searchPanelModeSelector.po"
+import { MapTreeViewLevelPageObject } from "../mapTreeView/mapTreeView.level.po"
 
 describe("NodeContextMenu", () => {
 	let browser: Browser
 	let page: Page
 
-	let settingsPanel: SearchPanelPageObject
 	let contextMenu: NodeContextMenuPageObject
+	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
+	let mapTreeViewLevel: MapTreeViewLevelPageObject
 
 	beforeAll(async () => {
 		browser = await launch()
@@ -20,15 +22,16 @@ describe("NodeContextMenu", () => {
 
 	beforeEach(async () => {
 		page = await newPage(browser)
-		settingsPanel = new SearchPanelPageObject(page)
 		contextMenu = new NodeContextMenuPageObject(page)
+		searchPanelModeSelector = new SearchPanelModeSelectorPageObject(page)
+		mapTreeViewLevel = new MapTreeViewLevelPageObject(page)
 
 		await goto(page)
 	})
 
 	it("right clicking a folder should open a context menu with color options", async () => {
-		await settingsPanel.toggleTreeViewMode()
-		await settingsPanel.rightClickRootNodeInTreeViewSearchPanel()
+		await searchPanelModeSelector.toggleTreeView()
+		await mapTreeViewLevel.openContextMenu("/root")
 
 		expect(await contextMenu.hasColorButtons()).toBeTruthy()
 	})

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
@@ -3,12 +3,14 @@ import { RibbonBarPageObject } from "./ribbonBar.po"
 import { SearchPanelPageObject } from "../searchPanel/searchPanel.po"
 import { Browser, Page } from "puppeteer"
 import { MetricChooserPageObject } from "../metricChooser/metricChooser.po"
+import { SearchPanelModeSelectorPageObject } from "../searchPanelModeSelector/searchPanelModeSelector.po"
 
 describe("RibbonBar", () => {
 	let browser: Browser
 	let page: Page
 
 	let searchPanel: SearchPanelPageObject
+	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
 	let ribbonBar: RibbonBarPageObject
 	let metricChooser: MetricChooserPageObject
 
@@ -24,6 +26,7 @@ describe("RibbonBar", () => {
 		page = await newPage(browser)
 
 		searchPanel = new SearchPanelPageObject(page)
+		searchPanelModeSelector = new SearchPanelModeSelectorPageObject(page)
 		ribbonBar = new RibbonBarPageObject(page)
 		metricChooser = new MetricChooserPageObject(page)
 
@@ -31,7 +34,7 @@ describe("RibbonBar", () => {
 	})
 
 	it("hovering over a folder should display the sum of metric of all children", async () => {
-		await searchPanel.toggleTreeViewMode()
+		await searchPanelModeSelector.toggleTreeView()
 		await searchPanel.hoverRootNodeInTreeViewSearchPanel()
 
 		const actual = await metricChooser.getAreaMetricValue()

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
@@ -4,6 +4,7 @@ import { SearchPanelPageObject } from "../searchPanel/searchPanel.po"
 import { Browser, Page } from "puppeteer"
 import { MetricChooserPageObject } from "../metricChooser/metricChooser.po"
 import { SearchPanelModeSelectorPageObject } from "../searchPanelModeSelector/searchPanelModeSelector.po"
+import { MapTreeViewLevelPageObject } from "../mapTreeView/mapTreeView.level.po"
 
 describe("RibbonBar", () => {
 	let browser: Browser
@@ -13,6 +14,7 @@ describe("RibbonBar", () => {
 	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
 	let ribbonBar: RibbonBarPageObject
 	let metricChooser: MetricChooserPageObject
+	let mapTreeViewLevel: MapTreeViewLevelPageObject
 
 	beforeAll(async () => {
 		browser = await launch()
@@ -29,13 +31,14 @@ describe("RibbonBar", () => {
 		searchPanelModeSelector = new SearchPanelModeSelectorPageObject(page)
 		ribbonBar = new RibbonBarPageObject(page)
 		metricChooser = new MetricChooserPageObject(page)
+		mapTreeViewLevel = new MapTreeViewLevelPageObject(page)
 
 		await goto(page)
 	})
 
 	it("hovering over a folder should display the sum of metric of all children", async () => {
 		await searchPanelModeSelector.toggleTreeView()
-		await searchPanel.hoverRootNodeInTreeViewSearchPanel()
+		await mapTreeViewLevel.hoverNode("/root")
 
 		const actual = await metricChooser.getAreaMetricValue()
 		expect(actual).toContain("600")

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.e2e.ts
@@ -2,6 +2,7 @@ import { goto, launch, newPage } from "../../../puppeteer.helper"
 import { RibbonBarPageObject } from "./ribbonBar.po"
 import { SearchPanelPageObject } from "../searchPanel/searchPanel.po"
 import { Browser, Page } from "puppeteer"
+import { MetricChooserPageObject } from "../metricChooser/metricChooser.po"
 
 describe("RibbonBar", () => {
 	let browser: Browser
@@ -9,6 +10,7 @@ describe("RibbonBar", () => {
 
 	let searchPanel: SearchPanelPageObject
 	let ribbonBar: RibbonBarPageObject
+	let metricChooser: MetricChooserPageObject
 
 	beforeAll(async () => {
 		browser = await launch()
@@ -23,6 +25,7 @@ describe("RibbonBar", () => {
 
 		searchPanel = new SearchPanelPageObject(page)
 		ribbonBar = new RibbonBarPageObject(page)
+		metricChooser = new MetricChooserPageObject(page)
 
 		await goto(page)
 	})
@@ -31,7 +34,7 @@ describe("RibbonBar", () => {
 		await searchPanel.toggleTreeViewMode()
 		await searchPanel.hoverRootNodeInTreeViewSearchPanel()
 
-		const actual = await ribbonBar.getAreaMetricValue()
+		const actual = await metricChooser.getAreaMetricValue()
 		expect(actual).toContain("600")
 	})
 

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.po.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.po.ts
@@ -16,10 +16,6 @@ export class RibbonBarPageObject {
 		await delay(400)
 	}
 
-	public async getAreaMetricValue(): Promise<number> {
-		return await this.page.$eval("area-metric-chooser-component .metric-value", el => el["innerText"])
-	}
-
 	public async focusSomething(): Promise<void> {
 		await this.page.evaluate(() => {
 			const element = <HTMLElement>document.getElementsByClassName("md-ink-ripple")[0]

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.po.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.po.ts
@@ -7,18 +7,13 @@ export class SearchPanelPageObject {
 	constructor(private page: Page) {}
 
 	public async toggle() {
-		await this.page.click(`search-panel-component md-card .section .section-title`)
+		await this.page.click("search-panel-component md-card .section .section-title")
 		await delay(400)
 	}
 
 	public async isOpen(): Promise<boolean> {
-		const classNames = await this.page.$eval(`ribbon-bar-component md-card`, el => el["className"])
+		const classNames = await this.page.$eval("search-panel-component md-card", el => el["className"])
 		return classNames.includes(this.EXPANDED)
-	}
-
-	public async toggleTreeViewMode() {
-		await this.page.click("#tree-view")
-		await delay(500)
 	}
 
 	public async rightClickRootNodeInTreeViewSearchPanel() {

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.po.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.po.ts
@@ -15,12 +15,4 @@ export class SearchPanelPageObject {
 		const classNames = await this.page.$eval("search-panel-component md-card", el => el["className"])
 		return classNames.includes(this.EXPANDED)
 	}
-
-	public async rightClickRootNodeInTreeViewSearchPanel() {
-		await this.page.click("map-tree-view-level-component > .tree-root > .tree-element-label-0", { button: "right" })
-	}
-
-	public async hoverRootNodeInTreeViewSearchPanel() {
-		await this.page.hover("map-tree-view-level-component > .tree-root > .tree-element-label-0")
-	}
 }

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.e2e.ts
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.e2e.ts
@@ -1,0 +1,35 @@
+import { goto, newPage, launch } from "../../../puppeteer.helper"
+import { SearchPanelModeSelectorPageObject } from "./searchPanelModeSelector.po"
+
+describe("SearchPanelModeSelector", () => {
+	let browser, page
+	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
+
+	beforeAll(async () => {
+		browser = await launch()
+	})
+
+	afterAll(async () => {
+		await browser.close()
+	})
+
+	beforeEach(async () => {
+		page = await newPage(browser)
+		searchPanelModeSelector = new SearchPanelModeSelectorPageObject(page)
+
+		await goto(page)
+	})
+
+	it("should open the tree-view when clicking on the tree-view icon", async () => {
+		await searchPanelModeSelector.toggleTreeView()
+
+		expect(await searchPanelModeSelector.isTreeViewOpen()).toBeTruthy()
+	})
+
+	it("should open and close tree-view when clicking on the tree-view icon twice", async () => {
+		await searchPanelModeSelector.toggleTreeView()
+		await searchPanelModeSelector.toggleTreeView()
+
+		expect(await searchPanelModeSelector.isTreeViewOpen()).toBeFalsy()
+	})
+})

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.e2e.ts
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.e2e.ts
@@ -20,14 +20,11 @@ describe("SearchPanelModeSelector", () => {
 		await goto(page)
 	})
 
-	it("should open the tree-view when clicking on the tree-view icon", async () => {
+	it("should open and close the tree-view when clicking on the tree-view icon", async () => {
 		await searchPanelModeSelector.toggleTreeView()
 
 		expect(await searchPanelModeSelector.isTreeViewOpen()).toBeTruthy()
-	})
 
-	it("should open and close tree-view when clicking on the tree-view icon twice", async () => {
-		await searchPanelModeSelector.toggleTreeView()
 		await searchPanelModeSelector.toggleTreeView()
 
 		expect(await searchPanelModeSelector.isTreeViewOpen()).toBeFalsy()

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.po.ts
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.po.ts
@@ -4,8 +4,8 @@ import { delay } from "../../../puppeteer.helper"
 export class SearchPanelModeSelectorPageObject {
 	constructor(private page: Page) {}
 
-	public async openTreeView() {
-		await this.page.click("search-panel-mode-selector-component #tree-view")
+	public async toggleTreeView() {
+		await this.page.click("#tree-view")
 		await delay(500)
 	}
 }

--- a/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.po.ts
+++ b/visualization/app/codeCharta/ui/searchPanelModeSelector/searchPanelModeSelector.po.ts
@@ -8,4 +8,10 @@ export class SearchPanelModeSelectorPageObject {
 		await this.page.click("#tree-view")
 		await delay(500)
 	}
+
+	public async isTreeViewOpen() {
+		const classNames = await this.page.$eval("#tree-view", el => el.className)
+
+		return classNames.includes("current")
+	}
 }


### PR DESCRIPTION
# Move page object functions to their designated page object

works on #1101 

## Description

This PR moves all functions to their designated page object files. 
I also refactored some functions to allow better reusability.

**Would be great to get a quick review on that, because this PR is the base for all the upcoming tasks in this issue. Thanks!**

## Definition of Done

A task/pull request will not be considered to be complete until all these items can be checked off.

- [ ] **All** requirements mentioned in the issue are implemented
- [ ] Does match the Code of Conduct and the Contribution file
- [ ] Task has its own **GitHub issue** (something it is solving)
  - [ ] Issue number is **included in the commit messages** for traceability
- [ ] **Update the README.md** with any changes/additions made
- [ ] **Update the CHANGELOG.md** with any changes/additions made
- [ ] **Enough test coverage to ensure that uncovered changes do not break functionality**
- [ ] **All tests pass**
- [ ] **Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?
- [ ] **Assign your PR to someone** for a code review
  - This person _will be contacted **first**_ if a bug is introduced into `master`
- [ ] **Manual testing** did not fail
