### PR TITLE
Use closes prefix to close issues after merging a pr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 _**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_
 
-Issue: #
+closes: #
 
 ## Description
 


### PR DESCRIPTION
# Use closes prefix to close issues after merging a pr

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Issue: #

## Description

I thought linking issues with zenhub is enough to do so as well, but I was wrong.
Let's use the old [github provided solution](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) again