### PR TITLE
Tech/demo use new sonarcloud projects

### DIFF
--- a/analysis/script/travis-build.sh
+++ b/analysis/script/travis-build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd analysis
-./gradlew build integrationTest
+./gradlew build

--- a/gh-pages/_posts/how-to/2019-06-28-analyze_codecharta_with_sonarqube_and_git_svn.md
+++ b/gh-pages/_posts/how-to/2019-06-28-analyze_codecharta_with_sonarqube_and_git_svn.md
@@ -20,7 +20,7 @@ title: Using Sonarqube and the Log from Git or Svn to visualize Codecharta's own
 # Getting the Sonarqube data
 
 - Install the latest analysis tools globally `npm i -g codecharta-analysis`
-- Generate visualization data from our CodeCharta Sonarqube analysis `ccsh sonarimport -o sonar.cc.json https://sonarcloud.io de.maibornwolff.codecharta:visualization`. A new file named _sonar.cc.json_ should appear in your working directory.
+- Generate visualization data from our CodeCharta Sonarqube analysis `ccsh sonarimport -o sonar.cc.json https://sonarcloud.io maibornwolff-gmbh_codecharta_visualization`. A new file named _sonar.cc.json_ should appear in your working directory.
 
 This file can already be opened in the [web visualization]({{site.web_visualization_link}}). If you want the information from the SCM log we need to continue a bit...
 
@@ -33,7 +33,7 @@ As the Codecharta project is managed using git, we want to analyze its git meta 
 - Clone the repository `git clone https://github.com/MaibornWolff/codecharta.git` and navigate to it `cd codecharta`
 - Generate a git log file `git log --numstat --raw --topo-order > ../git.log` and navigate back `cd ..`. file and a _git.log_ file.
 - Ensure that the log file is encoded with UTF-8 if you get `java.lang.IllegalArgumentException`
-- Parse the log file `ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o git.cc.json -p de.maibornwolff.codecharta:visualization`. A new file named _git.cc.json_ should appear in your working directory.
+- Parse the log file `ccsh scmlogparser git.log --input-format GIT_LOG_NUMSTAT_RAW -o git.cc.json -p maibornwolff-gmbh_codecharta_visualization`. A new file named _git.cc.json_ should appear in your working directory.
 
 ## SVN
 

--- a/script/build_gh_pages.sh
+++ b/script/build_gh_pages.sh
@@ -16,13 +16,13 @@ $CCSH scmlogparser -o codecharta_git.cc.json --input-format GIT_LOG_NUMSTAT_RAW 
 # Map for visualization
 $CCSH modify --setRoot root/visualization -o codecharta_git_mod.cc.json codecharta_git.cc.json
 
-$CCSH sonarimport -o codecharta_sonar.cc.json https://sonarcloud.io de.maibornwolff.codecharta:visualization
+$CCSH sonarimport -o codecharta_sonar.cc.json https://sonarcloud.io maibornwolff-gmbh_codecharta_visualization
 $CCSH modify --setRoot root/de.maibornwolff.codecharta/visualization -o codecharta_sonar_mod.cc.json codecharta_sonar.cc.json
 
 $CCSH merge -o ../visualization/app/codecharta.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json
 
 # Map for analysis
-$CCSH sonarimport -o codecharta_sonar_analysis.cc.json https://sonarcloud.io de.maibornwolff.codecharta:analysis
+$CCSH sonarimport -o codecharta_sonar_analysis.cc.json https://sonarcloud.io maibornwolff-gmbh_codecharta_analysis
 $CCSH modify --setRoot root/de.maibornwolff.codecharta/analysis -o codecharta_sonar_mod.cc.json codecharta_sonar_analysis.cc.json
 $CCSH modify --setRoot root/analysis -o codecharta_git_mod.cc.json codecharta_git.cc.json
 $CCSH merge -o ../visualization/app/codecharta_analysis.cc.json codecharta_sonar_mod.cc.json codecharta_git_mod.cc.json


### PR DESCRIPTION
# Demo should use the current state of the application from sonarcloud to build the demo files

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

- Demo uses the current state of the applications from sonarcloud to build the demo files
- Remove integrationTests from deploy stage, becasue they're not required at all