### PR TITLE
Tech/fix e2e test race condition

### DIFF
--- a/visualization/app/codeCharta/ui/dialog/dialog.error.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.error.po.ts
@@ -9,7 +9,7 @@ export class DialogErrorPageObject {
 		await page.waitForSelector("md-dialog-actions button", { visible: false })
 	}
 
-	public async waitUntilDialogCloses() {
+	public async waitUntilDialogIsClosed() {
 		await page.waitForSelector(".md-dialog-content-body")
 		await page.waitForSelector(".md-dialog-content-body", { visible: false })
 	}

--- a/visualization/app/codeCharta/ui/dialog/dialog.error.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.error.po.ts
@@ -8,4 +8,9 @@ export class DialogErrorPageObject {
 		await expect(page).toClick("md-dialog-actions button", { timeout: 3000 })
 		await page.waitForSelector("md-dialog-actions button", { visible: false })
 	}
+
+	public async waitUntilDialogCloses() {
+		await page.waitForSelector(".md-dialog-content-body")
+		await page.waitForSelector(".md-dialog-content-body", { visible: false })
+	}
 }

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
@@ -64,7 +64,7 @@ describe("FileChooser", () => {
 		await fileChooser.openFiles(["./app/codeCharta/ressources/sample1_with_api_warning.cc.json", "./app/codeCharta/assets/logo.png"])
 
 		expect(await dialogError.getMessage()).toEqual(" Minor API Version Outdated")
-		await dialogError.waitUntilDialogCloses()
+		await dialogError.waitUntilDialogIsClosed()
 
 		expect(await dialogError.getMessage()).toEqual(" file is empty or invalid")
 		await dialogError.clickOk()

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.e2e.ts
@@ -64,6 +64,7 @@ describe("FileChooser", () => {
 		await fileChooser.openFiles(["./app/codeCharta/ressources/sample1_with_api_warning.cc.json", "./app/codeCharta/assets/logo.png"])
 
 		expect(await dialogError.getMessage()).toEqual(" Minor API Version Outdated")
+		await dialogError.waitUntilDialogCloses()
 
 		expect(await dialogError.getMessage()).toEqual(" file is empty or invalid")
 		await dialogError.clickOk()


### PR DESCRIPTION
# Fix race condition

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

A new e2e tests has some race conditions, when multiple error dialogs pop up. This should fix it.
