### PR TITLE
Tech/run-commit-hooks-on-release

### DIFF
--- a/script/make_release.py
+++ b/script/make_release.py
@@ -209,7 +209,7 @@ confirm(message, printMessage)
 
 repo.index.add([release_post_path, changelog_path, gradle_properties,
                 analysis_package_json, analysis_package_lock_json, visualization_package_json, visualization_package_lock_json])
-repo.index.commit(f"Releasing {new_version}", skip_hooks=True)
+subprocess.run(["git", "commit", "-a" "-m", f'"Releasing {new_version}"'], shell=True)
 tag = repo.create_tag(new_version, ref="HEAD",
                       message=f"Releasing {new_version}")
 


### PR DESCRIPTION
# Run pre commit hook on release

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

GitPython can't run commit hooks. That's why I pushed with passing arguments to `subprocess`. Not running the pre-commit hooks is a problem though, because the edited files are not formatted correctly resulting in huge diffs on PRs.
Running the commit with subprocess on the shell shoul run the commit hooks and format the files.
