### PR TITLE
docs/analysis-test-add-sh-to-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+### Docs 🔎
+
+-   Added note how to fix missing `sh` command issue when running integration tests on Windows
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.53.0] - 2020-08-14

--- a/gh-pages/_docs/07-01-new-to-code.md
+++ b/gh-pages/_docs/07-01-new-to-code.md
@@ -82,6 +82,9 @@ Don't import the whole codecharta project to IntelliJ when working on the analys
 -   Run `gradlew.bat test` or `./gradlew test`
 -   Run `gradlew.bat integrationTest` or `./gradlew integrationTest`
 
+May the integration tests will fail because of missing or unknown `sh` command.
+To make it work you could add the path to the Git `sh.exe` (which is normally placed here `C:\<path-to-git>\Git\bin`) to your PATH variable.
+
 **If you want to run the JUnit tests with the IntelliJ-Runner, make sure to go to `File -> Settings ->Build,Execution, Deployment -> Build Tools -> Gradle` and select `Run test using: IntelliJ IDEA`**
 
 ### Linting/Formatting

--- a/gh-pages/_docs/07-01-new-to-code.md
+++ b/gh-pages/_docs/07-01-new-to-code.md
@@ -82,8 +82,8 @@ Don't import the whole codecharta project to IntelliJ when working on the analys
 -   Run `gradlew.bat test` or `./gradlew test`
 -   Run `gradlew.bat integrationTest` or `./gradlew integrationTest`
 
-May the integration tests will fail because of missing or unknown `sh` command.
-To make it work you could add the path to the Git `sh.exe` (which is normally placed here `C:\<path-to-git>\Git\bin`) to your PATH variable.
+The integration tests might fail on windows, because of a missing or unknown `sh` command.
+To make it work, add the path to the Git `sh.exe` (which is normally placed here `C:\<path-to-git>\Git\bin`) to your PATH variable.
 
 **If you want to run the JUnit tests with the IntelliJ-Runner, make sure to go to `File -> Settings ->Build,Execution, Deployment -> Build Tools -> Gradle` and select `Run test using: IntelliJ IDEA`**
 


### PR DESCRIPTION
# Add a note how to fix missing sh command when running integration tests on Windows.

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

The extended documentation should avoid future problems for new contributors when running integration tests for the first time on Windows.
