### PR TITLE
Fix/improve merge performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Improve performance when switching to multiple or delta mode when edges are available
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.55.0] - 2020-08-28

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.ts
@@ -21,5 +21,5 @@ export function getMergedBlacklist(inputFiles: CCFile[], withUpdatedPath: boolea
 			}
 		}
 	}
-	return Array.from(blacklist.values())
+	return [...blacklist.values()]
 }

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.ts
@@ -2,7 +2,7 @@ import { getUpdatedBlacklistItemPath } from "../../../../util/nodePathHelper"
 import { BlacklistItem, CCFile } from "../../../../codeCharta.model"
 
 export function getMergedBlacklist(inputFiles: CCFile[], withUpdatedPath: boolean): BlacklistItem[] {
-	const blacklist: BlacklistItem[] = []
+	const blacklist: Map<string, BlacklistItem> = new Map()
 
 	if (inputFiles.length == 1) {
 		return inputFiles[0].settings.fileSettings.blacklist
@@ -17,13 +17,9 @@ export function getMergedBlacklist(inputFiles: CCFile[], withUpdatedPath: boolea
 						: oldBlacklistItem.path,
 					type: oldBlacklistItem.type
 				}
-				const equalBlacklistItems = blacklist.find(b => b.path == blacklistItem.path && b.type == blacklistItem.type)
-
-				if (!equalBlacklistItems) {
-					blacklist.push(blacklistItem)
-				}
+				blacklist.set(`${blacklistItem.path}|${blacklistItem.type}`, blacklistItem)
 			}
 		}
 	}
-	return blacklist
+	return Array.from(blacklist.values())
 }

--- a/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
@@ -22,9 +22,8 @@ export function getMergedEdges(inputFiles: CCFile[], withUpdatedPath: boolean): 
 				const equalEdgeItem = edges.get(`${edge.fromNodeName}|${edge.toNodeName}`)
 
 				if (equalEdgeItem !== undefined) {
-					for (const key in edge.attributes) {
+					for (const key of Object.keys(edge.attributes)) {
 						equalEdgeItem.attributes[key] = edge.attributes[key]
-						edges.set(`${edge.fromNodeName}|${edge.toNodeName}`, equalEdgeItem)
 					}
 				} else {
 					edges.set(`${edge.fromNodeName}|${edge.toNodeName}`, edge)

--- a/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
@@ -32,5 +32,5 @@ export function getMergedEdges(inputFiles: CCFile[], withUpdatedPath: boolean): 
 			}
 		}
 	}
-	return Array.from(edges.values())
+	return [...edges.values()]
 }

--- a/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.ts
@@ -2,7 +2,7 @@ import { getUpdatedPath } from "../../../../util/nodePathHelper"
 import { CCFile, Edge } from "../../../../codeCharta.model"
 
 export function getMergedEdges(inputFiles: CCFile[], withUpdatedPath: boolean): Edge[] {
-	const edges: Edge[] = []
+	const edges: Map<string, Edge> = new Map()
 
 	if (inputFiles.length == 1) {
 		return inputFiles[0].settings.fileSettings.edges
@@ -19,18 +19,18 @@ export function getMergedEdges(inputFiles: CCFile[], withUpdatedPath: boolean): 
 					attributes: oldEdge.attributes,
 					visible: oldEdge.visible
 				}
-				const equalEdgeItem = edges.find(e => e.fromNodeName == edge.fromNodeName && e.toNodeName == edge.toNodeName)
+				const equalEdgeItem = edges.get(`${edge.fromNodeName}|${edge.toNodeName}`)
 
-				if (equalEdgeItem) {
+				if (equalEdgeItem !== undefined) {
 					for (const key in edge.attributes) {
 						equalEdgeItem.attributes[key] = edge.attributes[key]
+						edges.set(`${edge.fromNodeName}|${edge.toNodeName}`, equalEdgeItem)
 					}
 				} else {
-					edges.push(edge)
+					edges.set(`${edge.fromNodeName}|${edge.toNodeName}`, edge)
 				}
 			}
 		}
 	}
-
-	return edges
+	return Array.from(edges.values())
 }

--- a/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.ts
@@ -2,7 +2,7 @@ import { getUpdatedBlacklistItemPath } from "../../../../util/nodePathHelper"
 import { CCFile, MarkedPackage } from "../../../../codeCharta.model"
 
 export function getMergedMarkedPackages(inputFiles: CCFile[], withUpdatedPath: boolean): MarkedPackage[] {
-	const markedPackages: MarkedPackage[] = []
+	const markedPackages: Map<string, MarkedPackage> = new Map()
 
 	if (inputFiles.length == 1) {
 		return inputFiles[0].settings.fileSettings.markedPackages
@@ -17,14 +17,9 @@ export function getMergedMarkedPackages(inputFiles: CCFile[], withUpdatedPath: b
 						: oldMarkedPackages.path,
 					color: oldMarkedPackages.color
 				}
-				const equalMarkedPackages = markedPackages.find(x => x.path == markedPackage.path && x.color == markedPackage.color)
-
-				if (!equalMarkedPackages) {
-					markedPackages.push(markedPackage)
-				}
+				markedPackages.set(`${markedPackage.path}|${markedPackage.color}`, markedPackage)
 			}
 		}
 	}
-
-	return markedPackages
+	return Array.from(markedPackages.values())
 }

--- a/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.ts
@@ -21,5 +21,5 @@ export function getMergedMarkedPackages(inputFiles: CCFile[], withUpdatedPath: b
 			}
 		}
 	}
-	return Array.from(markedPackages.values())
+	return [...markedPackages.values()]
 }


### PR DESCRIPTION
# Fix bottleneck when merging edges on file selection change

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

- Use map to find already encountered edges / entries in constant time instead of O(n)
- Switching to multiple on maps with edges is 3 times faster now than before

## Screenshots or gifs

Before:

![before](https://user-images.githubusercontent.com/12533626/91606554-8e3b0e80-e972-11ea-9a3a-92fea28c749d.png)

After:

![after](https://user-images.githubusercontent.com/12533626/91606566-9430ef80-e972-11ea-82bb-48e485c29b49.png)


## Open Questions

@BridgeAR Might this be related to #1189 ? Can you please specify the steps on how to reproduce your bottleneck in the issue?