### PR TITLE
Tech/use-option-object-instead-of-boolean

### DIFF
--- a/visualization/app/codeCharta/state/store.service.spec.ts
+++ b/visualization/app/codeCharta/state/store.service.spec.ts
@@ -111,7 +111,7 @@ describe("StoreService", () => {
 		})
 
 		it("should dispatch an action silently and not notify subscribers", () => {
-			storeService.dispatch(setCamera(), true)
+			storeService.dispatch(setCamera(), { silent: true })
 
 			expect($rootScope.$broadcast).not.toHaveBeenCalled()
 		})
@@ -119,7 +119,7 @@ describe("StoreService", () => {
 		it("should dispatch an action silently and not show the loading-gif", () => {
 			storeService.dispatch(setIsLoadingMap(false))
 
-			storeService.dispatch(setCamera(), true)
+			storeService.dispatch(setCamera(), { silent: true })
 
 			expect(storeService.getState().appSettings.isLoadingMap).toBeFalsy()
 		})

--- a/visualization/app/codeCharta/state/store.service.ts
+++ b/visualization/app/codeCharta/state/store.service.ts
@@ -15,6 +15,10 @@ export interface StoreSubscriber {
 	onStoreChanged(actionType: string)
 }
 
+export interface DispatchOptions {
+	silent: boolean
+}
+
 export class StoreService {
 	private static STORE_CHANGED_EVENT = "store-changed"
 	private store: Store
@@ -24,7 +28,7 @@ export class StoreService {
 		this.store = createStore(rootReducer)
 	}
 
-	public dispatch(action: CCAction, isSilent = false) {
+	public dispatch(action: CCAction, options: DispatchOptions = { silent: false }) {
 		if (
 			!(
 				isActionOfType(action.type, IsLoadingMapActions) ||
@@ -33,7 +37,7 @@ export class StoreService {
 				isActionOfType(action.type, SearchPanelModeActions) ||
 				isActionOfType(action.type, SortingOptionActions) ||
 				isActionOfType(action.type, IsAttributeSideBarVisibleActions) ||
-				isSilent
+				options.silent
 			)
 		) {
 			this.dispatch(setIsLoadingMap(true))
@@ -41,7 +45,7 @@ export class StoreService {
 
 		splitStateActions(action).forEach(atomicAction => {
 			this.store.dispatch(atomicAction)
-			if (!isSilent) {
+			if (!options.silent) {
 				this.notify(atomicAction.type)
 			}
 		})

--- a/visualization/app/codeCharta/state/store/lookUp/idToBuilding/idToBuilding.service.ts
+++ b/visualization/app/codeCharta/state/store/lookUp/idToBuilding/idToBuilding.service.ts
@@ -16,6 +16,6 @@ export class IdToBuildingService implements CodeMapMeshChangedSubscriber {
 			idToBuilding.set(x.node.id, x)
 		})
 
-		this.storeService.dispatch(setIdToBuilding(idToBuilding), true)
+		this.storeService.dispatch(setIdToBuilding(idToBuilding), { silent: true })
 	}
 }

--- a/visualization/app/codeCharta/state/store/lookUp/idToNode/idToNode.service.ts
+++ b/visualization/app/codeCharta/state/store/lookUp/idToNode/idToNode.service.ts
@@ -17,6 +17,6 @@ export class IdToNodeService implements CodeMapPreRenderServiceSubscriber {
 			idToNode.set(x.data.id, x.data)
 		})
 
-		this.storeService.dispatch(setIdToNode(idToNode), true)
+		this.storeService.dispatch(setIdToNode(idToNode), { silent: true })
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeCameraService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeCameraService.ts
@@ -20,7 +20,7 @@ export class ThreeCameraService implements CameraChangeSubscriber, CameraSubscri
 
 	constructor(private $rootScope: IRootScopeService, private storeService: StoreService) {
 		this.throttledCameraChange = _.throttle(() => {
-			this.storeService.dispatch(setCamera(this.camera.position), true)
+			this.storeService.dispatch(setCamera(this.camera.position), { silent: true })
 		}, ThreeCameraService.DEBOUNCE_TIME)
 		CameraService.subscribe(this.$rootScope, this)
 	}

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
@@ -134,7 +134,7 @@ export class ThreeOrbitControlsService implements FocusNodeSubscriber, UnfocusNo
 	}
 
 	public onInput(camera: PerspectiveCamera) {
-		this.storeService.dispatch(setCameraTarget(this.controls.target), true)
+		this.storeService.dispatch(setCameraTarget(this.controls.target), { silent: true })
 		this.$rootScope.$broadcast(ThreeOrbitControlsService.CAMERA_CHANGED_EVENT_NAME, camera)
 	}
 


### PR DESCRIPTION
# Refactor use options object instead of plain boolean

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_


## Description

- Adresses https://github.com/MaibornWolff/codecharta/pull/1152#discussion_r481442909
