### PR TITLE
Tech/Replace lodash clone with rfdc

### DIFF
--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -3,7 +3,6 @@ import { CodeChartaService } from "./codeCharta.service"
 import { getService, instantiateModule } from "../../mocks/ng.mockhelper"
 import { TEST_FILE_CONTENT } from "./util/dataMocks"
 import { BlacklistType, CCFile, NodeMetricData, NodeType } from "./codeCharta.model"
-import _ from "lodash"
 import { StoreService } from "./state/store.service"
 import { resetFiles } from "./state/store/files/files.actions"
 import { ExportBlacklistType, ExportCCFile } from "./codeCharta.api.model"
@@ -11,6 +10,7 @@ import { getCCFiles, isSingleState } from "./model/files/files.helper"
 import { DialogService } from "./ui/dialog/dialog.service"
 import { CCValidationResult, ERROR_MESSAGES } from "./util/fileValidator"
 import { setNodeMetricData } from "./state/store/metricData/nodeMetricData/nodeMetricData.actions"
+import { clone } from "./util/clone"
 
 describe("codeChartaService", () => {
 	let codeChartaService: CodeChartaService
@@ -25,8 +25,8 @@ describe("codeChartaService", () => {
 		rebuildService()
 		withMockedDialogService()
 
-		validFileContent = _.cloneDeep(TEST_FILE_CONTENT)
-		metricData = _.cloneDeep([
+		validFileContent = clone(TEST_FILE_CONTENT)
+		metricData = clone([
 			{ name: "mcc", maxValue: 1 },
 			{ name: "rloc", maxValue: 2 }
 		])

--- a/visualization/app/codeCharta/state/store/dynamicSettings/margin/margin.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/margin/margin.service.spec.ts
@@ -11,7 +11,7 @@ import { DynamicMarginService } from "../../appSettings/dynamicMargin/dynamicMar
 import { setDynamicMargin } from "../../appSettings/dynamicMargin/dynamicMargin.actions"
 import { setAreaMetric } from "../areaMetric/areaMetric.actions"
 import { CodeMapNode } from "../../../../codeCharta.model"
-import _ from "lodash"
+import { clone } from "../../../../util/clone"
 
 describe("MarginService", () => {
 	let marginService: MarginService
@@ -34,7 +34,7 @@ describe("MarginService", () => {
 		storeService = getService<StoreService>("storeService")
 		codeMapPreRenderService = getService<CodeMapPreRenderService>("codeMapPreRenderService")
 
-		map = _.cloneDeep(TEST_FILE_WITH_PATHS.map)
+		map = clone(TEST_FILE_WITH_PATHS.map)
 	}
 
 	function rebuildService() {

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.spec.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.merger.spec.ts
@@ -1,17 +1,17 @@
 import { getMergedBlacklist } from "./blacklist.merger"
 import { TEST_FILE_DATA } from "../../../../util/dataMocks"
-import _ from "lodash"
 import { BlacklistItem, BlacklistType, CCFile } from "../../../../codeCharta.model"
+import { clone } from "../../../../util/clone"
 
 describe("BlacklistMerger", () => {
 	let file1: CCFile
 	let file2: CCFile
 
 	beforeEach(() => {
-		file1 = _.cloneDeep(TEST_FILE_DATA)
+		file1 = clone(TEST_FILE_DATA)
 		file1.fileMeta.fileName = "file1"
 
-		file2 = _.cloneDeep(TEST_FILE_DATA)
+		file2 = clone(TEST_FILE_DATA)
 		file2.fileMeta.fileName = "file2"
 	})
 

--- a/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.spec.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/edges/edges.merger.spec.ts
@@ -1,7 +1,7 @@
 import { getMergedEdges } from "./edges.merger"
 import { TEST_FILE_DATA } from "../../../../util/dataMocks"
-import _ from "lodash"
 import { CCFile, Edge } from "../../../../codeCharta.model"
+import { clone } from "../../../../util/clone"
 
 describe("EdgesMerger", () => {
 	describe("getMergedEdges", () => {
@@ -14,11 +14,11 @@ describe("EdgesMerger", () => {
 		let file2: CCFile
 
 		beforeEach(() => {
-			file1 = _.cloneDeep(TEST_FILE_DATA)
+			file1 = clone(TEST_FILE_DATA)
 			file1.fileMeta.fileName = "file1"
 			file1.settings.fileSettings.edges = []
 
-			file2 = _.cloneDeep(TEST_FILE_DATA)
+			file2 = clone(TEST_FILE_DATA)
 			file2.fileMeta.fileName = "file2"
 			file2.settings.fileSettings.edges = []
 

--- a/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.spec.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/markedPackages/markedPackages.merger.spec.ts
@@ -1,7 +1,7 @@
 import { TEST_FILE_DATA } from "../../../../util/dataMocks"
-import _ from "lodash"
 import { getMergedMarkedPackages } from "./markedPackages.merger"
 import { CCFile, MarkedPackage } from "../../../../codeCharta.model"
+import { clone } from "../../../../util/clone"
 
 describe("MarkedPackagesMerger", () => {
 	describe("getMergedMarkedPackages", () => {
@@ -14,10 +14,10 @@ describe("MarkedPackagesMerger", () => {
 		let file2: CCFile
 
 		beforeEach(() => {
-			file1 = _.cloneDeep(TEST_FILE_DATA)
+			file1 = clone(TEST_FILE_DATA)
 			file1.fileMeta.fileName = "file1"
 
-			file2 = _.cloneDeep(TEST_FILE_DATA)
+			file2 = clone(TEST_FILE_DATA)
 			file2.fileMeta.fileName = "file2"
 
 			mp1 = {

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.reducer.spec.ts
@@ -2,15 +2,15 @@ import { edgeMetricData, nodeEdgeMetricsMap } from "./edgeMetricData.reducer"
 import { calculateNewEdgeMetricData, EdgeMetricDataAction, setEdgeMetricData } from "./edgeMetricData.actions"
 import { EDGE_METRIC_DATA, FILE_STATES, VALID_NODE_WITH_PATH } from "../../../../util/dataMocks"
 import { FileState } from "../../../../model/files/files"
-import _ from "lodash"
 import { EdgeMetricDataService } from "./edgeMetricData.service"
+import { clone } from "../../../../util/clone"
 
 describe("edgeMetricData", () => {
 	let fileStates: FileState[]
 
 	beforeEach(() => {
-		fileStates = _.cloneDeep(FILE_STATES)
-		fileStates[0].file.map = _.cloneDeep(VALID_NODE_WITH_PATH)
+		fileStates = clone(FILE_STATES)
+		fileStates[0].file.map = clone(VALID_NODE_WITH_PATH)
 	})
 
 	describe("Default State", () => {

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
@@ -11,7 +11,7 @@ import { FilesService } from "../../files/files.service"
 import { BlacklistService } from "../../fileSettings/blacklist/blacklist.service"
 import { AttributeTypesService } from "../../fileSettings/attributeTypes/attributeTypes.service"
 import { FileState } from "../../../../model/files/files"
-import _ from "lodash"
+import { clone } from "../../../../util/clone"
 
 describe("EdgeMetricDataService", () => {
 	let edgeMetricDataService: EdgeMetricDataService
@@ -35,8 +35,8 @@ describe("EdgeMetricDataService", () => {
 		$rootScope = getService<IRootScopeService>("$rootScope")
 		storeService = getService<StoreService>("storeService")
 
-		files = _.cloneDeep(FILE_STATES)
-		files[0].file.map = _.cloneDeep(VALID_NODE_WITH_PATH)
+		files = clone(FILE_STATES)
+		files[0].file.map = clone(VALID_NODE_WITH_PATH)
 	}
 
 	function rebuildService() {

--- a/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.spec.ts
@@ -3,15 +3,15 @@ import { calculateNewNodeMetricData, NodeMetricDataAction, setNodeMetricData } f
 import { METRIC_DATA, TEST_DELTA_MAP_A, VALID_NODE_WITH_ROOT_UNARY } from "../../../../util/dataMocks"
 import { FileSelectionState, FileState } from "../../../../model/files/files"
 import { BlacklistType } from "../../../../codeCharta.model"
-import _ from "lodash"
 import { NodeDecorator } from "../../../../util/nodeDecorator"
 import { NodeMetricDataService } from "./nodeMetricData.service"
+import { clone } from "../../../../util/clone"
 
 describe("nodeMetricData", () => {
 	let fileState: FileState
 
 	beforeEach(() => {
-		const file = _.cloneDeep(TEST_DELTA_MAP_A)
+		const file = clone(TEST_DELTA_MAP_A)
 		NodeDecorator.decorateMapWithPathAttribute(file)
 		fileState = {
 			file,

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.spec.ts
@@ -4,7 +4,6 @@ import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
 import { IRootScopeService } from "angular"
 import { CODE_MAP_BUILDING, TEST_NODE_LEAF } from "../../util/dataMocks"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
-import _ from "lodash"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { CodeMapPreRenderService } from "../codeMap/codeMap.preRender.service"
 import { AreaMetricService } from "../../state/store/dynamicSettings/areaMetric/areaMetric.service"
@@ -14,6 +13,8 @@ import { ColorMetricService } from "../../state/store/dynamicSettings/colorMetri
 import { IsAttributeSideBarVisibleService } from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.service"
 import { StoreService } from "../../state/store.service"
 import { openAttributeSideBar } from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.actions"
+import { clone } from "../../util/clone"
+import _ from "lodash"
 
 describe("AttributeSideBarController", () => {
 	let attributeSideBarController: AttributeSideBarController
@@ -217,7 +218,7 @@ describe("AttributeSideBarController", () => {
 
 	describe("updateSortedMetricKeysWithoutPrimaryMetrics", () => {
 		beforeEach(() => {
-			attributeSideBarController["_viewModel"].node = _.cloneDeep(TEST_NODE_LEAF)
+			attributeSideBarController["_viewModel"].node = clone(TEST_NODE_LEAF)
 			attributeSideBarController["_viewModel"].node.attributes = {
 				a: 1,
 				b: 2,

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.spec.ts
@@ -5,9 +5,9 @@ import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { CodeMapNode } from "../../codeCharta.model"
 import { VALID_NODE_WITH_PATH } from "../../util/dataMocks"
 import { StoreService } from "../../state/store.service"
-import _ from "lodash"
 import { markPackage, setMarkedPackages } from "../../state/store/fileSettings/markedPackages/markedPackages.actions"
 import { EdgeMetricDataService } from "../../state/store/metricData/edgeMetricData/edgeMetricData.service"
+import { clone } from "../../util/clone"
 
 describe("CodeMapActionService", () => {
 	let codeMapActionsService: CodeMapActionsService
@@ -22,7 +22,7 @@ describe("CodeMapActionService", () => {
 		edgeMetricDataService = getService<EdgeMetricDataService>("edgeMetricDataService")
 		storeService = getService<StoreService>("storeService")
 
-		nodeA = _.cloneDeep(VALID_NODE_WITH_PATH)
+		nodeA = clone(VALID_NODE_WITH_PATH)
 		storeService.dispatch(setMarkedPackages())
 	}
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -11,7 +11,6 @@ import { MapTreeViewLevelController } from "../mapTreeView/mapTreeView.level.com
 import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 import { CodeMapBuilding } from "./rendering/codeMapBuilding"
 import { CODE_MAP_BUILDING, TEST_FILE_WITH_PATHS, TEST_NODE_ROOT, withMockedEventMethods } from "../../util/dataMocks"
-import _ from "lodash"
 import { BlacklistType, CCFile, CodeMapNode, Node } from "../../codeCharta.model"
 import { BlacklistService } from "../../state/store/fileSettings/blacklist/blacklist.service"
 import { FilesService } from "../../state/store/files/files.service"
@@ -19,6 +18,8 @@ import { StoreService } from "../../state/store.service"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { setIdToBuilding } from "../../state/store/lookUp/idToBuilding/idToBuilding.actions"
 import { setIdToNode } from "../../state/store/lookUp/idToNode/idToNode.actions"
+import { clone } from "../../util/clone"
+import _ from "lodash"
 
 describe("codeMapMouseEventService", () => {
 	let codeMapMouseEventService: CodeMapMouseEventService
@@ -59,7 +60,7 @@ describe("codeMapMouseEventService", () => {
 		storeService = getService<StoreService>("storeService")
 
 		codeMapBuilding = _.cloneDeep(CODE_MAP_BUILDING)
-		file = _.cloneDeep(TEST_FILE_WITH_PATHS)
+		file = clone(TEST_FILE_WITH_PATHS)
 		document.body.style.cursor = CursorType.Default
 	}
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.spec.ts
@@ -22,6 +22,7 @@ import { MetricDataService } from "../../state/store/metricData/metricData.servi
 import { calculateNewNodeMetricData } from "../../state/store/metricData/nodeMetricData/nodeMetricData.actions"
 import { getCCFiles } from "../../model/files/files.helper"
 import { calculateNewEdgeMetricData } from "../../state/store/metricData/edgeMetricData/edgeMetricData.actions"
+import { clone } from "../../util/clone"
 
 describe("codeMapPreRenderService", () => {
 	let codeMapPreRenderService: CodeMapPreRenderService
@@ -53,13 +54,13 @@ describe("codeMapPreRenderService", () => {
 		codeMapRenderService = getService<CodeMapRenderService>("codeMapRenderService")
 		edgeMetricDataService = getService<EdgeMetricDataService>("edgeMetricDataService")
 
-		fileMeta = _.cloneDeep(FILE_STATES[0].file.fileMeta)
-		map = _.cloneDeep(TEST_FILE_WITH_PATHS.map)
+		fileMeta = clone(FILE_STATES[0].file.fileMeta)
+		map = clone(TEST_FILE_WITH_PATHS.map)
 		map.children[1].children = _.slice(map.children[1].children, 0, 2)
 
-		const ccFile: CCFile = _.cloneDeep(TEST_DELTA_MAP_B)
+		const ccFile: CCFile = clone(TEST_DELTA_MAP_B)
 
-		const fileStates = _.cloneDeep(FILE_STATES)
+		const fileStates = clone(FILE_STATES)
 		NodeDecorator.decorateMapWithPathAttribute(fileStates[0].file)
 		NodeDecorator.decorateMapWithPathAttribute(ccFile)
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -7,7 +7,6 @@ import { CodeMapArrowService } from "./codeMap.arrow.service"
 import { Node, CodeMapNode, State } from "../../codeCharta.model"
 import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { METRIC_DATA, STATE, TEST_FILE_WITH_PATHS, TEST_NODES, VALID_EDGES } from "../../util/dataMocks"
-import * as _ from "lodash"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { Vector3 } from "three"
 import * as THREE from "three"
@@ -18,6 +17,8 @@ import { setEdges } from "../../state/store/fileSettings/edges/edges.actions"
 import { unfocusNode } from "../../state/store/dynamicSettings/focusedNodePath/focusedNodePath.actions"
 import { NodeMetricDataService } from "../../state/store/metricData/nodeMetricData/nodeMetricData.service"
 import { setNodeMetricData } from "../../state/store/metricData/nodeMetricData/nodeMetricData.actions"
+import { clone } from "../../util/clone"
+import _ from "lodash"
 
 describe("codeMapRenderService", () => {
 	let storeService: StoreService
@@ -48,7 +49,7 @@ describe("codeMapRenderService", () => {
 		codeMapArrowService = getService<CodeMapArrowService>("codeMapArrowService")
 
 		state = _.cloneDeep(STATE)
-		map = _.cloneDeep(TEST_FILE_WITH_PATHS.map)
+		map = clone(TEST_FILE_WITH_PATHS.map)
 		NodeDecorator.decorateMap(map, METRIC_DATA, [])
 		storeService.dispatch(setState(state))
 		storeService.dispatch(unfocusNode())

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
@@ -5,9 +5,9 @@ import { CodeMapPreRenderService } from "../codeMap.preRender.service"
 import { CodeMapBuilding } from "../rendering/codeMapBuilding"
 import { ThreeSceneService } from "./threeSceneService"
 import { IRootScopeService } from "angular"
-import _ from "lodash"
 import { StoreService } from "../../../state/store.service"
 import { CodeMapMesh } from "../rendering/codeMapMesh"
+import _ from "lodash"
 
 describe("ThreeSceneService", () => {
 	let threeSceneService: ThreeSceneService

--- a/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/edgeChooser/edgeChooser.component.spec.ts
@@ -5,10 +5,10 @@ import { IRootScopeService, ITimeoutService } from "angular"
 import { CodeMapActionsService } from "../codeMap/codeMap.actions.service"
 import { CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service"
 import { CODE_MAP_BUILDING } from "../../util/dataMocks"
-import _ from "lodash"
 import { StoreService } from "../../state/store.service"
 import { EdgeMetricService } from "../../state/store/dynamicSettings/edgeMetric/edgeMetric.service"
 import { EdgeMetricDataService } from "../../state/store/metricData/edgeMetricData/edgeMetricData.service"
+import _ from "lodash"
 
 describe("EdgeChooserController", () => {
 	let edgeChooserController: EdgeChooserController

--- a/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileChooser/fileChooser.component.spec.ts
@@ -6,8 +6,8 @@ import { CodeChartaService } from "../../codeCharta.service"
 import { DialogService } from "../dialog/dialog.service"
 import { FileChooserController } from "./fileChooser.component"
 import { TEST_FILE_CONTENT, withMockedEventMethods } from "../../util/dataMocks"
-import _ from "lodash"
 import { StoreService } from "../../state/store.service"
+import { clone } from "../../util/clone"
 
 describe("fileChooserController", () => {
 	let fileChooserController: FileChooserController
@@ -36,7 +36,7 @@ describe("fileChooserController", () => {
 		storeSevice = getService<StoreService>("storeService")
 
 		fileName = "someFile.json"
-		content = _.cloneDeep(TEST_FILE_CONTENT)
+		content = clone(TEST_FILE_CONTENT)
 	}
 
 	function rebuildController() {

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -1,5 +1,4 @@
 import "./fileExtensionBar.module"
-import _ from "lodash"
 import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { IRootScopeService } from "angular"
 import {
@@ -16,6 +15,8 @@ import { StoreService } from "../../state/store.service"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 import { setDistributionMetric } from "../../state/store/dynamicSettings/distributionMetric/distributionMetric.actions"
+import { clone } from "../../util/clone"
+import _ from "lodash"
 
 describe("FileExtensionBarController", () => {
 	let fileExtensionBarController: FileExtensionBarController
@@ -144,7 +145,7 @@ describe("FileExtensionBarController", () => {
 
 	describe("highlightBarHoveredBuildings", () => {
 		beforeEach(() => {
-			const map = _.cloneDeep(VALID_NODE_WITH_PATH_AND_EXTENSION)
+			const map = clone(VALID_NODE_WITH_PATH_AND_EXTENSION)
 			map.children.push({
 				name: "README.md",
 				type: NodeType.FILE,

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.component.spec.ts
@@ -10,10 +10,10 @@ import {
 	VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_NAME,
 	VALID_NODE_WITH_MULTIPLE_FOLDERS_SORTED_BY_UNARY
 } from "../../util/dataMocks"
-import _ from "lodash"
 import { StoreService } from "../../state/store.service"
 import { SortingOrderAscendingService } from "../../state/store/appSettings/sortingOrderAscending/sortingOrderAscending.service"
 import { SortingOptionService } from "../../state/store/dynamicSettings/sortingOption/sortingOption.service"
+import { clone } from "../../util/clone"
 
 describe("MapTreeViewController", () => {
 	let mapTreeViewController: MapTreeViewController
@@ -34,7 +34,7 @@ describe("MapTreeViewController", () => {
 		$timeout = getService<ITimeoutService>("$timeout")
 		storeService = getService<StoreService>("storeService")
 
-		mapWithMultipleFolders = _.cloneDeep(VALID_NODE_WITH_MULTIPLE_FOLDERS)
+		mapWithMultipleFolders = clone(VALID_NODE_WITH_MULTIPLE_FOLDERS)
 	}
 
 	function rebuildController() {

--- a/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
+++ b/visualization/app/codeCharta/ui/mapTreeView/mapTreeView.level.component.spec.ts
@@ -13,12 +13,13 @@ import {
 	VALID_NODE_WITH_ROOT_UNARY,
 	withMockedEventMethods
 } from "../../util/dataMocks"
-import _ from "lodash"
 import { CodeMapPreRenderService } from "../codeMap/codeMap.preRender.service"
 import { StoreService } from "../../state/store.service"
 import { setMarkedPackages } from "../../state/store/fileSettings/markedPackages/markedPackages.actions"
 import { setSearchedNodePaths } from "../../state/store/dynamicSettings/searchedNodePaths/searchedNodePaths.actions"
 import { NodeMetricDataService } from "../../state/store/metricData/nodeMetricData/nodeMetricData.service"
+import { clone } from "../../util/clone"
+import _ from "lodash"
 
 describe("MapTreeViewLevelController", () => {
 	let mapTreeViewLevelController: MapTreeViewLevelController
@@ -63,7 +64,7 @@ describe("MapTreeViewLevelController", () => {
 			codeMapBuilding = _.cloneDeep(CODE_MAP_BUILDING)
 			codeMapBuilding.node.path = "somePath"
 
-			codeMapNode = _.cloneDeep(VALID_NODE_WITH_PATH)
+			codeMapNode = clone(VALID_NODE_WITH_PATH)
 			codeMapNode.path = "somePath"
 		})
 

--- a/visualization/app/codeCharta/ui/metricDeltaSelected/metricDeltaSelected.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricDeltaSelected/metricDeltaSelected.component.spec.ts
@@ -5,10 +5,10 @@ import { instantiateModule, getService } from "../../../../mocks/ng.mockhelper"
 import { IRootScopeService, ITimeoutService } from "angular"
 import { CODE_MAP_BUILDING } from "../../util/dataMocks"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
-import _ from "lodash"
 import { StoreService } from "../../state/store.service"
 import { InvertDeltaColorsService } from "../../state/store/appSettings/invertDeltaColors/invertDeltaColors.service"
 import { setInvertDeltaColors } from "../../state/store/appSettings/invertDeltaColors/invertDeltaColors.actions"
+import _ from "lodash"
 
 describe("MetricDeltaSelectedController", () => {
 	let metricDeltaSelectedController: MetricDeltaSelectedController

--- a/visualization/app/codeCharta/ui/metricValueHovered/metricValueHovered.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricValueHovered/metricValueHovered.component.spec.ts
@@ -5,10 +5,10 @@ import { IRootScopeService, ITimeoutService } from "angular"
 import { CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service"
 import { Node } from "../../codeCharta.model"
 import { CODE_MAP_BUILDING } from "../../util/dataMocks"
-import _ from "lodash"
 import { AreaMetricService } from "../../state/store/dynamicSettings/areaMetric/areaMetric.service"
 import { HeightMetricService } from "../../state/store/dynamicSettings/heightMetric/heightMetric.service"
 import { ColorMetricService } from "../../state/store/dynamicSettings/colorMetric/colorMetric.service"
+import _ from "lodash"
 
 describe("MetricValueHoveredController", () => {
 	let metricValueHoveredController: MetricValueHoveredController
@@ -106,7 +106,7 @@ describe("MetricValueHoveredController", () => {
 			metricValueHoveredController["_viewModel"].colorMetric = "color"
 
 			metricValueHoveredController.onBuildingHovered(codeMapBuilding)
-			const node: Node = metricValueHoveredController["_viewModel"]["hoveredNode"]
+			const node: Node = metricValueHoveredController["_viewModel"].hoveredNode
 
 			expect(node.deltas).toBe(undefined)
 			expect(node.attributes["area"]).toBe(10)
@@ -122,7 +122,7 @@ describe("MetricValueHoveredController", () => {
 
 			metricValueHoveredController.onBuildingHovered(deltaBuilding)
 
-			const node: Node = metricValueHoveredController["_viewModel"]["hoveredNode"]
+			const node: Node = metricValueHoveredController["_viewModel"].hoveredNode
 			expect(node.deltas["area"]).toBe(40)
 			expect(node.attributes["area"]).toBe(10)
 			expect(node.deltas["color"]).toBe(60)
@@ -134,8 +134,8 @@ describe("MetricValueHoveredController", () => {
 		it("hovered delta color should be neutral color if hoveredHeigtDelta is 0", () => {
 			withMockedBuildingTransitions()
 			metricValueHoveredController["_viewModel"].heightMetric = "height"
-			metricValueHoveredController["_viewModel"]["hoveredNode"] = deltaBuilding.node as Node
-			metricValueHoveredController["_viewModel"]["hoveredNode"]["deltas"]["height"] = 0
+			metricValueHoveredController["_viewModel"].hoveredNode = deltaBuilding.node as Node
+			metricValueHoveredController["_viewModel"].hoveredNode["deltas"]["height"] = 0
 
 			metricValueHoveredController.onBuildingHovered(deltaBuilding)
 
@@ -145,8 +145,8 @@ describe("MetricValueHoveredController", () => {
 		it("hovered delta color should be positive color if hoveredHeigtDelta is 2", () => {
 			withMockedBuildingTransitions()
 			metricValueHoveredController["_viewModel"].heightMetric = "height"
-			metricValueHoveredController["_viewModel"]["hoveredNode"] = deltaBuilding.node as Node
-			metricValueHoveredController["_viewModel"]["hoveredNode"]["deltas"]["height"] = 2
+			metricValueHoveredController["_viewModel"].hoveredNode = deltaBuilding.node as Node
+			metricValueHoveredController["_viewModel"].hoveredNode["deltas"]["height"] = 2
 
 			metricValueHoveredController.onBuildingHovered(deltaBuilding)
 
@@ -156,8 +156,8 @@ describe("MetricValueHoveredController", () => {
 		it("hovered delta color should be negative color if hoveredHeigtDelta is -2", () => {
 			withMockedBuildingTransitions()
 			metricValueHoveredController["_viewModel"].heightMetric = "height"
-			metricValueHoveredController["_viewModel"]["hoveredNode"] = deltaBuilding.node as Node
-			metricValueHoveredController["_viewModel"]["hoveredNode"]["deltas"]["height"] = -2
+			metricValueHoveredController["_viewModel"].hoveredNode = deltaBuilding.node as Node
+			metricValueHoveredController["_viewModel"].hoveredNode["deltas"]["height"] = -2
 
 			metricValueHoveredController.onBuildingHovered(deltaBuilding)
 
@@ -169,7 +169,7 @@ describe("MetricValueHoveredController", () => {
 		it("should set hoveredNode to null if data incomplete", () => {
 			metricValueHoveredController.onBuildingUnhovered()
 
-			expect(metricValueHoveredController["_viewModel"]["hoveredNode"]).toBe(null)
+			expect(metricValueHoveredController["_viewModel"].hoveredNode).toBe(null)
 		})
 	})
 })

--- a/visualization/app/codeCharta/util/codeMapHelper.spec.ts
+++ b/visualization/app/codeCharta/util/codeMapHelper.spec.ts
@@ -2,7 +2,7 @@ import { CodeMapHelper } from "./codeMapHelper"
 import { BlacklistItem, BlacklistType, CodeMapNode, MarkedPackage, NodeType } from "../codeCharta.model"
 import { instantiateModule } from "../../../mocks/ng.mockhelper"
 import { TEST_FILE_WITH_PATHS } from "./dataMocks"
-import _ from "lodash"
+import { clone } from "./clone"
 
 describe("codeMapHelper", () => {
 	let testRoot: CodeMapNode
@@ -15,7 +15,7 @@ describe("codeMapHelper", () => {
 	function restartSystem() {
 		instantiateModule("app.codeCharta.ui.codeMap")
 
-		testRoot = _.cloneDeep(TEST_FILE_WITH_PATHS.map)
+		testRoot = clone(TEST_FILE_WITH_PATHS.map)
 		blacklist = []
 	}
 

--- a/visualization/app/codeCharta/util/deltaGenerator.spec.ts
+++ b/visualization/app/codeCharta/util/deltaGenerator.spec.ts
@@ -1,16 +1,16 @@
-import _ from "lodash"
 import { DeltaGenerator } from "./deltaGenerator"
 import { TEST_DELTA_MAP_A, TEST_DELTA_MAP_B } from "./dataMocks"
 import { CCFile, NodeType } from "../codeCharta.model"
 import { NodeDecorator } from "./nodeDecorator"
+import { clone } from "./clone"
 
 describe("deltaGenerator", () => {
 	let fileA: CCFile
 	let fileB: CCFile
 
 	beforeEach(() => {
-		fileA = _.cloneDeep(TEST_DELTA_MAP_A)
-		fileB = _.cloneDeep(TEST_DELTA_MAP_B)
+		fileA = clone(TEST_DELTA_MAP_A)
+		fileB = clone(TEST_DELTA_MAP_B)
 	})
 
 	it("golden test", () => {

--- a/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
+++ b/visualization/app/codeCharta/util/fileExtensionCalculator.spec.ts
@@ -1,14 +1,14 @@
-import _ from "lodash"
 import { FileExtensionCalculator, MetricDistribution } from "./fileExtensionCalculator"
 import { BlacklistType, CodeMapNode, NodeType } from "../codeCharta.model"
 import { VALID_NODE_WITH_PATH_AND_EXTENSION, VALID_NODE_WITHOUT_RLOC_METRIC, setIsBlacklisted } from "./dataMocks"
 import { HSL } from "./color/hsl"
+import { clone } from "./clone"
 
 describe("FileExtensionCalculator", () => {
 	let map: CodeMapNode
 
 	beforeEach(() => {
-		map = _.cloneDeep(VALID_NODE_WITH_PATH_AND_EXTENSION)
+		map = clone(VALID_NODE_WITH_PATH_AND_EXTENSION)
 	})
 
 	describe("getFileExtensionDistribution", () => {

--- a/visualization/app/codeCharta/util/mapBuilder.spec.ts
+++ b/visualization/app/codeCharta/util/mapBuilder.spec.ts
@@ -1,13 +1,13 @@
 import { VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH, VALID_NODE_WITH_PATH } from "./dataMocks"
 import { CodeMapNode } from "../codeCharta.model"
 import { MapBuilder } from "./mapBuilder"
-import _ from "lodash"
+import { clone } from "./clone"
 
 describe("mapBuilder", () => {
 	let rootNode: CodeMapNode
 
 	beforeEach(() => {
-		rootNode = _.cloneDeep(VALID_NODE_WITH_PATH)
+		rootNode = clone(VALID_NODE_WITH_PATH)
 	})
 
 	function buildHashMap(rootNode: CodeMapNode): Map<string, CodeMapNode> {
@@ -29,7 +29,7 @@ describe("mapBuilder", () => {
 		})
 
 		it("should create a valid delta map with empty folders in between", () => {
-			rootNode = _.cloneDeep(VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH)
+			rootNode = clone(VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH)
 			const hashMap = buildHashMap(rootNode)
 
 			expect(MapBuilder.createCodeMapFromHashMap(hashMap)).toMatchSnapshot()

--- a/visualization/app/codeCharta/util/nodeDecorator.spec.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.spec.ts
@@ -11,9 +11,9 @@ import {
 	EdgeMetricData
 } from "../codeCharta.model"
 import { NodeDecorator } from "./nodeDecorator"
-import _ from "lodash"
 import { HierarchyNode } from "d3"
 import { NodeMetricDataService } from "../state/store/metricData/nodeMetricData/nodeMetricData.service"
+import { clone } from "./clone"
 
 describe("nodeDecorator", () => {
 	let file: CCFile
@@ -25,9 +25,9 @@ describe("nodeDecorator", () => {
 	let attributeTypes: AttributeTypes
 
 	beforeEach(() => {
-		file = _.cloneDeep(TEST_DELTA_MAP_A)
+		file = clone(TEST_DELTA_MAP_A)
 		map = file.map
-		deltaMap = _.cloneDeep(VALID_NODE_WITH_PATH_AND_DELTAS)
+		deltaMap = clone(VALID_NODE_WITH_PATH_AND_DELTAS)
 		metricData = [
 			{ name: "rloc", maxValue: 999999 },
 			{ name: "functions", maxValue: 999999 },
@@ -44,7 +44,7 @@ describe("nodeDecorator", () => {
 			nodes: { functions: AttributeTypeValue.relative, rloc: AttributeTypeValue.absolute },
 			edges: { pairingRate: AttributeTypeValue.relative }
 		}
-		blacklist = _.cloneDeep(STATE.fileSettings.blacklist)
+		blacklist = clone(STATE.fileSettings.blacklist)
 		NodeDecorator.decorateMapWithPathAttribute(file)
 	})
 

--- a/visualization/app/codeCharta/util/treeMapGenerator.spec.ts
+++ b/visualization/app/codeCharta/util/treeMapGenerator.spec.ts
@@ -2,6 +2,7 @@ import { NodeMetricData, State } from "../codeCharta.model"
 import { CodeMapNode, Node } from "../codeCharta.model"
 import { TreeMapGenerator } from "./treeMapGenerator"
 import { METRIC_DATA, TEST_FILE_WITH_PATHS, VALID_NODE_WITH_PATH, VALID_EDGES, STATE } from "./dataMocks"
+import { clone } from "./clone"
 import _ from "lodash"
 
 describe("treeMapGenerator", () => {
@@ -16,10 +17,10 @@ describe("treeMapGenerator", () => {
 	})
 
 	function restartSystem() {
-		map = _.cloneDeep(TEST_FILE_WITH_PATHS.map)
+		map = clone(TEST_FILE_WITH_PATHS.map)
 		state = _.cloneDeep(STATE)
-		codeMapNode = _.cloneDeep(VALID_NODE_WITH_PATH)
-		metricData = _.cloneDeep(METRIC_DATA)
+		codeMapNode = clone(VALID_NODE_WITH_PATH)
+		metricData = clone(METRIC_DATA)
 		isDeltaState = false
 		state.dynamicSettings.focusedNodePath = ""
 	}


### PR DESCRIPTION
# Replaces most occurences of lodash deepClone with rfdc

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

This PR resolves[ this conversion](https://github.com/MaibornWolff/codecharta/pull/1213#discussion_r483990910) for other test files.

I couldn't replace the lodash-implementation completly. It seems like `rfdc` can't clone objects that have Maps or Sets as values.
I also wasn't able to clone a class using get functions, such as `public get id()`
