### PR TITLE
Fix/validation unique file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Validation of unique filenames not checking for the complete path and instead throwing an error on duplicate filename
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.57.0] - 2020-09-11

--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -237,5 +237,41 @@ describe("codeChartaService", () => {
 			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledTimes(1)
 			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledWith(expectedError)
 		})
+
+		it("should not show a validation error if filenames are duplicated when their path is different", () => {
+			validFileContent.nodes[0].children[0].name = "duplicate"
+			validFileContent.nodes[0].children[1].children[0].name = "duplicate"
+
+			codeChartaService.loadFiles([{ fileName, content: validFileContent }])
+
+			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledTimes(0)
+			expect(storeService.getState().files).toHaveLength(1)
+		})
+
+		it("should show a validation error if two files in a folder have the same name", () => {
+			validFileContent.nodes[0].children[1].children[0].name = "duplicate"
+			validFileContent.nodes[0].children[1].children[1].name = "duplicate"
+			const expectedError: CCValidationResult = {
+				error: [`${ERROR_MESSAGES.nodesNotUnique} Found duplicate of File with path: /root/Parent Leaf/duplicate`],
+				warning: []
+			}
+
+			codeChartaService.loadFiles([{ fileName, content: validFileContent }])
+
+			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledTimes(1)
+			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledWith(expectedError)
+		})
+
+		it("should not show a validation error if two files in a folder have the same name but different type", () => {
+			validFileContent.nodes[0].children[1].children[0].name = "duplicate"
+			validFileContent.nodes[0].children[1].children[0].type = NodeType.FILE
+			validFileContent.nodes[0].children[1].children[1].name = "duplicate"
+			validFileContent.nodes[0].children[1].children[1].type = NodeType.FOLDER
+
+			codeChartaService.loadFiles([{ fileName, content: validFileContent }])
+
+			expect(dialogService.showValidationErrorDialog).toHaveBeenCalledTimes(0)
+			expect(storeService.getState().files).toHaveLength(1)
+		})
 	})
 })

--- a/visualization/app/codeCharta/util/fileValidator.spec.ts
+++ b/visualization/app/codeCharta/util/fileValidator.spec.ts
@@ -18,7 +18,7 @@ describe("FileValidator", () => {
 	let invalidFile
 
 	beforeEach(() => {
-		file = TEST_FILE_CONTENT
+		file = clone(TEST_FILE_CONTENT)
 	})
 
 	it("API version exists in package.json", () => {
@@ -133,7 +133,7 @@ describe("FileValidator", () => {
 		file.nodes[0].children[1].type = NodeType.FILE
 
 		const expectedError: CCValidationResult = {
-			error: [`${ERROR_MESSAGES.nodesNotUnique} Found duplicate of File with name: same`],
+			error: [`${ERROR_MESSAGES.nodesNotUnique} Found duplicate of File with path: /root/same`],
 			warning: []
 		}
 
@@ -159,42 +159,6 @@ describe("FileValidator", () => {
 		file.nodes[0] = {
 			something: "something"
 		} as any
-
-		const expectedError: CCValidationResult = {
-			error: [
-				"Required error: nodes[0] should have required property 'name'",
-				"Required error: nodes[0] should have required property 'type'"
-			],
-			warning: []
-		}
-
-		assert.throws(() => {
-			validate(file)
-		}, expectedError)
-	})
-
-	it("attributes should not allow whitespaces", () => {
-		file.nodes[0].attributes = {
-			"tes t1": 0
-		}
-
-		const expectedError: CCValidationResult = {
-			error: [
-				"Required error: nodes[0] should have required property 'name'",
-				"Required error: nodes[0] should have required property 'type'"
-			],
-			warning: []
-		}
-
-		assert.throws(() => {
-			validate(file)
-		}, expectedError)
-	})
-
-	it("attributes should not allow special characters", () => {
-		file.nodes[0].attributes = {
-			"tes)t1": 0
-		}
 
 		const expectedError: CCValidationResult = {
 			error: [

--- a/visualization/app/codeCharta/util/fileValidator.ts
+++ b/visualization/app/codeCharta/util/fileValidator.ts
@@ -100,20 +100,21 @@ function getValidationMessage(error: Ajv.ErrorObject) {
 function validateAllNodesAreUnique(node: CodeMapNode, result: CCValidationResult) {
 	const names = new Set<string>()
 	names.add(`${node.name}|${node.type}`)
-	validateChildrenAreUniqueRecursive(node, result, names)
+	validateChildrenAreUniqueRecursive(node, result, names, `/${node.name}`)
 }
 
-function validateChildrenAreUniqueRecursive(node: CodeMapNode, result: CCValidationResult, names: Set<string>) {
+function validateChildrenAreUniqueRecursive(node: CodeMapNode, result: CCValidationResult, names: Set<string>, subPath: string) {
 	if (!node.children || node.children.length === 0) {
 		return
 	}
 
 	for (const child of node.children) {
-		if (names.has(`${child.name}|${child.type}`)) {
-			result.error.push(`${ERROR_MESSAGES.nodesNotUnique} Found duplicate of ${child.type} with name: ${child.name}`)
+		const path = `${subPath}/${child.name}`
+		if (names.has(`${path}|${child.type}`)) {
+			result.error.push(`${ERROR_MESSAGES.nodesNotUnique} Found duplicate of ${child.type} with path: ${path}`)
 		} else {
-			names.add(`${child.name}|${child.type}`)
-			validateChildrenAreUniqueRecursive(child, result, names)
+			names.add(`${path}|${child.type}`)
+			validateChildrenAreUniqueRecursive(child, result, names, path)
 		}
 	}
 }


### PR DESCRIPTION
# Fix validation not checking for complete path to identify unique nodes

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

- We can't start the decoration process earlier, since the decoration requires a valid file
