### PR TITLE
Tech/eslint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: pull_request
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hallee/eslint-action@1.0.3
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        with:
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          source-root: visualization

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,12 @@ jobs:
   fast_finish: true
   include:
     - stage: test
-      name: "Visualization Unit Test and Linter"
+      name: "Visualization Unit Test"
       before_script:
         - cd visualization
         - npm install
       script:
         - npm run test --ci
-        - npm run lint
     - name: "Visualization E2E Test"
       before_script:
         - cd visualization

--- a/visualization/app/codeCharta/codeCharta.component.ts
+++ b/visualization/app/codeCharta/codeCharta.component.ts
@@ -40,6 +40,7 @@ export class CodeChartaController {
 		this.urlUtils = new UrlExtractor(this.$location, this.$http)
 		this.storeService.dispatch(setIsLoadingFile(true))
 		this.loadFileOrSample()
+		console.log("Just a linting error to test the action")
 	}
 
 	public loadFileOrSample() {


### PR DESCRIPTION
# Add ESLint Github Action

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

This action can highlight linting errors in your code directly. I might be in love with github actions already.
I'm not sure how fast gh-actions are though. But splitting things up between travis and github should speed our PR-checking up