### PR TITLE
Fix/890/deselecting building will not dehighlight connected buildings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Deselcting a building will instantly dehighlight the buildings which were connected through edges #890
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.57.4] - 2020-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Deselcting a building will instantly dehighlight the buildings which were connected through edges #890
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.58.1] - 2020-10-02
@@ -43,8 +45,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed 🗑
 
 ### Fixed 🐞
-
--   Deselcting a building will instantly dehighlight the buildings which were connected through edges #890
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
@@ -94,6 +94,7 @@ describe("CodeMapArrowService", () => {
 			codeMapArrowService.clearArrows = jest.fn()
 			codeMapArrowService["showEdgesOfBuildings"] = jest.fn()
 			codeMapArrowService.addEdgePreview = jest.fn()
+			threeSceneService.clearHighlight = jest.fn()
 		})
 		it("should call clearArrows and showEdgesOfBuildings through BuildingSelected", () => {
 			codeMapArrowService.onBuildingSelected(CODE_MAP_BUILDING)
@@ -123,6 +124,7 @@ describe("CodeMapArrowService", () => {
 			codeMapArrowService.onBuildingDeselected()
 
 			expect(codeMapArrowService.clearArrows).toHaveBeenCalled()
+			expect(threeSceneService.clearHighlight).toHaveBeenCalled()
 			expect(codeMapArrowService["showEdgesOfBuildings"]).toHaveBeenCalledTimes(0)
 			expect(codeMapArrowService.addEdgePreview).toHaveBeenCalled()
 		})

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
@@ -32,6 +32,7 @@ export class CodeMapArrowService
 
 	onBuildingDeselected() {
 		this.clearArrows()
+		this.threeSceneService.clearHighlight()
 		this.addEdgePreview(
 			null,
 			this.storeService.getState().fileSettings.edges.filter(x => x.visible !== EdgeVisibility.none)


### PR DESCRIPTION
# Deselcting building will not dehighlight connected buildings

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

fixes: #890 

## Description

**Descriptive pull request text**, answering:
 - When deselecting a building, the highlighted list is completely cleared
 - That way, when the arrows are cleared, the buildings which where highlighted by the selected building, will also be cleared instantly  

## Screenshots or gifs

![dehighlight](https://user-images.githubusercontent.com/50145538/95469649-2cfa5800-0980-11eb-801d-e1bbe3329486.gif)
