### PR TITLE
Bug/1432/disable map highlighting on drag or move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Disable building's highlight effect on moving the map #1432
+
 ### Chore 👨‍💻 👩‍💻
 
 -   Schedules and merge retries of dependabot dependency updates changed

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -274,7 +274,7 @@ describe("codeMapMouseEventService", () => {
 			expect(threeCameraService.camera.updateMatrixWorld).toHaveBeenCalledWith(false)
 		})
 
-		it("should unhover the building, when no intersection was found, a building is hovered and nothing is hovered in the treeView", () => {
+		it("should un-highlight the building, when no intersection was found and a  building is hovered", () => {
 			codeMapMouseEventService["highlightedInTreeView"] = null
 
 			codeMapMouseEventService.updateHovering()
@@ -295,7 +295,7 @@ describe("codeMapMouseEventService", () => {
 			expect(document.body.style.cursor).toEqual(CursorType.Pointer)
 		})
 
-		it("should not hover node when an intersection was found and the cursor is set to grabbing", () => {
+		it("should not highlight node when an intersection was found and the cursor is set to grabbing", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
@@ -310,7 +310,7 @@ describe("codeMapMouseEventService", () => {
 			expect(document.body.style.cursor).toEqual(CursorType.Grabbing)
 		})
 
-		it("should not hover a node when an intersection was found and the cursor is set to moving", () => {
+		it("should not highlight a node when an intersection was found and the cursor is set to moving", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
@@ -325,7 +325,7 @@ describe("codeMapMouseEventService", () => {
 			expect(document.body.style.cursor).toEqual(CursorType.Moving)
 		})
 
-		it("should not hover a node again when the intersection building is the same as the hovered building", () => {
+		it("should not highlight a node again when the intersection building is the same", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
@@ -367,7 +367,7 @@ describe("codeMapMouseEventService", () => {
 				expect(document.body.style.cursor).toEqual(CursorType.Default)
 			})
 
-			it("should not do anything when no building is hovered and nothing is selected", () => {
+			it("should not do anything when no building is highlight and nothing is selected", () => {
 				threeSceneService.getHighlightedBuilding = jest.fn()
 				threeSceneService.getSelectedBuilding = jest.fn()
 
@@ -445,7 +445,7 @@ describe("codeMapMouseEventService", () => {
 	})
 
 	describe("onDocumentMouseDown", () => {
-		it("should the cursor to moving when pressing the right button", () => {
+		it("should change the cursor to moving when pressing the right button", () => {
 			const event = { button: ClickType.RightClick } as MouseEvent
 
 			codeMapMouseEventService.onDocumentMouseDown(event)
@@ -471,7 +471,7 @@ describe("codeMapMouseEventService", () => {
 	})
 
 	describe("onDocumentDoubleClick", () => {
-		it("should return if hovered is null", () => {
+		it("should return if highlighted is null", () => {
 			threeSceneService.getHighlightedBuilding = jest.fn()
 
 			codeMapMouseEventService.onDocumentDoubleClick()

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -282,21 +282,20 @@ describe("codeMapMouseEventService", () => {
 			expect(threeSceneService.clearHighlight).toHaveBeenCalled()
 		})
 
-		it("should hover a node when no node is hovered, and an intersection was found and change the cursor to pointing", () => {
+		it("should hover a node when an intersection was found and the cursor is set to pointing", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
-
 			threeSceneService.getHighlightedBuilding = jest.fn()
 
 			codeMapMouseEventService.updateHovering()
 
-			expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalledWith(CODE_MAP_BUILDING)
+			expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalled()
 			expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
 			expect(document.body.style.cursor).toEqual(CursorType.Pointer)
 		})
 
-		it("should hover a node when no node is hovered, and an intersection was found but not change cursor in grabbing mode", () => {
+		it("should not hover node when an intersection was found and the cursor is set to grabbing", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
@@ -306,12 +305,12 @@ describe("codeMapMouseEventService", () => {
 
 			codeMapMouseEventService.updateHovering()
 
-			expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalledWith(CODE_MAP_BUILDING)
-			expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+			expect(threeSceneService.addBuildingToHighlightingList).not.toHaveBeenCalled()
+			expect(threeSceneService.highlightBuildings).not.toHaveBeenCalled()
 			expect(document.body.style.cursor).toEqual(CursorType.Grabbing)
 		})
 
-		it("should hover a node when no node is hovered, and an intersection was found but not change cursor in moving mode", () => {
+		it("should not hover a node when an intersection was found and the cursor is set to moving", () => {
 			threeSceneService.getMapMesh = jest.fn().mockReturnValue({
 				checkMouseRayMeshIntersection: jest.fn().mockReturnValue(CODE_MAP_BUILDING)
 			})
@@ -321,8 +320,8 @@ describe("codeMapMouseEventService", () => {
 
 			codeMapMouseEventService.updateHovering()
 
-			expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalledWith(CODE_MAP_BUILDING)
-			expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+			expect(threeSceneService.addBuildingToHighlightingList).not.toHaveBeenCalled()
+			expect(threeSceneService.highlightBuildings).not.toHaveBeenCalled()
 			expect(document.body.style.cursor).toEqual(CursorType.Moving)
 		})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -181,6 +181,7 @@ export class CodeMapMouseEventService
 			CodeMapMouseEventService.changeCursorIndicator(CursorType.Grabbing)
 		}
 		this.mouseOnLastClick = { x: event.clientX, y: event.clientY }
+		this.unhoverBuilding()
 		$(document.activeElement).blur()
 	}
 
@@ -238,18 +239,18 @@ export class CodeMapMouseEventService
 	private hoverBuildingAndChildren(hoveredBuilding: CodeMapBuilding) {
 		if (!this.isGrabbing && !this.isMoving) {
 			CodeMapMouseEventService.changeCursorIndicator(CursorType.Pointer)
-		}
 
-		const { lookUp } = this.storeService.getState()
-		const codeMapNode = lookUp.idToNode.get(hoveredBuilding.node.id)
-		for (const { data } of hierarchy(codeMapNode)) {
-			const building = lookUp.idToBuilding.get(data.id)
-			if (building) {
-				this.threeSceneService.addBuildingToHighlightingList(building)
+			const { lookUp } = this.storeService.getState()
+			const codeMapNode = lookUp.idToNode.get(hoveredBuilding.node.id)
+			for (const { data } of hierarchy(codeMapNode)) {
+				const building = lookUp.idToBuilding.get(data.id)
+				if (building) {
+					this.threeSceneService.addBuildingToHighlightingList(building)
+				}
 			}
+			this.threeSceneService.highlightBuildings()
+			this.$rootScope.$broadcast(CodeMapMouseEventService.BUILDING_HOVERED_EVENT, { hoveredBuilding })
 		}
-		this.threeSceneService.highlightBuildings()
-		this.$rootScope.$broadcast(CodeMapMouseEventService.BUILDING_HOVERED_EVENT, { hoveredBuilding })
 	}
 
 	private unhoverBuilding() {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -200,7 +200,7 @@ export class CodeMapMouseEventService
 
 	private onRightClick() {
 		this.isMoving = false
-		const building = this.threeSceneService.getHighlightedBuilding()
+		const building = this.intersectedBuilding
 		// check if mouse moved to prevent the node context menu to show up after moving the map, when the cursor ends on a building
 		if (building && !this.hasMouseMoved(this.mouseOnLastClick)) {
 			this.$rootScope.$broadcast(CodeMapMouseEventService.BUILDING_RIGHT_CLICKED_EVENT, {
@@ -208,6 +208,7 @@ export class CodeMapMouseEventService
 				x: this.mouse.x,
 				y: this.mouse.y
 			})
+			this.hoverBuilding(building)
 		}
 	}
 

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -127,7 +127,6 @@
 		"@types/puppeteer": "^3.0.2",
 		"@typescript-eslint/eslint-plugin": "^4.0.1",
 		"@typescript-eslint/parser": "^4.0.1",
-		"@webpack-cli/serve": "^1.0.1",
 		"babel-loader": "^8.1.0",
 		"bestzip": "^2.1.5",
 		"clean-webpack-plugin": "^3.0.0",

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -127,6 +127,7 @@
 		"@types/puppeteer": "^3.0.2",
 		"@typescript-eslint/eslint-plugin": "^4.0.1",
 		"@typescript-eslint/parser": "^4.0.1",
+		"@webpack-cli/serve": "^1.0.1",
 		"babel-loader": "^8.1.0",
 		"bestzip": "^2.1.5",
 		"clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
# Disable map highlighting on drag or move

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1432

## Description

**Descriptive pull request text**, answering:
- disables highlighting when cursor is in dragging or moving mode
- does not fire highlight events in those modes reducing overhead