### PR TITLE
Bug/1276/edge preview broken when selecting zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   EdgePreview on Map broken when selecting zero #1276
+
 ### Chore 👨‍💻 👩‍💻
 
 -   Schedules and merge retries of dependabot dependency updates changed

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
@@ -132,10 +132,10 @@ describe("EdgeMetricDataService", () => {
 			expect(nodePaths).toEqual(["/root/big leaf", "/root/Parent Leaf/small leaf"])
 		})
 
-		it("should return null if amount of edges is 0", () => {
+		it("should return an empty set if amount of edges is 0", () => {
 			const nodePaths = edgeMetricDataService.getNodesWithHighestValue("pairingRate", 0)
 
-			expect(nodePaths).toEqual(null)
+			expect(nodePaths).toEqual([])
 		})
 	})
 

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.spec.ts
@@ -131,6 +131,12 @@ describe("EdgeMetricDataService", () => {
 
 			expect(nodePaths).toEqual(["/root/big leaf", "/root/Parent Leaf/small leaf"])
 		})
+
+		it("should return null if amount of edges is 0", () => {
+			const nodePaths = edgeMetricDataService.getNodesWithHighestValue("pairingRate", 0)
+
+			expect(nodePaths).toEqual(null)
+		})
 	})
 
 	describe("getMetricValuesForNode", () => {

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
@@ -55,15 +55,15 @@ export class EdgeMetricDataService implements StoreSubscriber, BlacklistSubscrib
 	}
 
 	getNodesWithHighestValue(metricName: string, amountOfEdgePreviews: number) {
+		if (amountOfEdgePreviews === 0) {
+			return []
+		}
+
 		const nodeEdgeMetrics = nodeEdgeMetricsMap.get(metricName)
 		const keys: string[] = []
 
 		if (nodeEdgeMetrics === undefined) {
 			return keys
-		}
-
-		if (amountOfEdgePreviews === 0) {
-			return null
 		}
 
 		for (const key of nodeEdgeMetrics.keys()) {

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
@@ -55,12 +55,13 @@ export class EdgeMetricDataService implements StoreSubscriber, BlacklistSubscrib
 	}
 
 	getNodesWithHighestValue(metricName: string, amountOfEdgePreviews: number) {
+		const keys: string[] = []
+
 		if (amountOfEdgePreviews === 0) {
-			return []
+			return keys
 		}
 
 		const nodeEdgeMetrics = nodeEdgeMetricsMap.get(metricName)
-		const keys: string[] = []
 
 		if (nodeEdgeMetrics === undefined) {
 			return keys

--- a/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
+++ b/visualization/app/codeCharta/state/store/metricData/edgeMetricData/edgeMetricData.service.ts
@@ -62,6 +62,10 @@ export class EdgeMetricDataService implements StoreSubscriber, BlacklistSubscrib
 			return keys
 		}
 
+		if (amountOfEdgePreviews === 0) {
+			return null
+		}
+
 		for (const key of nodeEdgeMetrics.keys()) {
 			keys.push(key)
 			if (keys.length === amountOfEdgePreviews) {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -60,7 +60,7 @@ export class CodeMapActionsService {
 		for (const edge of edges) {
 			edge.visible = EdgeVisibility.none
 
-			if (edge.attributes[edgeMetric] !== undefined && edgePreviewNodes !== null) {
+			if (edge.attributes[edgeMetric] !== undefined) {
 				const hasFromNodeEdgePreview = edgePreviewNodes.has(edge.fromNodeName)
 				const hasToNodeEdgePreview = edgePreviewNodes.has(edge.toNodeName)
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.actions.service.ts
@@ -60,7 +60,7 @@ export class CodeMapActionsService {
 		for (const edge of edges) {
 			edge.visible = EdgeVisibility.none
 
-			if (edge.attributes[edgeMetric] !== undefined) {
+			if (edge.attributes[edgeMetric] !== undefined && edgePreviewNodes !== null) {
 				const hasFromNodeEdgePreview = edgePreviewNodes.has(edge.fromNodeName)
 				const hasToNodeEdgePreview = edgePreviewNodes.has(edge.toNodeName)
 


### PR DESCRIPTION
#Edge Preview shows all edges when slectiing 0

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1276

## Description

- Fix the bug with all edges being shown when selecting 0 for the amount.

## Screenshots or gifs
