### PR TITLE
Label Improvment: Change size and default displayed Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Improved file sorting in the file overview of the search bar
     -   Numbers are sorted naturally
     -   Characters are compared with their base character (e.g., `a` is now next to `á`).
--   Label metric not shown by default
+-   Label metric not shown by default anymore
 
 ### Removed 🗑
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
     -   Activate/Deactivate the new option "Enable Experimental Features"
     -   The features will be shown/hidden accordingly
 -   "CustomViews", the first experimental feature has been added #1318
+
     -   It must be enabled by activating the new option in the Global Settings dialog as mentioned before.
     -   You can save your current map configurations to replay/restore them later.
     -   A saved CustomView can only be applied for it's original map.
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Changed
 
 -   Improved search
+
     1. Not providing any star in the search bar from now on expects the input to
        be a wildcard search. Thus, files are going to match paths that have
        leading or following characters. E.g., `oo` is going to match
@@ -39,15 +41,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
     1. Whitespace handling changed to ignore leading whitespace.
 
 -   Distribution metric #1188
+
     1. set rloc to default distribution metric, showing language percentages for real lines of code, if available. Else set to unary to show language distribution over files
 
 -   Improved file sorting in the file overview of the search bar
     -   Numbers are sorted naturally
     -   Characters are compared with their base character (e.g., `a` is now next to `á`).
+-   Label metric not shown by default
 
 ### Removed 🗑
 
 ### Fixed 🐞
+
+-   Label showing node name and metric values (2 lines) have incorrect width
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
--   Label showing node name and metric values (2 lines) have incorrect width
-
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.61.0] - 2020-10-30

--- a/visualization/app/codeCharta/state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.actions.ts
@@ -20,4 +20,4 @@ export function setShowMetricLabelNameValue(
 	}
 }
 
-export const defaultShowMetricLabelNameValue = true
+export const defaultShowMetricLabelNameValue = false

--- a/visualization/app/codeCharta/state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.reducer.spec.ts
@@ -6,7 +6,7 @@ describe("showMetricLabelNameValue", () => {
 		it("should initialize the default state", () => {
 			const result = showMetricLabelNameValue(undefined, {} as ShowMetricLabelNameValueAction)
 
-			expect(result).toEqual(true)
+			expect(result).toEqual(false)
 		})
 	})
 
@@ -20,7 +20,7 @@ describe("showMetricLabelNameValue", () => {
 		it("should set default showMetricLabelNameValue", () => {
 			const result = showMetricLabelNameValue(false, setShowMetricLabelNameValue())
 
-			expect(result).toEqual(true)
+			expect(result).toEqual(false)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -21,7 +21,7 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 	private LABEL_COLOR_RGBA = ColorConverter.convertHexToRgba(this.mapLabelColors.rgb, this.mapLabelColors.alpha)
 	private LABEL_WIDTH_DIVISOR = 2100 // empirically gathered
 	private LABEL_HEIGHT_DIVISOR = 35 // empirically gathered
-	private LABEL_CORNER_RADIUS = 35 //empirically gathered
+	private LABEL_CORNER_RADIUS = 40 //empirically gathered
 
 	private currentScale: Vector3 = new Vector3(1, 1, 1)
 	private resetScale = false
@@ -118,7 +118,10 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 		const multiLineContext = message.split("\n")
 
 		// setting canvas width/height before ctx draw, else canvas is empty
-		canvas.width = context.measureText(message).width + margin
+		canvas.width =
+			context.measureText(multiLineContext[0]).width > context.measureText(multiLineContext[1]).width
+				? context.measureText(multiLineContext[0]).width + margin
+				: context.measureText(multiLineContext[1]).width + margin
 		canvas.height = margin + fontsize * multiLineContext.length
 
 		// bg

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -118,10 +118,12 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 		const multiLineContext = message.split("\n")
 
 		// setting canvas width/height before ctx draw, else canvas is empty
+		const firstMultiLineContextWidth = context.measureText(multiLineContext[0]).width
+		const secondMultiLineContextWidth = context.measureText(multiLineContext[1]).width
 		canvas.width =
-			context.measureText(multiLineContext[0]).width > context.measureText(multiLineContext[1]).width
-				? context.measureText(multiLineContext[0]).width + margin
-				: context.measureText(multiLineContext[1]).width + margin
+			firstMultiLineContextWidth > secondMultiLineContextWidth
+				? firstMultiLineContextWidth + margin
+				: secondMultiLineContextWidth + margin
 		canvas.height = margin + fontsize * multiLineContext.length
 
 		// bg

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -1402,7 +1402,7 @@ export const DEFAULT_STATE: State = {
 		searchPanelMode: SearchPanelMode.minimized,
 		isAttributeSideBarVisible: false,
 		panelSelection: PanelSelection.NONE,
-		showMetricLabelNameValue: true,
+		showMetricLabelNameValue: false,
 		showMetricLabelNodeName: true,
 		experimentalFeaturesEnabled: false
 	},


### PR DESCRIPTION
# Label Improvment: Change size and default displayed Info

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

_(Currently there are a lot of label change requests, I will split my improvment suggestions into smaller PRs to make reviews easier)_

This PR will:
- Remove metrics from being displayed by default
- Fix width issues with mutli-line labels, making them a bit more compact

## Screenshots or gifs
