### PR TITLE
Bug/1523/labels do not take delta into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
--   Labels do not take delta height into account([#1523](https://github.com/MaibornWolff/codecharta/issues/1523))
+-   Labels do not take delta height into account ([#1523](https://github.com/MaibornWolff/codecharta/issues/1523))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Labels do not take delta height into account([#1523](https://github.com/MaibornWolff/codecharta/issues/1523))
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.63.0] - 2020-11-30

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -111,7 +111,7 @@ describe("CodeMapLabelService", () => {
 		})
 
 		it("should add label if node has a height attribute mentioned in renderSettings", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
 
 			expect(codeMapLabelService["labels"].length).toBe(1)
 		})
@@ -119,41 +119,41 @@ describe("CodeMapLabelService", () => {
 		it("should not add label if node has not a height attribute mentioned in renderSettings", () => {
 			sampleLeaf.attributes = { notsome: 0 }
 
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
 
 			expect(codeMapLabelService["labels"].length).toBe(0)
 		})
 
 		it("should calculate correct height without delta with node name only", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(91)
 		})
 
 		it("should calculate correct height without delta with metric values only", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(91)
 		})
 
 		it("should calculate correct height without delta for two line label: node name and metric value", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(106)
 		})
 
 		it("should set the text correctly, creating a two line label", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(2)
 		})
 
 		it("should set the text correctly, creating a one line label", () => {
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(1)
@@ -164,8 +164,8 @@ describe("CodeMapLabelService", () => {
 			const SY = 2
 			const SZ = 3
 
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
-			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const scaleBeforeA: Vector3 = new Vector3(
 				codeMapLabelService["labels"][0].sprite.position.x,

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -111,7 +111,7 @@ describe("CodeMapLabelService", () => {
 		})
 
 		it("should add label if node has a height attribute mentioned in renderSettings", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
 
 			expect(codeMapLabelService["labels"].length).toBe(1)
 		})
@@ -119,41 +119,41 @@ describe("CodeMapLabelService", () => {
 		it("should not add label if node has not a height attribute mentioned in renderSettings", () => {
 			sampleLeaf.attributes = { notsome: 0 }
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
 
 			expect(codeMapLabelService["labels"].length).toBe(0)
 		})
 
 		it("should calculate correct height without delta with node name only", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(91)
 		})
 
 		it("should calculate correct height without delta with metric values only", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(91)
 		})
 
 		it("should calculate correct height without delta for two line label: node name and metric value", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(106)
 		})
 
 		it("should set the text correctly, creating a two line label", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(2)
 		})
 
 		it("should set the text correctly, creating a one line label", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(1)
@@ -164,8 +164,8 @@ describe("CodeMapLabelService", () => {
 			const SY = 2
 			const SZ = 3
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabelLeaf(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 
 			const scaleBeforeA: Vector3 = new Vector3(
 				codeMapLabelService["labels"][0].sprite.position.x,

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -38,15 +38,14 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 	}
 
 	//labels need to be scaled according to map or it will clip + looks bad
-	addLabel(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, hightestNode: number) {
-		// todo: tk rename to addLeafLabel
+	addLabelLeaf(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, highestNode: number) {
 		const state = this.storeService.getState()
 		const x = node.x0 - state.treeMap.mapSize
 		const y = node.z0
 		const z = node.y0 - state.treeMap.mapSize
 
 		const labelX = x + node.width / 2
-		const labelY = y + hightestNode
+		const labelY = y + highestNode
 		const labelYOrigin = y + node.height
 		const labelZ = z + node.length / 2
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -38,7 +38,9 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 	}
 
 	//labels need to be scaled according to map or it will clip + looks bad
-	addLabelLeaf(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, highestNode: number) {
+	addLabel(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, highestNode: number) {
+		// todo: tk rename to addLeafLabel
+
 		const state = this.storeService.getState()
 		const x = node.x0 - state.treeMap.mapSize
 		const y = node.z0

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -150,7 +150,7 @@ describe("codeMapRenderService", () => {
 		it("should call codeMapLabelService.addLabels for each shown leaf label", () => {
 			codeMapRenderService["setLabels"](sortedNodes)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(2)
+			expect(codeMapLabelService.addLabelLeaf).toHaveBeenCalledTimes(2)
 		})
 
 		it("should not generate labels when showMetricLabelNodeName and showMetricLabelNameValue are both false", () => {
@@ -159,7 +159,7 @@ describe("codeMapRenderService", () => {
 
 			codeMapRenderService["setLabels"](sortedNodes)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(0)
+			expect(codeMapLabelService.addLabelLeaf).toHaveBeenCalledTimes(0)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -6,7 +6,16 @@ import { CodeMapLabelService } from "./codeMap.label.service"
 import { CodeMapArrowService } from "./codeMap.arrow.service"
 import { Node, CodeMapNode, State } from "../../codeCharta.model"
 import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
-import { DEFAULT_STATE, METRIC_DATA, STATE, TEST_FILE_WITH_PATHS, TEST_NODES, VALID_EDGES } from "../../util/dataMocks"
+import {
+	DEFAULT_STATE,
+	METRIC_DATA,
+	STATE,
+	TEST_FILE_WITH_PATHS,
+	TEST_NODE_LEAF,
+	TEST_NODE_ROOT,
+	TEST_NODES,
+	VALID_EDGES
+} from "../../util/dataMocks"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { Object3D, Vector3 } from "three"
 import { StoreService } from "../../state/store.service"
@@ -150,7 +159,7 @@ describe("codeMapRenderService", () => {
 		it("should call codeMapLabelService.addLabels for each shown leaf label", () => {
 			codeMapRenderService["setLabels"](sortedNodes)
 
-			expect(codeMapLabelService.addLabelLeaf).toHaveBeenCalledTimes(2)
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(2)
 		})
 
 		it("should not generate labels when showMetricLabelNodeName and showMetricLabelNameValue are both false", () => {
@@ -159,7 +168,19 @@ describe("codeMapRenderService", () => {
 
 			codeMapRenderService["setLabels"](sortedNodes)
 
-			expect(codeMapLabelService.addLabelLeaf).toHaveBeenCalledTimes(0)
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(0)
+		})
+
+		it("should take delta into account for height calculation when in delta mode", () => {
+			expect(codeMapRenderService["getHighestNodeDelta"]([TEST_NODE_ROOT])).toEqual(12)
+		})
+
+		it("should correctly calculate heights node accounting for delta", () => {
+			expect(codeMapRenderService["getHighestNodeDelta"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(22)
+		})
+
+		it("should not account for delta height when not in delta mode", () => {
+			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(2)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -172,15 +172,11 @@ describe("codeMapRenderService", () => {
 		})
 
 		it("should take delta into account for height calculation when in delta mode", () => {
-			expect(codeMapRenderService["getHighestNodeDelta"]([TEST_NODE_ROOT])).toEqual(12)
+			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT])).toEqual(12)
 		})
 
 		it("should correctly calculate heights node accounting for delta", () => {
-			expect(codeMapRenderService["getHighestNodeDelta"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(22)
-		})
-
-		it("should not account for delta height when not in delta mode", () => {
-			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(2)
+			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(22)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -74,9 +74,7 @@ export class CodeMapRenderService {
 		const appSettings = this.storeService.getState().appSettings
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
-		const highestNode = isDeltaState(this.storeService.getState().files)
-			? this.getHighestNodeDelta(sortedNodes)
-			: this.getHighestNode(sortedNodes)
+		const highestNode = this.getHighestNode(sortedNodes)
 
 		this.codeMapLabelService.clearLabels()
 		if (showLabelNodeName || showLabelNodeMetric) {
@@ -99,13 +97,8 @@ export class CodeMapRenderService {
 		}
 	}
 
-	private getHighestNodeDelta(sortedNodes: Node[]) {
-		const sortedNodeValues = sortedNodes.map(node => node.height + Math.abs(node.heightDelta))
-		return Math.max(...sortedNodeValues)
-	}
-
 	private getHighestNode(sortedNodes: Node[]) {
-		const sortedNodeValues = sortedNodes.map(node => node.height)
+		const sortedNodeValues = sortedNodes.map(({ height, heightDelta }) => height + Math.abs(heightDelta ?? 0))
 		return Math.max(...sortedNodeValues)
 	}
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -74,22 +74,25 @@ export class CodeMapRenderService {
 		const appSettings = this.storeService.getState().appSettings
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
-		const hightestNode = this.getHighestNode(sortedNodes)
+		const highestNode = this.getHighestNode(sortedNodes)
 
 		this.codeMapLabelService.clearLabels()
 		if (showLabelNodeName || showLabelNodeMetric) {
 			let { amountOfTopLabels } = appSettings
 			for (let index = 0; index < sortedNodes.length && amountOfTopLabels !== 0; index++) {
 				if (sortedNodes[index].isLeaf) {
+
+
+					console.log(highestNode, sortedNodes[index].height)
 					//get neighbors with label
 					//neighbor ==> width + margin + 1
-					this.codeMapLabelService.addLabel(
+					this.codeMapLabelService.addLabelLeaf(
 						sortedNodes[index],
 						{
 							showNodeName: showLabelNodeName,
 							showNodeMetric: showLabelNodeMetric
 						},
-						hightestNode
+						highestNode
 					)
 					amountOfTopLabels -= 1
 				}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -74,19 +74,18 @@ export class CodeMapRenderService {
 		const appSettings = this.storeService.getState().appSettings
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
-		const highestNode = this.getHighestNode(sortedNodes)
+		const highestNode = isDeltaState(this.storeService.getState().files)
+			? this.getHighestNodeDelta(sortedNodes)
+			: this.getHighestNode(sortedNodes)
 
 		this.codeMapLabelService.clearLabels()
 		if (showLabelNodeName || showLabelNodeMetric) {
 			let { amountOfTopLabels } = appSettings
 			for (let index = 0; index < sortedNodes.length && amountOfTopLabels !== 0; index++) {
 				if (sortedNodes[index].isLeaf) {
-
-
-					console.log(highestNode, sortedNodes[index].height)
 					//get neighbors with label
 					//neighbor ==> width + margin + 1
-					this.codeMapLabelService.addLabelLeaf(
+					this.codeMapLabelService.addLabel(
 						sortedNodes[index],
 						{
 							showNodeName: showLabelNodeName,
@@ -98,6 +97,11 @@ export class CodeMapRenderService {
 				}
 			}
 		}
+	}
+
+	private getHighestNodeDelta(sortedNodes: Node[]) {
+		const sortedNodeValues = sortedNodes.map(node => node.height + Math.abs(node.heightDelta))
+		return Math.max(...sortedNodeValues)
 	}
 
 	private getHighestNode(sortedNodes: Node[]) {

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -459,61 +459,6 @@ export const VALID_NODE_WITH_PATH: CodeMapNode = {
 	]
 }
 
-export const VALID_NODE_WITH_MERGED_FOLDERS_AND_PATH: CodeMapNode = {
-	name: "root",
-	attributes: {},
-	type: NodeType.FOLDER,
-	path: "/root",
-	isExcluded: false,
-	isFlattened: false,
-	children: [
-		{
-			name: "big leaf",
-			type: NodeType.FILE,
-			path: "/root/in/between/big leaf",
-			attributes: { rloc: 100, functions: 10, mcc: 1 },
-			link: "http://www.google.de",
-			isExcluded: false,
-			isFlattened: false
-		},
-		{
-			name: "Parent Leaf",
-			type: NodeType.FOLDER,
-			attributes: {},
-			path: "/root/in/between/Parent Leaf",
-			isExcluded: false,
-			isFlattened: false,
-			children: [
-				{
-					name: "small leaf",
-					type: NodeType.FILE,
-					path: "/root/in/between/Parent Leaf/small leaf",
-					attributes: { rloc: 30, functions: 100, mcc: 100 },
-					isExcluded: false,
-					isFlattened: false
-				},
-				{
-					name: "other small leaf",
-					type: NodeType.FILE,
-					path: "/root/in/between/Parent Leaf/other small leaf",
-					attributes: { rloc: 70, functions: 1000, mcc: 10 },
-					isExcluded: false,
-					isFlattened: false
-				},
-				{
-					name: "empty folder",
-					type: NodeType.FOLDER,
-					path: "/root/in/between/Parent Leaf/empty folder",
-					attributes: {},
-					isExcluded: false,
-					isFlattened: false,
-					children: []
-				}
-			]
-		}
-	]
-}
-
 export const VALID_FILE_NODE_WITH_ID: CodeMapNode = {
 	name: "big leaf",
 	id: 1,


### PR DESCRIPTION
# Labels do no take delta into account for height calculation

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1523 

## Description

- Current label implementation did not take label delta height into account when in delta mode, this fixes the issue
- Fix typo in variable name
