### PR TITLE
Bug/1595/height scaling not applied to building anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Height scaling not applied to buildings ([#1595](https://github.com/MaibornWolff/codecharta/issues/1595)))
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.64.0] - 2020-12-15

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -70,7 +70,7 @@ describe("codeMapRenderService", () => {
 
 	function withMockedThreeSceneService() {
 		threeSceneService = codeMapRenderService["threeSceneService"] = jest.fn().mockReturnValue({
-			scale: jest.fn(),
+			scaleHeight: jest.fn(),
 			mapGeometry: jest.fn().mockReturnValue({
 				scale: new Vector3(1, 2, 3)
 			}),
@@ -116,6 +116,22 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["scaleMap"]()
 
 			expect(codeMapArrowService.scale).toHaveBeenCalledWith()
+		})
+
+		it("should call threeSceneService.scaleHeight", () => {
+			storeService.dispatch(setScaling(scaling))
+
+			codeMapRenderService["scaleMap"]()
+
+			expect(threeSceneService.scaleHeight).toHaveBeenCalled()
+		})
+	})
+
+	describe("setNewMapMesh", () => {
+		it("should call threeSceneService.setMapMesh", () => {
+			codeMapRenderService["setNewMapMesh"](TEST_NODES)
+
+			expect(threeSceneService.setMapMesh).toHaveBeenCalled()
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -34,6 +34,7 @@ export class CodeMapRenderService {
 	scaleMap() {
 		this.codeMapLabelService.scale()
 		this.codeMapArrowService.scale()
+		this.threeSceneService.scaleHeight()
 	}
 
 	private getSortedNodes(map: CodeMapNode) {

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
@@ -18,6 +18,8 @@ import { klona } from "klona"
 import { CodeMapNode } from "../../../codeCharta.model"
 import { setIdToBuilding } from "../../../state/store/lookUp/idToBuilding/idToBuilding.actions"
 import { setIdToNode } from "../../../state/store/lookUp/idToNode/idToNode.actions"
+import { setScaling } from "../../../state/store/appSettings/scaling/scaling.actions"
+import { Vector3 } from "three"
 
 describe("ThreeSceneService", () => {
 	let threeSceneService: ThreeSceneService
@@ -187,6 +189,28 @@ describe("ThreeSceneService", () => {
 			threeSceneService.clearHighlight()
 
 			expect(threeSceneService["highlighted"]).toHaveLength(0)
+		})
+	})
+
+	describe("scaleHeight", () => {
+		it("should update mapGeometry scaling to new vector", () => {
+			const scaling = new Vector3(1, 2, 3)
+			storeService.dispatch(setScaling(scaling))
+			threeSceneService.scaleHeight()
+
+			const mapGeometry = threeSceneService.mapGeometry
+
+			expect(mapGeometry.scale).toEqual(scaling)
+		})
+
+		it("should call mapMesh.scale and apply the correct scaling to the mesh", () => {
+			const scaling = new Vector3(1, 2, 3)
+			storeService.dispatch(setScaling(scaling))
+			threeSceneService["mapMesh"].setScale = jest.fn()
+
+			threeSceneService.scaleHeight()
+
+			expect(threeSceneService["mapMesh"].setScale).toHaveBeenCalledWith(scaling)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
@@ -95,6 +95,15 @@ export class ThreeSceneService implements CodeMapPreRenderServiceSubscriber {
 		}
 	}
 
+	scaleHeight() {
+		const { mapSize } = this.storeService.getState().treeMap
+		const scale = this.storeService.getState().appSettings.scaling
+
+		this.mapGeometry.scale.set(scale.x, scale.y, scale.z)
+		this.mapGeometry.position.set(-mapSize * scale.x, 0, -mapSize * scale.z)
+		this.mapMesh.setScale(scale)
+	}
+
 	private highlightMaterial(materials: Material[]) {
 		const highlightedNodeIds = new Set(this.highlighted.map(({ node }) => node.id))
 		const constantHighlightedNodes = new Set<number>()


### PR DESCRIPTION
# Height scaling not applied to building anymore

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1595 

## Description

- scaling factor was used for height calculation,despite being called in margin calculation as well
- re-introduce and rename function to reflect its behaviour
- add tests that explain behaviour and test for scaling being applied to mesh to avoid further confusion