### PR TITLE
Bug/1618/labels placed at wrong height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Global settings not reverting to default ones ([#1632](https://github.com/MaibornWolff/codecharta/issues/1632))
 -   Maximum treemap files shown in squarified node ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+-   Temporary labels are placed at the wrong height for scaled buildings ([#1618](https://github.com/MaibornWolff/codecharta/issues/1618))
+-   Visible labels will disappear or placed lower for scaled buildings ([#1619](https://github.com/MaibornWolff/codecharta/issues/1619))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -154,6 +154,22 @@ describe("CodeMapLabelService", () => {
 			expect(positionWithoutDelta.y).toBe(31)
 		})
 
+		it("should use node height value if nodeHeight is greater than the nodes height ", () => {
+			codeMapLabelService["nodeHeight"] = 100
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+
+			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionWithoutDelta.y).toBe(131)
+		})
+
+		it("should use the nodes actual height if its greater then node height( by construction this is is only the case for temporary labels)", () => {
+			codeMapLabelService["nodeHeight"] = 0
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 10)
+
+			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionWithoutDelta.y).toBe(41)
+		})
+
 		it("should calculate correct height without delta for two line label: node name and metric value", () => {
 			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -217,6 +217,14 @@ describe("CodeMapLabelService", () => {
 			assertLabelPositions(scaledLabelB, expectedScaledSpritePositions, expectedScaledLineGeometryStart)
 		})
 
+		it("should apply scaling factor to a newly created label", () => {
+			storeService.dispatch(setScaling(new Vector3(1, 2, 1)))
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+
+			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionWithoutDelta.y).toBe(37)
+		})
+
 		function assertLabelPositions(scaledLabel, expectedSpritePositions: Vector3, expectedScaledLineGeometryStart: Vector3) {
 			expect(scaledLabel.sprite.position.x).toBe(expectedSpritePositions.x)
 			expect(scaledLabel.sprite.position.y).toBe(expectedSpritePositions.y)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -55,10 +55,10 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 		const y = node.z0
 		const z = node.y0 - state.treeMap.mapSize
 
-		const labelX = x + node.width / 2
-		const labelY = y + this.nodeHeight * multiplier.y
+		const labelX = (x + node.width / 2) * multiplier.x
+		const labelY = (y + this.nodeHeight) * multiplier.y
 		const labelYOrigin = y + node.height
-		const labelZ = z + node.length / 2
+		const labelZ = (z + node.length / 2) * multiplier.z
 
 		if (node.attributes?.[state.dynamicSettings.heightMetric]) {
 			let labelText = ""

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -42,15 +42,21 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 
 	//labels need to be scaled according to map or it will clip + looks bad
 	addLabel(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, highestNode: number) {
+		const { scaling } = this.storeService.getState().appSettings
+		const { margin } = this.storeService.getState().dynamicSettings
+
 		this.nodeHeight = this.nodeHeight > highestNode ? this.nodeHeight : highestNode
 		// todo: tk rename to addLeafLabel
+
+		const multiplier = scaling.clone()
+
 		const state = this.storeService.getState()
 		const x = node.x0 - state.treeMap.mapSize
 		const y = node.z0
 		const z = node.y0 - state.treeMap.mapSize
 
 		const labelX = x + node.width / 2
-		const labelY = y + this.nodeHeight
+		const labelY = y + this.nodeHeight * multiplier.y
 		const labelYOrigin = y + node.height
 		const labelZ = z + node.length / 2
 
@@ -68,7 +74,6 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 			}
 
 			const label = this.makeText(labelText, 30, node)
-			const { margin } = this.storeService.getState().dynamicSettings
 			const {
 				appSettings: { layoutAlgorithm }
 			} = state
@@ -90,6 +95,7 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 			}
 
 			label.sprite.position.set(labelX, labelY + labelOffset, labelZ) //label_height
+
 			label.sprite.material.color = new Color(this.mapLabelColors.rgb)
 			label.sprite.material.opacity = this.mapLabelColors.alpha
 			label.sprite.userData = { node }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -709,14 +709,23 @@ describe("codeMapMouseEventService", () => {
 	})
 
 	describe("drawTemporaryLabelFor", () => {
-		it("should call addLabel on codeMapLabelService with given node and set temporaryLabel", () => {
+		it("should call addLabel on codeMapLabelService with given node and the corresponding height that is different from 0", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
 			codeMapLabelService.addLabel = jest.fn()
 
 			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
+			const nodeHeight = codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).toHaveBeenCalled()
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(
+				codeMapBuilding.node,
+				{
+					showNodeName: true,
+					showNodeMetric: false
+				},
+				12
+			)
+			expect(nodeHeight).toBeGreaterThan(0)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -239,7 +239,7 @@ export class CodeMapMouseEventService
 				showNodeName: showLabelNodeName,
 				showNodeMetric: showLabelNodeMetric
 			},
-			0
+			codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
 		)
 
 		labels = this.threeSceneService.labels?.children


### PR DESCRIPTION
# Fix label issue for scaled buildings in 1618 and 1619

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1618, #1619

## Description

- Temporary labels are now drawn correctly for scaled builidings(in normal and delta mode)
- Drawing new labels/ changing the margin (redraws labels) will not break the positioning on scaled buildings
- Fixed a small bug for 0 height temporary labels in case no constant labels were enabled

