### PR TITLE
Fix: remove unnecessary break line for secondary metrics #1093

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Global settings not reverting to default ones ([#1632](https://github.com/MaibornWolff/codecharta/issues/1632))
 -   Maximum treemap files shown in squarified node ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+-   Unnecessary break line for secondary metrics ([#1093](https://github.com/MaibornWolff/codecharta/issues/1093))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
@@ -75,7 +75,9 @@
 		<div class="metrics-wrapper">
 			<div class="metric-box scrollable-content">
 				<table class="secondary-metrics" aria-hidden="true">
-					<th scope="col">Secondary Metrics</th>
+					<tr>
+						<th scope="col" colspan="2">Secondary Metrics</th>
+					</tr>
 					<tr ng-repeat="attributekey in $ctrl._viewModel.secondaryMetricKeys track by $index">
 						<td>
 							<span class="metric-value">{{ $ctrl._viewModel.node.attributes[attributekey] | number: 0 }}</span>

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
@@ -133,6 +133,7 @@ attribute-side-bar-component {
 
 				th {
 					text-align: left;
+					white-space: nowrap;
 				}
 
 				td {

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
@@ -133,7 +133,6 @@ attribute-side-bar-component {
 
 				th {
 					text-align: left;
-					white-space: nowrap;
 				}
 
 				td {


### PR DESCRIPTION
# Don't break line for secondary metrics span

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Closes: #1093 

## Description
The words are forced into one line.

## Screenshots or gifs
<img width="344" alt="Screenshot 2021-01-15 at 12 55 48" src="https://user-images.githubusercontent.com/57844849/104724533-1149df00-5731-11eb-97fb-8502f56cbb4f.png">
