### PR TITLE
Fix/1624/maximum treemap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.66.0] - 2021-01-18

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.component.html
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.component.html
@@ -16,7 +16,7 @@
 			<max-tree-map-files-component
 				ng-model="$ctrl._viewModel.maxTreeMapFiles"
 				ng-change="$ctrl.applySettingsMaxTreeMapFiles()"
-				ng-show="$ctrl._viewModel.layoutAlgorithm === 'Squarified TreeMap'"
+				ng-show="$ctrl._viewModel.layoutAlgorithm === 'TreeMapStreet'"
 			>
 			</max-tree-map-files-component>
 


### PR DESCRIPTION
# Fix wrong wrong maximum treemap file option

closes: #1624

## Description

the maximum treemap files option on global config should only be visible when TreeMapStreet is active

![image](https://user-images.githubusercontent.com/74670211/105010123-a0117100-5a3b-11eb-8a10-a5d449685185.png)

