### PR TITLE
Bug/1686/labels placed incorrecly on delta maps that share no common nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
--   fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
--   fixed incorrect label placement on delta maps that share no common nodes ([#1686](https://github.com/MaibornWolff/codecharta/issues/1686))
+- fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
-- fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+-   fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+-   fixed incorrect label placement on delta maps that share no common nodes ([#1686](https://github.com/MaibornWolff/codecharta/issues/1686))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 - fixed wrong max tree map visibility ([#1624](https://github.com/MaibornWolff/codecharta/issues/1624))
+- fixed incorrect label placement on delta maps that share no common nodes ([#1686](https://github.com/MaibornWolff/codecharta/issues/1686))
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -23,6 +23,7 @@ describe("CodeMapLabelService", () => {
 	let sampleLeaf: Node
 	let otherSampleLeaf: Node
 	let canvasContextMock
+	let sampleLeafDelta: Node
 
 	beforeEach(() => {
 		restartSystem()
@@ -88,6 +89,22 @@ describe("CodeMapLabelService", () => {
 			children: []
 		} as undefined) as Node
 
+		sampleLeafDelta = ({
+			name: "otherSampleLeaf",
+			width: 4,
+			height: 7,
+			length: 2,
+			depth: 1,
+			x0: 5,
+			z0: 6,
+			y0: 7,
+			isLeaf: true,
+			deltas: { a: 1, b: 2 },
+			attributes: { a: 20, b: 15, mcc: 99 },
+			heightDelta: 8,
+			children: []
+		} as undefined) as Node
+
 		canvasContextMock = {
 			font: "",
 			measureText: jest.fn(),
@@ -124,10 +141,11 @@ describe("CodeMapLabelService", () => {
 		beforeEach(() => {
 			storeService.dispatch(setAmountOfTopLabels(1))
 			storeService.dispatch(setHeightMetric("mcc"))
+			codeMapLabelService["nodeHeight"] = 0
 		})
 
 		it("should add label if node has a height attribute mentioned in renderSettings", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
 
 			expect(codeMapLabelService["labels"].length).toBe(1)
 		})
@@ -135,57 +153,77 @@ describe("CodeMapLabelService", () => {
 		it("should not add label if node has not a height attribute mentioned in renderSettings", () => {
 			sampleLeaf.attributes = { notsome: 0 }
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 100)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
 
 			expect(codeMapLabelService["labels"].length).toBe(0)
 		})
 
 		it("should calculate correct height without delta with node name only", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
-			expect(positionWithoutDelta.y).toBe(31)
+			expect(positionWithoutDelta.y).toBe(33)
 		})
 
 		it("should calculate correct height without delta with metric values only", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
-			expect(positionWithoutDelta.y).toBe(31)
+			expect(positionWithoutDelta.y).toBe(33)
 		})
 
 		it("should use node height value if nodeHeight is greater than the nodes height ", () => {
 			codeMapLabelService["nodeHeight"] = 100
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(131)
 		})
 
-		it("should use the nodes actual height if its greater then node height( by construction this is is only the case for temporary labels)", () => {
-			codeMapLabelService["nodeHeight"] = 0
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 10)
+		it("should use the nodes actual height if its greater then nodeHeight", () => {
+			codeMapLabelService["nodeHeight"] = 10
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(41)
 		})
 
 		it("should calculate correct height without delta for two line label: node name and metric value", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
+
+			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionWithoutDelta.y).toBe(48)
+		})
+
+		it("should use the nodes actual height if its greater then nodeHeight and update nodeHeight correctly", () => {
+			codeMapLabelService.addLabel(sampleLeafDelta, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(46)
+			expect(codeMapLabelService["nodeHeight"]).toEqual(15)
+		})
+
+		it("should use the updated and stored value for nodeHeight when adding a new, smaller node", () => {
+			codeMapLabelService["nodeHeight"] = 10
+			codeMapLabelService.addLabel(sampleLeafDelta, { showNodeName: true, showNodeMetric: false })
+
+			const positionSampleDeltaLeaf: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionSampleDeltaLeaf.y).toBe(46)
+
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
+			const positionSampleLeafWithAppliedDeltaNodeHeight: Vector3 = codeMapLabelService["labels"][0].sprite.position
+			expect(positionSampleLeafWithAppliedDeltaNodeHeight.y).toBe(46)
 		})
 
 		it("should set the text correctly, creating a two line label", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(2)
 		})
 
 		it("should set the text correctly, creating a one line label", () => {
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(1)
@@ -198,8 +236,8 @@ describe("CodeMapLabelService", () => {
 			const SZ = 3
 			const SCALE_CONSTANT_LABEL = codeMapLabelService["LABEL_HEIGHT_COEFFICIENT"]
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: true })
 
 			const originalSpritePositionsA = codeMapLabelService["labels"][0].sprite.position.clone()
 			const originalLineGeometryStartVertices = codeMapLabelService["labels"][0].line.geometry["vertices"][0].clone()
@@ -235,10 +273,10 @@ describe("CodeMapLabelService", () => {
 
 		it("should apply scaling factor to a newly created label", () => {
 			storeService.dispatch(setScaling(new Vector3(1, 2, 1)))
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
-			expect(positionWithoutDelta.y).toBe(37)
+			expect(positionWithoutDelta.y).toBe(41)
 		})
 
 		function assertLabelPositions(scaledLabel, expectedSpritePositions: Vector3, expectedScaledLineGeometryStart: Vector3) {
@@ -261,8 +299,8 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setAmountOfTopLabels(2))
 			storeService.dispatch(setHeightMetric("mcc"))
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
-			codeMapLabelService.addLabel(otherSampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
+			codeMapLabelService.addLabel(otherSampleLeaf, { showNodeName: true, showNodeMetric: false })
 			threeSceneService.labels.children.length = 4
 
 			codeMapLabelService.clearTemporaryLabel(sampleLeaf)
@@ -275,7 +313,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setAmountOfTopLabels(2))
 			storeService.dispatch(setHeightMetric("mcc"))
 
-			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false }, 0)
+			codeMapLabelService.addLabel(sampleLeaf, { showNodeName: true, showNodeMetric: false })
 			threeSceneService.labels.children.length = 2
 
 			codeMapLabelService.clearTemporaryLabel(otherSampleLeaf)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -41,11 +41,13 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 	}
 
 	//labels need to be scaled according to map or it will clip + looks bad
-	addLabel(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }, highestNode: number) {
+	addLabel(node: Node, options: { showNodeName: boolean; showNodeMetric: boolean }) {
 		const { scaling } = this.storeService.getState().appSettings
 		const { margin } = this.storeService.getState().dynamicSettings
 
-		this.nodeHeight = this.nodeHeight > highestNode ? this.nodeHeight : highestNode
+		const newHighestNode = node.height + Math.abs(node.heightDelta ?? 0)
+
+		this.nodeHeight = this.nodeHeight > newHighestNode ? this.nodeHeight : newHighestNode
 		// todo: tk rename to addLeafLabel
 
 		const multiplier = scaling.clone()

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -717,14 +717,10 @@ describe("codeMapMouseEventService", () => {
 			const nodeHeight = codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(
-				codeMapBuilding.node,
-				{
-					showNodeName: true,
-					showNodeMetric: false
-				},
-				12
-			)
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(codeMapBuilding.node, {
+				showNodeName: true,
+				showNodeMetric: false
+			})
 			expect(nodeHeight).toBeGreaterThan(0)
 		})
 	})

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -233,14 +233,10 @@ export class CodeMapMouseEventService
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
 
-		this.codeMapLabelService.addLabel(
-			codeMapBuilding.node,
-			{
-				showNodeName: showLabelNodeName,
-				showNodeMetric: showLabelNodeMetric
-			},
-			codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
-		)
+		this.codeMapLabelService.addLabel(codeMapBuilding.node, {
+			showNodeName: showLabelNodeName,
+			showNodeMetric: showLabelNodeMetric
+		})
 
 		labels = this.threeSceneService.labels?.children
 		const labelForBuilding = this.threeSceneService.getLabelForHoveredNode(codeMapBuilding, labels)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -6,16 +6,7 @@ import { CodeMapLabelService } from "./codeMap.label.service"
 import { CodeMapArrowService } from "./codeMap.arrow.service"
 import { Node, CodeMapNode, State } from "../../codeCharta.model"
 import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
-import {
-	DEFAULT_STATE,
-	METRIC_DATA,
-	STATE,
-	TEST_FILE_WITH_PATHS,
-	TEST_NODE_LEAF,
-	TEST_NODE_ROOT,
-	TEST_NODES,
-	VALID_EDGES
-} from "../../util/dataMocks"
+import { DEFAULT_STATE, METRIC_DATA, STATE, TEST_FILE_WITH_PATHS, TEST_NODES, VALID_EDGES } from "../../util/dataMocks"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { Object3D, Vector3 } from "three"
 import { StoreService } from "../../state/store.service"
@@ -169,14 +160,6 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["setLabels"](sortedNodes)
 
 			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(0)
-		})
-
-		it("should take delta into account for height calculation when in delta mode", () => {
-			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT])).toEqual(12)
-		})
-
-		it("should correctly calculate heights node accounting for delta", () => {
-			expect(codeMapRenderService["getHighestNode"]([TEST_NODE_ROOT, TEST_NODE_LEAF])).toEqual(22)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -18,8 +18,6 @@ export class CodeMapRenderService {
 		private codeMapArrowService: CodeMapArrowService
 	) {}
 
-	private highestNode = 0
-
 	render(map: CodeMapNode) {
 		const sortedNodes = this.getSortedNodes(map)
 		this.setNewMapMesh(sortedNodes)
@@ -66,7 +64,6 @@ export class CodeMapRenderService {
 		const appSettings = this.storeService.getState().appSettings
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
-		this.highestNode = this.getHighestNode(sortedNodes)
 
 		this.codeMapLabelService.clearLabels()
 		if (showLabelNodeName || showLabelNodeMetric) {
@@ -75,23 +72,14 @@ export class CodeMapRenderService {
 				if (sortedNodes[index].isLeaf) {
 					//get neighbors with label
 					//neighbor ==> width + margin + 1
-					this.codeMapLabelService.addLabel(
-						sortedNodes[index],
-						{
-							showNodeName: showLabelNodeName,
-							showNodeMetric: showLabelNodeMetric
-						},
-						this.highestNode
-					)
+					this.codeMapLabelService.addLabel(sortedNodes[index], {
+						showNodeName: showLabelNodeName,
+						showNodeMetric: showLabelNodeMetric
+					})
 					amountOfTopLabels -= 1
 				}
 			}
 		}
-	}
-
-	private getHighestNode(sortedNodes: Node[]) {
-		const sortedNodeValues = sortedNodes.map(({ height, heightDelta }) => height + Math.abs(heightDelta ?? 0))
-		return Math.max(...sortedNodeValues)
 	}
 
 	private setArrows(sortedNodes: Node[]) {


### PR DESCRIPTION
# Fix incorrect label placement for delta maps that share no common nodes

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1686 

## Description

The issue seems to be that when the two maps share no nodes the deltaHeight was calculated too early, before it is scaled down to 500(the highest height is always 500 in CodeCharta). I moved it from the render service, because when accesing it directly we could run into ThreeJS crashes due to the values not being avalible.

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Screenshots or gifs
![correctDeltaHeight](https://user-images.githubusercontent.com/25777197/105185902-658a0000-5b31-11eb-9f50-299568ee713f.PNG)

