### PR TITLE
Fix/1606/switching maps in delta shows no change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Switching maps in delta mode now shows the differences between the maps ([#1606](https://github.com/maibornwolff/codecharta/issues/1606))
+
 ### Chore 👨‍💻 👩‍💻
 
 ## [1.67.0] - 2021-01-26

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
@@ -155,7 +155,7 @@ export class CodeMapPreRenderService implements StoreSubscriber, MetricDataSubsc
 		if (visibleFileStates.length === 2) {
 			let [reference, comparison] = visibleFileStates
 			if (reference.selectedAs !== FileSelectionState.Reference) {
-				const temporary = reference
+				const temporary = comparison
 				comparison = reference
 				reference = temporary
 			}


### PR DESCRIPTION
# Switching maps in Delta Mode

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

fixes: #1606 

## Description

- This PR fixes the bug, that the differences between two maps were not shown when switching maps.
- Switching the maps did not show any differences because the reference map remained the same while the comparison map became the reference map. So we compared the same maps in delta.
- This happened because there was a wrong allocation of the reference map when changing the origin reference map.

## Screenshots or gifs

![switchMaps](https://user-images.githubusercontent.com/50145538/106277352-395d3600-6239-11eb-9f34-8072b6552f5d.gif)
