### PR TITLE
fix broken linter under windows

### DIFF
--- a/visualization/.eslintrc.js
+++ b/visualization/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
         "@typescript-eslint/explicit-member-accessibility": ["error", { accessibility: "no-public" }],
 
         eqeqeq: ["error", "smart"],
-        "linebreak-style": ["error", "unix"],
+        "linebreak-style": ["error", (process.platform === "win32" ? "windows" : "unix")],
         "no-console": ["error", { allow: ["warn", "error"] }],
         "no-duplicate-imports": "error",
         "no-else-return": ["error", { allowElseIf: false }],


### PR DESCRIPTION
# Broken linter under windows

Issue: #1807

## Description

unix `linebreak-style` linter option breaks windows linter. with this pr, the line-break depends on the operating system.
