### PR TITLE
ci: use deploy token with more privileges and prevent recursive builds

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
  check_prettier:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
       working-directory: ./
     steps:
     - uses: actions/checkout@v2
-
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.1.4
       with:
@@ -44,6 +44,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
  build_visualization_test:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -85,6 +86,7 @@ jobs:
           path: ./visualization/dist/
 
  build_visualization_e2e:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -120,6 +122,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
  publish_sonar_analysis:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -153,6 +156,7 @@ jobs:
           JAVA_HOME: ''
 
  publish_sonar_visualization:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest

--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           BRANCH: main
           FOLDER: gh-pages
           CLEAN: true


### PR DESCRIPTION
# Use token with more privileges to deploy gh-pages

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

- Prevent recursive triggering of pipelines triggered by master push
- Use a dedicated deploy token for gh-pages provided by the tech-user

## ToDo
- Before merging this, we need a token named `DEPLOY_TOKEN` in our secrets created by the codecharta-user with the priviliges to push to a protected branch.