### PR TITLE
Update release github-actions to have correct dockerhub images

### DIFF
--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -10,7 +10,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
         
@@ -85,6 +84,9 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./analysis/node-wrapper/package.json
           working-directory: ./visualization
+          
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Run Docker Image
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -93,6 +95,7 @@ jobs:
           name: codecharta/codecharta-visualization
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{env.RELEASE_VERSION}}
           workdir: ./visualization
 
       - name: Deploy


### PR DESCRIPTION
# Provide tag numbers instead of "latest" in dockerhub

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

 -the current script version releases all images with the tag:latest, however the previous implementation released them under the tag name aswell as keeping previously released versions. This PR restores the old behaviour.

## Screenshots or gifs
