### PR TITLE
Fix auto approve issue

### DIFF
--- a/.github/workflows/auto-approve-and-merge.yml
+++ b/.github/workflows/auto-approve-and-merge.yml
@@ -1,29 +1,32 @@
 name: Auto approve and merge PRs by dependabot
 
 on:
-  pull_request
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
 
 jobs:
   autoapprove:
     name: Auto Approve a PR by dependabot
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Auto approve
         uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
-
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
   automerge:
     name: Auto merge after successful checks
     # By default, jobs run in parallel. To run the jobs sequentially, they keywords "needs" is needed.
     # Auto merge action can be done only when the PR is approved, hence this automerge needs autoapprove as a prerequisite
     needs: autoapprove
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Auto merge
         uses: pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: dependencies


### PR DESCRIPTION
This should fix the `Resource not accessible by integration` issue coming up with dependabot auto approval. This is now triggered as soon as the `Tests` actions are done and should have the correct privileges. I am not certain about the latter though.
