### PR TITLE
Feature/1715/add description to global settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+-   Hints for Global Settings were added
+
 ## [1.70.1] - 2021-03-12
 
 ## [1.70.0] - 2021-03-09

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
@@ -1,0 +1,40 @@
+import { goto } from "../../../puppeteer.helper"
+import { FileChooserPageObject } from "../fileChooser/fileChooser.po"
+import { DialogGlobalSettingsPageObject } from "./dialog.globalSettings.po"
+
+describe("LegendPanel", () => {
+	let globalSettingsPageObject: DialogGlobalSettingsPageObject
+	let fileChooser: FileChooserPageObject
+
+	beforeEach(async () => {
+		globalSettingsPageObject = new DialogGlobalSettingsPageObject()
+		fileChooser = new FileChooserPageObject()
+
+		await goto()
+		await setupTest()
+	})
+
+	async function setupTest() {
+		await fileChooser.openFiles(["./app/codeCharta/ressources/sample1_with_different_edges.cc.json"])
+		await globalSettingsPageObject.openGlobalSettings()
+	}
+
+	describe("GlobalSettings", () => {
+		it("Should contain the label for the map layout", async () => {
+			const label = await globalSettingsPageObject.getMapLayoutLabel()
+			expect(label).toEqual("Map Layout")
+		})
+		it("Should contain the Display quality Layout", async () => {
+			const label = await globalSettingsPageObject.getDisplayQualityLabel()
+			expect(label).toEqual("Display quality")
+		})
+		/*
+		it("Should change the layout algorithm", async () => {
+			globalSettingsPageObject.changeLayout()
+			globalSettingsPageObject.setStreetMapAsLayout()
+			const label = await globalSettingsPageObject.getLayout()
+			console.log("this.is.it ", label)
+		})
+*/
+	})
+})

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
@@ -1,8 +1,9 @@
 import { goto } from "../../../puppeteer.helper"
+import { LayoutAlgorithm, SharpnessMode } from "../../codeCharta.model"
 import { FileChooserPageObject } from "../fileChooser/fileChooser.po"
 import { DialogGlobalSettingsPageObject } from "./dialog.globalSettings.po"
 
-describe("LegendPanel", () => {
+describe("DialogGlobalSettings", () => {
 	let globalSettingsPageObject: DialogGlobalSettingsPageObject
 	let fileChooser: FileChooserPageObject
 
@@ -19,22 +20,40 @@ describe("LegendPanel", () => {
 		await globalSettingsPageObject.openGlobalSettings()
 	}
 
-	describe("GlobalSettings", () => {
-		it("Should contain the label for the map layout", async () => {
+	describe("Map Layout", () => {
+		it("should contain the label for the map layout", async () => {
 			const label = await globalSettingsPageObject.getMapLayoutLabel()
+
 			expect(label).toEqual("Map Layout")
 		})
-		it("Should contain the Display quality Layout", async () => {
+		it("should contain the Display quality Layout", async () => {
 			const label = await globalSettingsPageObject.getDisplayQualityLabel()
+
 			expect(label).toEqual("Display quality")
 		})
-		/*
-		it("Should change the layout algorithm", async () => {
-			globalSettingsPageObject.changeLayout()
-			globalSettingsPageObject.setStreetMapAsLayout()
-			const label = await globalSettingsPageObject.getLayout()
-			console.log("this.is.it ", label)
+
+		it("should change the layout algorithm", async () => {
+			await globalSettingsPageObject.changeLayoutToTreeMapStreet()
+
+			const layout = await globalSettingsPageObject.getLayout()
+
+			expect(layout).toEqual(LayoutAlgorithm.TreeMapStreet)
 		})
-*/
+	})
+
+	describe("Display Quality", () => {
+		it("should should maximum-tree-map slider when TreeMapStreet is chosen as layout", async () => {
+			await globalSettingsPageObject.changeLayoutToTreeMapStreet()
+
+			await globalSettingsPageObject.isTreeMapFilesComponentVisible()
+		})
+
+		it("should change the display quality to Pixel Ratio without Antialiasing", async () => {
+			await globalSettingsPageObject.changedDisplayQuality()
+
+			const layout = await globalSettingsPageObject.getDisplayQuality()
+
+			expect(layout).toEqual(SharpnessMode.PixelRatioNoAA)
+		})
 	})
 })

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
@@ -13,4 +13,30 @@ export class DialogGlobalSettingsPageObject {
 	async getDisplayQualityLabel() {
 		return page.$eval("sharpness-mode-selector-component > div > md-input-container > label", element => element["innerText"])
 	}
+
+	async changeLayoutToTreeMapStreet() {
+		await page.click("div.md-dialog-content layout-selection-component div md-input-container md-select")
+		await page.waitForSelector(".md-select-menu-container.md-active", { visible: true })
+		await page.click('md-select-menu md-content [value="TreeMapStreet"]')
+	}
+
+	async getLayout() {
+		await page.waitForSelector("layout-selection-component .md-select-value")
+		return page.$eval("layout-selection-component .md-select-value", element => element["innerText"])
+	}
+
+	async isTreeMapFilesComponentVisible() {
+		return page.waitForSelector("max-tree-map-files-component", { visible: true })
+	}
+
+	async changedDisplayQuality() {
+		await page.click("div.md-dialog-content sharpness-mode-selector-component div md-input-container md-select")
+		await page.waitForSelector(".md-select-menu-container.md-active", { visible: true })
+		await page.click('md-select-menu md-content [value="Pixel Ratio without Antialiasing"]')
+	}
+
+	async getDisplayQuality() {
+		await page.waitForSelector("sharpness-mode-selector-component .md-select-value")
+		return page.$eval("sharpness-mode-selector-component .md-select-value", element => element["innerText"])
+	}
 }

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
@@ -1,0 +1,16 @@
+import { clickButtonOnPageElement } from "../../../puppeteer.helper"
+
+export class DialogGlobalSettingsPageObject {
+	async openGlobalSettings() {
+		await clickButtonOnPageElement("global-settings-button-component .toolbar-button")
+		await page.waitForSelector("md-dialog.global-settings")
+	}
+
+	async getMapLayoutLabel() {
+		return page.$eval("layout-selection-component > div > md-input-container > label", element => element["innerText"])
+	}
+
+	async getDisplayQualityLabel() {
+		return page.$eval("sharpness-mode-selector-component > div > md-input-container > label", element => element["innerText"])
+	}
+}

--- a/visualization/app/codeCharta/ui/layoutSelection/layoutSelection.component.html
+++ b/visualization/app/codeCharta/ui/layoutSelection/layoutSelection.component.html
@@ -1,5 +1,10 @@
-<md-select ng-model="$ctrl._viewModel.layoutAlgorithm" ng-change="$ctrl.applyLayoutAlgorithm()" class="maxSelect">
-	<md-option ng-repeat="layout in $ctrl._viewModel.layoutAlgorithms" value="{{::layout}}">
-		{{::layout}}
-	</md-option>
-</md-select>
+<div>
+	<md-input-container class="global-layout-container">
+		<label> Map Layout </label>
+		<md-select ng-model="$ctrl._viewModel.layoutAlgorithm" ng-change="$ctrl.applyLayoutAlgorithm()" class="maxSelect">
+			<md-option ng-repeat="layout in $ctrl._viewModel.layoutAlgorithms" value="{{::layout}}">
+				{{::layout}}
+			</md-option>
+		</md-select>
+	</md-input-container>
+</div>

--- a/visualization/app/codeCharta/ui/layoutSelection/layoutSelection.component.scss
+++ b/visualization/app/codeCharta/ui/layoutSelection/layoutSelection.component.scss
@@ -2,4 +2,8 @@ layout-selection-component {
 	.maxSelect {
 		margin-bottom: 10px;
 	}
+
+	.global-layout-container {
+		display: inherit;
+	}
 }

--- a/visualization/app/codeCharta/ui/maxTreeMapFiles/maxTreeMapFiles.component.html
+++ b/visualization/app/codeCharta/ui/maxTreeMapFiles/maxTreeMapFiles.component.html
@@ -1,25 +1,27 @@
-<span>Maximum TreeMap Files</span>
-<md-slider-container class="md-block">
-	<md-slider
-		flex
-		step="1"
-		min="1"
-		max="1000"
-		ng-model="$ctrl._viewModel.maxTreeMapFiles"
-		id="maxTreeMapFiles-slider"
-		ng-change="$ctrl.onChangeMaxTreeMapFilesSlider()"
-		class="md-primary"
-	>
-	</md-slider>
-	<md-input-container>
-		<input
-			flex
-			step="1"
-			min="1"
-			max="1000"
-			type="number"
-			ng-model="$ctrl._viewModel.maxTreeMapFiles"
-			ng-change="$ctrl.onChangeMaxTreeMapFilesSlider()"
-		/>
+<div>
+	<md-input-container class="md-block">
+		<label> Maximum TreeMap Files </label>
+		<div layout="row">
+			<md-slider
+				flex
+				step="1"
+				min="1"
+				max="1000"
+				ng-model="$ctrl._viewModel.maxTreeMapFiles"
+				id="maxTreeMapFiles-slider"
+				ng-change="$ctrl.onChangeMaxTreeMapFilesSlider()"
+				class="md-primary"
+			>
+			</md-slider>
+			<input
+				flex="15"
+				step="1"
+				min="1"
+				max="1000"
+				type="number"
+				ng-model="$ctrl._viewModel.maxTreeMapFiles"
+				ng-change="$ctrl.onChangeMaxTreeMapFilesSlider()"
+			/>
+		</div>
 	</md-input-container>
-</md-slider-container>
+</div>

--- a/visualization/app/codeCharta/ui/maxTreeMapFiles/maxTreeMapFiles.component.scss
+++ b/visualization/app/codeCharta/ui/maxTreeMapFiles/maxTreeMapFiles.component.scss
@@ -1,9 +1,5 @@
 max-tree-map-files-component {
-	.span {
-		padding-top: 25px;
-	}
-
 	.md-block {
-		height: 30px;
+		height: 40px;
 	}
 }

--- a/visualization/app/codeCharta/ui/sharpnessModeSelector/sharpnessModeSelector.component.html
+++ b/visualization/app/codeCharta/ui/sharpnessModeSelector/sharpnessModeSelector.component.html
@@ -1,5 +1,10 @@
-<md-select ng-model="$ctrl._viewModel.sharpnessMode" ng-change="$ctrl.applySharpnessMode()" class="maxSelect">
-	<md-option ng-repeat="mode in $ctrl._viewModel.sharpnessModes" value="{{::mode}}">
-		{{::mode}}
-	</md-option>
-</md-select>
+<div>
+	<md-input-container class="sharpness-container">
+		<label> Display quality </label>
+		<md-select ng-model="$ctrl._viewModel.sharpnessMode" ng-change="$ctrl.applySharpnessMode()" class="maxSelect">
+			<md-option ng-repeat="mode in $ctrl._viewModel.sharpnessModes" value="{{::mode}}">
+				{{::mode}}
+			</md-option>
+		</md-select>
+	</md-input-container>
+</div>

--- a/visualization/app/codeCharta/ui/sharpnessModeSelector/sharpnessModeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/sharpnessModeSelector/sharpnessModeSelector.component.scss
@@ -2,4 +2,8 @@ sharpness-mode-selector-component {
 	.maxSelect {
 		margin-bottom: 10px;
 	}
+
+	.sharpness-container {
+		display: inherit;
+	}
 }


### PR DESCRIPTION
# Add description to Global Settings

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1715 

## Description

- This PR adds hints in the form of labels to the Map Layout and Display Quality settings in Global Settings.
- This PR also adds some e2e tests for the Map Layout Chooser and Display quality Chooser

## Screenshots or gifs

<img width="843" alt="Without TreeMap slider" src="https://user-images.githubusercontent.com/50145538/112344319-42600600-8cc4-11eb-8448-6a8c081257de.png">

<img width="840" alt="With TreeMap slider" src="https://user-images.githubusercontent.com/50145538/112344335-45f38d00-8cc4-11eb-8b40-aad036140220.png">

