### PR TITLE
Fix/global dialog reset positioned incorrectly

### DIFF
--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.scss
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.component.scss
@@ -23,7 +23,7 @@ blacklist-panel-component {
 	}
 
 	.pattern-text {
-		direction: rtl;
+		direction: ltr;
 		overflow: hidden;
 		width: 100%;
 		padding-right: 10px;

--- a/visualization/app/codeCharta/ui/dialog/dialog.component.scss
+++ b/visualization/app/codeCharta/ui/dialog/dialog.component.scss
@@ -7,6 +7,10 @@
 	}
 }
 
+reset-settings-button-component {
+	text-align: right;
+}
+
 .icon-link {
 	font-size: 16px !important;
 	margin-left: 6px;

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.html
@@ -1,4 +1,9 @@
-<md-card ng-class="{ expanded: $ctrl._viewModel.isExpanded }" ng-attr-id="search-panel-card" ng-mouseup="$event.stopPropagation()">
+<md-card
+	class="search-panel-card"
+	ng-class="{ expanded: $ctrl._viewModel.isExpanded }"
+	ng-attr-id="search-panel-card"
+	ng-mouseup="$event.stopPropagation()"
+>
 	<div class="section">
 		<div class="section-header">
 			<search-bar-component ng-click="$ctrl.openSearchPanel()"></search-bar-component>

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.scss
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanel.component.scss
@@ -2,4 +2,8 @@ search-panel-component {
 	search-panel-mode-selector-component {
 		display: inline-block;
 	}
+
+	.search-panel-card .section-body {
+		padding: 6px;
+	}
 }


### PR DESCRIPTION
# Small attachment to 1952

## Description

Global setting reset button now correctly aligned right sided
Excluded view from search component has padding again
