### PR TITLE
fix: deprecated url parameter for sonarqube version lower than 6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+-   SonarImport: SonarQube 8.8 support. Older versions are still supported.
+
 ## [1.73.0] - 2021-05-10
 
 ### Added 🚀

--- a/analysis/import/SonarImporter/build.gradle
+++ b/analysis/import/SonarImporter/build.gradle
@@ -12,11 +12,13 @@ dependencies {
     runtime group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jersey_version
     runtime group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junit5_version
-testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrest_version
+    testImplementation group: 'junit', name: 'junit', version: junit4_version
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrest_version
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrest_version
     testImplementation group: 'io.mockk', name: 'mockk', version: mokk_version
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: wiremock_version
+
+    testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junit5_version
 }
 
 test {

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMain.kt
@@ -3,6 +3,7 @@ package de.maibornwolff.codecharta.importer.sonar
 import de.maibornwolff.codecharta.filter.mergefilter.MergeFilter
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMeasuresAPIDatasource
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMetricsAPIDatasource
+import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarVersionAPIDatasource
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import picocli.CommandLine
@@ -63,20 +64,21 @@ class SonarImporterMain(
         }
     }
 
-    private fun createMesauresAPIImporter(): SonarMeasuresAPIImporter {
+    private fun createMeasuresAPIImporter(): SonarMeasuresAPIImporter {
         if (url.endsWith("/")) url = url.substring(0, url.length - 1)
         val baseUrl = URL(url)
-        val ds = SonarMeasuresAPIDatasource(user, baseUrl)
-        val metricsDS = SonarMetricsAPIDatasource(user, baseUrl)
+        val version = SonarVersionAPIDatasource(user, baseUrl).getSonarqubeVersion()
+        val measuresDatasource = SonarMeasuresAPIDatasource(user, baseUrl, version)
+        val metricsDatasource = SonarMetricsAPIDatasource(user, baseUrl)
         val sonarCodeURLLinker = SonarCodeURLLinker(baseUrl)
         val translator = SonarMetricTranslatorFactory.createMetricTranslator()
 
-        return SonarMeasuresAPIImporter(ds, metricsDS, sonarCodeURLLinker, translator, usePath)
+        return SonarMeasuresAPIImporter(measuresDatasource, metricsDatasource, sonarCodeURLLinker, translator, usePath)
     }
 
     override fun call(): Void? {
         print(" ")
-        val importer = createMesauresAPIImporter()
+        val importer = createMeasuresAPIImporter()
         var project = importer.getProjectFromMeasureAPI(projectId, metrics)
 
         val pipedProject = ProjectDeserializer.deserializeProject(input)

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
@@ -23,7 +23,7 @@ import javax.ws.rs.core.MediaType
 class SonarMeasuresAPIDatasource(
     private val user: String,
     private val baseUrl: URL,
-    private val version: Version = Version(6, 5)
+    private val version: Version = SonarVersionAPIDatasource.DEFAULT_VERSION
 ) {
 
     private val client: Client = ClientBuilder.newClient()

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasource.kt
@@ -20,7 +20,11 @@ import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
 import javax.ws.rs.core.MediaType
 
-class SonarMeasuresAPIDatasource(private val user: String, private val baseUrl: URL, private val version: Version) {
+class SonarMeasuresAPIDatasource(
+    private val user: String,
+    private val baseUrl: URL,
+    private val version: Version = Version(6, 5)
+) {
 
     private val client: Client = ClientBuilder.newClient()
     private val logger = KotlinLogging.logger {}

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
@@ -1,6 +1,5 @@
 package de.maibornwolff.codecharta.importer.sonar.dataaccess
 
-import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
 import de.maibornwolff.codecharta.importer.sonar.filter.ErrorResponseFilter
 import de.maibornwolff.codecharta.importer.sonar.model.Version
 import java.net.URI
@@ -29,16 +28,19 @@ class SonarVersionAPIDatasource(private val user: String, private val baseUrl: U
             request.header("Authorization", "Basic " + AuthentificationHandler.createAuthTxtBase64Encoded(user))
         }
 
-        try {
-            System.err.print("Fetching SonarQube Version...")
+        return try {
+            System.err.println("Fetching SonarQube Version...")
             val version = request.get(String::class.java)
-            return Version.parse(version)
-        } catch (e: RuntimeException) {
-            throw SonarImporterException("Error requesting $versionAPIRequestURI", e)
+            Version.parse(version)
+        } catch (e: Exception) {
+            System.err.println("Error requesting $versionAPIRequestURI")
+            System.err.println("Falling back to SonarQube version $DEFAULT_VERSION")
+            DEFAULT_VERSION
         }
     }
 
     companion object {
         private const val VERSION_URL_PATTERN = "%s/api/server/version"
+        val DEFAULT_VERSION = Version(6, 5)
     }
 }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
@@ -1,0 +1,44 @@
+package de.maibornwolff.codecharta.importer.sonar.dataaccess
+
+import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
+import de.maibornwolff.codecharta.importer.sonar.filter.ErrorResponseFilter
+import de.maibornwolff.codecharta.importer.sonar.model.Version
+import java.net.URI
+import java.net.URL
+import javax.ws.rs.client.Client
+import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.core.MediaType
+
+class SonarVersionAPIDatasource(private val user: String, private val baseUrl: URL) {
+
+    private val client: Client = ClientBuilder.newClient()
+
+    init {
+        client.register(ErrorResponseFilter::class.java)
+        client.register(GsonProvider::class.java)
+    }
+
+    fun getSonarqubeVersion(): Version {
+        val versionAPIRequestURI = URI(String.format(VERSION_URL_PATTERN, baseUrl))
+
+        val request = client
+            .target(versionAPIRequestURI)
+            .request(MediaType.APPLICATION_JSON + "; charset=utf-8")
+
+        if (user.isNotEmpty()) {
+            request.header("Authorization", "Basic " + AuthentificationHandler.createAuthTxtBase64Encoded(user))
+        }
+
+        try {
+            System.err.print("Fetching SonarQube Version...")
+            val version = request.get(String::class.java)
+            return Version.parse(version)
+        } catch (e: RuntimeException) {
+            throw SonarImporterException("Error requesting $versionAPIRequestURI", e)
+        }
+    }
+
+    companion object {
+        private const val VERSION_URL_PATTERN = "%s/api/server/version"
+    }
+}

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasource.kt
@@ -1,6 +1,5 @@
 package de.maibornwolff.codecharta.importer.sonar.dataaccess
 
-import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
 import de.maibornwolff.codecharta.importer.sonar.filter.ErrorResponseFilter
 import de.maibornwolff.codecharta.importer.sonar.model.Version
 import java.net.URI
@@ -34,18 +33,14 @@ class SonarVersionAPIDatasource(private val user: String, private val baseUrl: U
             val version = request.get(String::class.java)
             Version.parse(version)
         } catch (exception: Exception) {
-            when (exception) {
-                is SonarImporterException -> {
-                    System.err.println("Falling back to SonarQube version $DEFAULT_VERSION")
-                    DEFAULT_VERSION
-                }
-                else -> throw SonarImporterException("Error requesting $versionAPIRequestURI")
-            }
+            System.err.println("Error requesting $versionAPIRequestURI")
+            System.err.println("Falling back to SonarQube version ${DEFAULT_VERSION.major}.${DEFAULT_VERSION.minor}")
+            DEFAULT_VERSION
         }
     }
 
     companion object {
         private const val VERSION_URL_PATTERN = "%s/api/server/version"
-        val DEFAULT_VERSION = Version(6, 5)
+        val DEFAULT_VERSION = Version(8, 9)
     }
 }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
@@ -1,19 +1,25 @@
 package de.maibornwolff.codecharta.importer.sonar.model
 
 import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
-import java.lang.Exception
+import java.lang.NumberFormatException
 
 class Version(val major: Int, val minor: Int) {
 
     companion object {
         fun parse(version: String): Version {
-            try {
-                val tokenized = version.split(".").subList(0, 2)
-                val versions = tokenized.map { it.toInt() }
-                return Version(versions[0], versions[1])
-            } catch (exception: Exception) {
-                throw SonarImporterException("Could not parse version $version.")
+            if (version.isEmpty()) {
+                throw SonarImporterException("Could not parse empty version.")
             }
+
+            val tokenized = ("$version.0.0.0").split(".").subList(0, 2)
+
+            val versions = try {
+                tokenized.map { it.toInt() }
+            } catch (exception: NumberFormatException) {
+                throw SonarImporterException("Could not parse version $version.", exception)
+            }
+
+            return Version(versions[0], versions[1])
         }
     }
 

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
@@ -1,15 +1,17 @@
 package de.maibornwolff.codecharta.importer.sonar.model
 
 import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
+import java.lang.Exception
 
-class Version(private val major: Int, private val minor: Int) {
+class Version(val major: Int, val minor: Int) {
+
     companion object {
         fun parse(version: String): Version {
-            val tokenized = version.split(".").subList(0, 2)
-            val versions = tokenized.map { it.toInt() }
             try {
+                val tokenized = version.split(".").subList(0, 2)
+                val versions = tokenized.map { it.toInt() }
                 return Version(versions[0], versions[1])
-            } catch (exception: NullPointerException) {
+            } catch (exception: Exception) {
                 throw SonarImporterException("Could not parse version $version.")
             }
         }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/model/Version.kt
@@ -1,0 +1,21 @@
+package de.maibornwolff.codecharta.importer.sonar.model
+
+import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
+
+class Version(private val major: Int, private val minor: Int) {
+    companion object {
+        fun parse(version: String): Version {
+            val tokenized = version.split(".").subList(0, 2)
+            val versions = tokenized.map { it.toInt() }
+            try {
+                return Version(versions[0], versions[1])
+            } catch (exception: NullPointerException) {
+                throw SonarImporterException("Could not parse version $version.")
+            }
+        }
+    }
+
+    fun isSmallerThan(version: Version): Boolean {
+        return major < version.major || major == version.major && minor < version.minor
+    }
+}

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMainTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/SonarImporterMainTest.kt
@@ -7,21 +7,36 @@ import com.github.tomakehurst.wiremock.client.WireMock.verify
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import de.maibornwolff.codecharta.importer.sonar.SonarImporterMain.Companion.main
 import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMetricsAPIDatasource
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import javax.ws.rs.core.MediaType
 import kotlin.jvm.Throws
 
 class SonarImporterMainTest {
     companion object {
         private const val PORT = 8089
 
-        private val METRIC_LIST_URL_PATH =
+        private const val METRIC_LIST_URL_PATH =
             "/api/metrics/search?f=hidden,decimalScale&p=1&ps=${SonarMetricsAPIDatasource.PAGE_SIZE}"
     }
 
     @JvmField
     @Rule
     var wireMockRule = WireMockRule(PORT)
+
+    @Before
+    fun mockVersionRequest() {
+        WireMock.stubFor(
+            WireMock.get(urlEqualTo("/api/server/version"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withHeader("Content-Type", MediaType.TEXT_PLAIN + "; charset=utf-8")
+                        .withStatus(200)
+                        .withBody("7.8.0.0")
+                )
+        )
+    }
 
     @Test
     @Throws(Exception::class)

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
@@ -25,8 +25,6 @@ import java.net.URL
 
 class SonarMeasuresAPIDatasourceIntegrationTest {
 
-    private val logger = KotlinLogging.logger {}
-
     @Rule
     @JvmField
     var wireMockRule = WireMockRule(PORT)

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarMeasuresAPIDatasourceIntegrationTest.kt
@@ -13,11 +13,12 @@ import de.maibornwolff.codecharta.importer.sonar.dataaccess.SonarMetricsAPIDatas
 import de.maibornwolff.codecharta.importer.sonar.model.ErrorEntity
 import de.maibornwolff.codecharta.importer.sonar.model.ErrorResponse
 import de.maibornwolff.codecharta.importer.sonar.model.Measures
-import mu.KotlinLogging
+import de.maibornwolff.codecharta.importer.sonar.model.Version
 import org.hamcrest.Matchers.`is`
 import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.IOException
 import java.net.MalformedURLException
 import java.net.URI
@@ -86,9 +87,9 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         )
 
         // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
 
-        val componentMap = ds.getComponentMap(PROJECT_KEY, listOf("coverage"))
+        val componentMap = measuresApiDatasource.getComponentMap(PROJECT_KEY, listOf("coverage"))
 
         // then
         assertThat(componentMap.componentList.size, `is`(5))
@@ -129,11 +130,11 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         )
 
         // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
 
-        val measures1 = ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
-        val measures2 = ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 2)
-        val measures3 = ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 3)
+        val measures1 = measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
+        val measures2 = measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 2)
+        val measures3 = measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 3)
 
         // then
         assertThat(measures1, `is`(createExpectedPagedMeasures(1)))
@@ -156,8 +157,8 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         )
 
         // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
-        val measures = ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val measures = measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
 
         // then
         assertThat(measures, `is`(createExpectedMeasures()))
@@ -178,8 +179,8 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         )
 
         // when
-        val ds = SonarMeasuresAPIDatasource(USERNAME, createBaseUrl())
-        val measures = ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource(USERNAME, createBaseUrl())
+        val measures = measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
 
         // then
         assertThat(measures, `is`(createExpectedMeasures()))
@@ -201,51 +202,42 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         )
 
         // when
-        val ds = SonarMeasuresAPIDatasource(USERNAME, createBaseUrl())
-        ds.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource(USERNAME, createBaseUrl())
+        measuresApiDatasource.getMeasuresFromPage(PROJECT_KEY, listOf("coverage"), 1)
     }
 
     @Test
-    @Throws(Exception::class)
     fun createMeasureAPIRequestURI() {
-        // given
         val expectedMeasuresAPIRequestURI =
-            URI(createBaseUrl().toString() + "/api/measures/component_tree?baseComponentKey=&qualifiers=FIL,UTS&metricKeys=coverage&p=0&ps=500")
+            URI(createBaseUrl().toString() + "/api/measures/component_tree?component=&qualifiers=FIL,UTS&metricKeys=coverage&p=0&ps=500")
 
-        // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
-        val measureAPIRequestURI = ds.createMeasureAPIRequestURI("", listOf("coverage"), 0)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val measureAPIRequestURI = measuresApiDatasource.createMeasureAPIRequestURI("", listOf("coverage"), 0)
 
-        // then
         assertThat(measureAPIRequestURI, `is`(expectedMeasuresAPIRequestURI))
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    @Throws(Exception::class)
+    @Test
     fun createMeasureAPIRequestURI_without_metrics_throws_exception() {
-        // given
-        // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
-        ds.createMeasureAPIRequestURI("", listOf(), 0)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
 
-        // then throw
+        assertThrows<IllegalArgumentException> {
+            measuresApiDatasource.createMeasureAPIRequestURI("", listOf(), 0)
+        }
     }
 
-    @Test(expected = SonarImporterException::class)
-    @Throws(Exception::class)
+    @Test
     fun createMeasureAPIRequestURI_illegal_character_in_metrics_should_throw_exception() {
-        // given
-        // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
-        ds.createMeasureAPIRequestURI("", listOf(" "), 0)
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
 
-        // then throw
+        assertThrows<SonarImporterException> {
+            measuresApiDatasource.createMeasureAPIRequestURI("", listOf(" "), 0)
+        }
     }
 
     @Test
     @Throws(Exception::class)
     fun getComponents_from_server_if_no_authentication_needed() {
-        // given
         stubFor(
             get(urlEqualTo(URL_PATH))
                 .willReturn(
@@ -256,11 +248,27 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
                 )
         )
 
-        // when
-        val ds = SonarMeasuresAPIDatasource("", createBaseUrl())
-        val components = ds.getComponentMap(PROJECT_KEY, listOf("coverage"))
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl())
+        val components = measuresApiDatasource.getComponentMap(PROJECT_KEY, listOf("coverage"))
 
-        // then
+        assertThat(components.componentList.count(), `is`(34))
+    }
+
+    @Test
+    fun `should use deprecated query parameters if sonarqube version is too old`() {
+        stubFor(
+            get(urlEqualTo(URL_PATH_DEPRECATED))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)
+                        .withBody(createResponseString())
+                )
+        )
+
+        val measuresApiDatasource = SonarMeasuresAPIDatasource("", createBaseUrl(), Version(6, 5))
+        val components = measuresApiDatasource.getComponentMap(PROJECT_KEY, listOf("coverage"))
+
         assertThat(components.componentList.count(), `is`(34))
     }
 
@@ -270,11 +278,13 @@ class SonarMeasuresAPIDatasourceIntegrationTest {
         private const val PROJECT_KEY = "someProject"
         private val GSON = GsonBuilder().create()
         private const val URL_PATH =
-            "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=1&ps=$PAGE_SIZE"
+            "/api/measures/component_tree?component=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=1&ps=$PAGE_SIZE"
         private const val URL_PATH_SECOND_PAGE =
-            "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=2&ps=$PAGE_SIZE"
+            "/api/measures/component_tree?component=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=2&ps=$PAGE_SIZE"
         private const val URL_PATH_THIRD_PAGE =
-            "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=3&ps=$PAGE_SIZE"
+            "/api/measures/component_tree?component=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=3&ps=$PAGE_SIZE"
+        private const val URL_PATH_DEPRECATED =
+            "/api/measures/component_tree?baseComponentKey=$PROJECT_KEY&qualifiers=FIL,UTS&metricKeys=coverage&p=1&ps=$PAGE_SIZE"
 
         private fun createBaseUrl(): URL {
             try {

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasourceIntegrationTest.kt
@@ -5,11 +5,9 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.junit.WireMockRule
-import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.assertThrows
 import java.net.MalformedURLException
 import java.net.URL
 import javax.ws.rs.core.MediaType
@@ -40,7 +38,7 @@ class SonarVersionAPIDatasourceIntegrationTest {
     }
 
     @Test
-    fun `should fallback to default version`() {
+    fun `should fallback to default version if version is not parsable`() {
         stubFor(
             get(urlEqualTo(URL_PATH))
                 .willReturn(
@@ -53,23 +51,25 @@ class SonarVersionAPIDatasourceIntegrationTest {
 
         val version = versionAPIDatasource.getSonarqubeVersion()
 
-        assertEquals(version.major, 6)
-        assertEquals(version.minor, 5)
+        assertEquals(version.major, SonarVersionAPIDatasource.DEFAULT_VERSION.major)
+        assertEquals(version.minor, SonarVersionAPIDatasource.DEFAULT_VERSION.minor)
     }
 
     @Test
-    fun `should throw an exception if we encounter an error during the request`() {
+    fun `should fallback to default version if version endpoint is not available`() {
         stubFor(
             get(urlEqualTo(URL_PATH))
                 .willReturn(
                     aResponse()
                         .withHeader("Content-Type", MediaType.TEXT_PLAIN + "; charset=utf-8")
-                        .withStatus(400)
-                        .withBody("6")
+                        .withStatus(404)
                 )
         )
 
-        assertThrows<SonarImporterException> { versionAPIDatasource.getSonarqubeVersion() }
+        val version = versionAPIDatasource.getSonarqubeVersion()
+
+        assertEquals(version.major, SonarVersionAPIDatasource.DEFAULT_VERSION.major)
+        assertEquals(version.minor, SonarVersionAPIDatasource.DEFAULT_VERSION.minor)
     }
 
     companion object {

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasourceIntegrationTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/dataaccess/SonarVersionAPIDatasourceIntegrationTest.kt
@@ -1,0 +1,87 @@
+package de.maibornwolff.codecharta.importer.sonar.dataaccess
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import java.net.MalformedURLException
+import java.net.URL
+import javax.ws.rs.core.MediaType
+
+class SonarVersionAPIDatasourceIntegrationTest {
+
+    @Rule
+    @JvmField
+    var wireMockRule = WireMockRule(PORT)
+    private val versionAPIDatasource = SonarVersionAPIDatasource("somename", createBaseUrl())
+
+    @Test
+    fun `should parse the version to 6 point 6`() {
+        stubFor(
+            get(urlEqualTo(URL_PATH))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", MediaType.TEXT_PLAIN + "; charset=utf-8")
+                        .withStatus(200)
+                        .withBody("6.5.3.1234")
+                )
+        )
+
+        val version = versionAPIDatasource.getSonarqubeVersion()
+
+        assertEquals(version.major, 6)
+        assertEquals(version.minor, 5)
+    }
+
+    @Test
+    fun `should fallback to default version`() {
+        stubFor(
+            get(urlEqualTo(URL_PATH))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", MediaType.TEXT_PLAIN + "; charset=utf-8")
+                        .withStatus(200)
+                        .withBody("6")
+                )
+        )
+
+        val version = versionAPIDatasource.getSonarqubeVersion()
+
+        assertEquals(version.major, 6)
+        assertEquals(version.minor, 5)
+    }
+
+    @Test
+    fun `should throw an exception if we encounter an error during the request`() {
+        stubFor(
+            get(urlEqualTo(URL_PATH))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", MediaType.TEXT_PLAIN + "; charset=utf-8")
+                        .withStatus(400)
+                        .withBody("6")
+                )
+        )
+
+        assertThrows<SonarImporterException> { versionAPIDatasource.getSonarqubeVersion() }
+    }
+
+    companion object {
+        private const val PORT = 8089
+        private const val URL_PATH = "/api/server/version"
+
+        private fun createBaseUrl(): URL {
+            try {
+                return URL("http://localhost:$PORT")
+            } catch (e: MalformedURLException) {
+                throw RuntimeException(e)
+            }
+        }
+    }
+}

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
@@ -18,8 +18,21 @@ class VersionTest {
     }
 
     @Test
-    fun `should throw an error if version is not parsable`() {
-        assertThrows<SonarImporterException> { Version.parse("8") }
+    fun `should parse a version even though minor is not specified`() {
+        val result = Version.parse("8")
+
+        assertEquals(result.major, 8)
+        assertEquals(result.minor, 0)
+    }
+
+    @Test
+    fun `should throw an error if version is empty`() {
+        assertThrows<SonarImporterException> { Version.parse("") }
+    }
+
+    @Test
+    fun `should throw an error if version does not contain a number`() {
+        assertThrows<SonarImporterException> { Version.parse("a") }
     }
 
     @Test

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
@@ -1,7 +1,9 @@
 package de.maibornwolff.codecharta.importer.sonar.model
 
 import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
 

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/model/VersionTest.kt
@@ -1,0 +1,61 @@
+package de.maibornwolff.codecharta.importer.sonar.model
+
+import de.maibornwolff.codecharta.importer.sonar.SonarImporterException
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+
+class VersionTest {
+
+    @Test
+    fun `should parse a full version`() {
+        val result = Version.parse("8.9.0.1234")
+
+        assertEquals(result.major, 8)
+        assertEquals(result.minor, 9)
+    }
+
+    @Test
+    fun `should throw an error if version is not parsable`() {
+        assertThrows<SonarImporterException> { Version.parse("8") }
+    }
+
+    @Test
+    fun `should return true if major version is smaller`() {
+        val version = Version(6, 6)
+        val greaterVersion = Version(8, 9)
+
+        assertTrue(version.isSmallerThan(greaterVersion))
+    }
+
+    @Test
+    fun `should return false if major version is greater`() {
+        val version = Version(6, 6)
+        val smallerVersion = Version(5, 9)
+
+        assertFalse(version.isSmallerThan(smallerVersion))
+    }
+
+    @Test
+    fun `should return true if major version is the same but minor version is smaller`() {
+        val version = Version(6, 6)
+        val greaterVersion = Version(6, 7)
+
+        assertTrue(version.isSmallerThan(greaterVersion))
+    }
+
+    @Test
+    fun `should return false if major version is the same but minor version is smaller`() {
+        val version = Version(6, 6)
+        val smallerVersion = Version(6, 5)
+
+        assertFalse(version.isSmallerThan(smallerVersion))
+    }
+
+    @Test
+    fun `should return false if both are the same`() {
+        val version = Version(6, 6)
+
+        assertFalse(version.isSmallerThan(version))
+    }
+}


### PR DESCRIPTION
# Fetching measures for SonarQube > 6.6 results in an error

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

- Adds new datasource to fetch the Sonarqube Version
- Adds fallback to version 8.9 if endpoint is not available or version is not parsable
- Conditional URI generation depending on version
