### PR TITLE
Proposal: Allow inbuild dependabot to read secrets again(see comment)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - main
-  pull_request:
+  pull_request_target:
     branches:
     - main
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
     - main
-  pull_request_target:
+  pull_request:
     branches:
     - main
+  pull_request_target:
+      branches:
+      - main
 
 jobs:
  check_prettier:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,10 +1,7 @@
 name: Tests
 
 on:
-  push:
-    branches:
-    - main
-  pull_request_target:
+  pull_request_target
 
 jobs:
  check_prettier:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,8 +11,7 @@ on:
 jobs:
  check_prettier:
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+     "!contains(github.event.head_commit.message, 'Deploying to main')" 
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
@@ -47,8 +46,9 @@ jobs:
 
  build_visualization_test:
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -91,8 +91,9 @@ jobs:
 
  build_visualization_e2e:
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -129,8 +130,9 @@ jobs:
 
  publish_sonar_analysis:
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') 
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -165,8 +167,9 @@ jobs:
 
  publish_sonar_visualization:
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')   
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))  
     needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -95,7 +95,8 @@ jobs:
     if: |
      "!contains(github.event.head_commit.message, 'Deploying to main')" && 
      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    name: Visualization E2E
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    
+    name: Visualization E2E
     runs-on: ubuntu-latest
     env:
       working-directory: ./visualization
@@ -133,7 +134,8 @@ jobs:
     if: |
      "!contains(github.event.head_commit.message, 'Deploying to main')" && 
      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    name: "Build and Publish Analysis Sonar Results"
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))   
+    name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
       working-directory: ./analysis
@@ -169,7 +171,8 @@ jobs:
     if: |
      "!contains(github.event.head_commit.message, 'Deploying to main')" && 
      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    needs: [build_visualization_test, build_visualization_e2e]
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    
+    needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,7 +1,12 @@
 name: Tests
 
 on:
-  pull_request_target
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
  check_prettier:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,13 +5,13 @@ on:
     branches:
     - main
   pull_request_target:
-    branches:
-    - main
 
 jobs:
  check_prettier:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" 
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Prettier Test
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
     - main
-  pull_request:
+  pull_request_target:
     branches:
     - main
 
 jobs:
  check_prettier:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    if: |
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
@@ -44,7 +47,10 @@ jobs:
       working-directory: ${{env.working-directory}}
 
  build_visualization_test:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    if: |
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -86,8 +92,10 @@ jobs:
           path: ./visualization/dist/
 
  build_visualization_e2e:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    name: Visualization E2E
+    if: |
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    name: Visualization E2E
     runs-on: ubuntu-latest
     env:
       working-directory: ./visualization
@@ -122,8 +130,10 @@ jobs:
       working-directory: ${{env.working-directory}}
 
  publish_sonar_analysis:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    name: "Build and Publish Analysis Sonar Results"
+    if: |
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
       working-directory: ./analysis
@@ -156,16 +166,26 @@ jobs:
           JAVA_HOME: ''
 
  publish_sonar_visualization:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    needs: [build_visualization_test, build_visualization_e2e]
+    if: |
+     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest
     env:
       working-directory: ./visualization
 
     steps:
-      - uses: actions/checkout@v2
-
+      - name: Checkout
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@v2
+        
+      - name: Checkout PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v2
+        with:
+         ref: ${{ github.event.pull_request.head.sha }}
+      
       - uses: actions/download-artifact@v2
         with:
           name: coverage

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,9 +11,8 @@ on:
 jobs:
  check_prettier:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
-     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
@@ -48,9 +47,8 @@ jobs:
 
  build_visualization_test:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
-     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -93,9 +91,8 @@ jobs:
 
  build_visualization_e2e:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
-     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -132,9 +129,8 @@ jobs:
 
  publish_sonar_analysis:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
-     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))   
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') 
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -169,9 +165,8 @@ jobs:
 
  publish_sonar_visualization:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
-     ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-     || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))    
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')   
     needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,9 +11,9 @@ on:
 jobs:
  check_prettier:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     "!contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
@@ -48,9 +48,9 @@ jobs:
 
  build_visualization_test:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     "!contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -93,9 +93,9 @@ jobs:
 
  build_visualization_e2e:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     "!contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -132,9 +132,9 @@ jobs:
 
  publish_sonar_analysis:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     "!contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -169,9 +169,9 @@ jobs:
 
  publish_sonar_visualization:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main')" && 
+     "!contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))  
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
     needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,9 +11,9 @@ on:
 jobs:
  check_prettier:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main') && 
+      !contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Prettier Test
     runs-on: ubuntu-latest
     env:
@@ -48,9 +48,9 @@ jobs:
 
  build_visualization_test:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main') && 
+      !contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Visualization Test
     runs-on: ubuntu-latest
     env:
@@ -93,9 +93,9 @@ jobs:
 
  build_visualization_e2e:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main') && 
+      !contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -132,9 +132,9 @@ jobs:
 
  publish_sonar_analysis:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main') && 
+      !contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -169,9 +169,9 @@ jobs:
 
  publish_sonar_visualization:
     if: |
-     "!contains(github.event.head_commit.message, 'Deploying to main') && 
+      !contains(github.event.head_commit.message, 'Deploying to main') && 
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') 
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))"
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
     needs: [build_visualization_test, build_visualization_e2e]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Dependabot cant read secrets following last update

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1966

## Description

- According to this discussion:  https://github.com/dependabot/dependabot-core/issues/3253 and this migration guide: https://hugo.alliau.me/2021/05/04/migration-to-github-native-dependabot-solutions-for-auto-merge-and-action-secrets/#share-your-secrets-with-dependabot the following PR will allow dependabot to read secrets again 

- However: This represents a workaround: This proposal uses on.pull_request_target for dependabot PRs which is less secure (we can read all secrets like this). When github-actions eventually implemenents a working solution we will have to change that again if the PR is accepted. 
- Concerning dependabot secrets (new option in Settings -> Secrets): I tried it, as did people in the linked discussion and it is not working properly as of today.

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Screenshots or gifs
