### PR TITLE
Split Sonar Analysis to own workflow

### DIFF
--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -6,7 +6,9 @@ on:
     types:
       - completed
 jobs:
-  if: github.actor != 'dependabot[bot]' || github.actor != 'dependabot-preview[bot]'
+  if: |
+    github.actor != 'dependabot[bot]'
+    && github.actor != 'dependabot-preview[bot]'
 
   publish_sonar_analysis:
     if: "!contains(github.event.head_commit.message, 'Deploying to main')"
@@ -44,7 +46,6 @@ jobs:
 
   publish_sonar_visualization:
     if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    needs: [ build_visualization_test, build_visualization_e2e ]
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -1,0 +1,72 @@
+name: SonarAnalysis
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+jobs:
+  if: github.actor != 'dependabot[bot]' || github.actor != 'dependabot-preview[bot]'
+
+  publish_sonar_analysis:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    name: "Build and Publish Analysis Sonar Results"
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./analysis
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: '11'
+
+      - name: Build
+        run: chmod +x ./gradlew
+        working-directory: ${{env.working-directory}}
+
+      - name: Test Analysis
+        run: |
+          ./gradlew build integrationTest
+          ./gradlew jacocoTestReport
+        working-directory: ${{env.working-directory}}
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v1.5
+        with:
+          projectBaseDir: ./analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          JAVA_HOME: ''
+
+  publish_sonar_visualization:
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    needs: [ build_visualization_test, build_visualization_e2e ]
+    name: "Build and Publish Visualization Sonar Results"
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./visualization
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: test.yml
+          workflow_conclusion: success
+          commit: ${{github.event.pull_request.head.sha}}
+          name: coverage
+          path: ./visualization/dist/
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v1.5
+        with:
+          projectBaseDir: ./visualization
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -40,10 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           JAVA_HOME: ''
-          
-      - name: Dependabot_Success_Analysis
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
-        run: echo "Success"
 
   publish_sonar_visualization:
     name: "Build and Publish Visualization Sonar Results"
@@ -74,7 +70,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         
-      - name: Dependabot_Success_Visualization
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
-        run: echo "Success"
         

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -40,9 +40,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           JAVA_HOME: ''
+          
+      - name: Dependabot_Success_Analysis
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        run: echo "Success"
 
   publish_sonar_visualization:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -52,6 +55,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download artifact
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
@@ -62,9 +66,15 @@ jobs:
           path: ./visualization/dist/
 
       - name: SonarCloud Scan
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         uses: SonarSource/sonarcloud-github-action@v1.5
         with:
           projectBaseDir: ./visualization
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        
+      - name: Dependabot_Success_Visualization
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        run: echo "Success"
+        

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -6,12 +6,9 @@ on:
     types:
       - completed
 jobs:
-  if: |
-    github.actor != 'dependabot[bot]'
-    && github.actor != 'dependabot-preview[bot]'
 
   publish_sonar_analysis:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: "Build and Publish Analysis Sonar Results"
     runs-on: ubuntu-latest
     env:
@@ -45,7 +42,7 @@ jobs:
           JAVA_HOME: ''
 
   publish_sonar_visualization:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: "Build and Publish Visualization Sonar Results"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           path: ./visualization/dist/
 
  build_visualization_e2e:
-     if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           path: ./visualization/dist/
 
  build_visualization_e2e:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
+     if: "!contains(github.event.head_commit.message, 'Deploying to main')"
     name: Visualization E2E
     runs-on: ubuntu-latest
     env:
@@ -121,60 +121,3 @@ jobs:
         npm run e2e:ci
       working-directory: ${{env.working-directory}}
 
- publish_sonar_analysis:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    name: "Build and Publish Analysis Sonar Results"
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./analysis
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: '11'
-
-      - name: Build
-        run: chmod +x ./gradlew
-        working-directory: ${{env.working-directory}}
-
-      - name: Test Analysis
-        run: |
-          ./gradlew build integrationTest
-          ./gradlew jacocoTestReport
-        working-directory: ${{env.working-directory}}
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.5
-        with:
-          projectBaseDir: ./analysis
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          JAVA_HOME: ''
-
- publish_sonar_visualization:
-    if: "!contains(github.event.head_commit.message, 'Deploying to main')"
-    needs: [build_visualization_test, build_visualization_e2e]
-    name: "Build and Publish Visualization Sonar Results"
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./visualization
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@v2
-        with:
-          name: coverage
-          path: ./visualization/dist/
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.5
-        with:
-          projectBaseDir: ./visualization
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
# Split Test and Sonar Analysis workflow, onyl run analysis on non dependabot PRs

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes : #1966 

## Description

- only run sonar cloud for PRs not triggered by dependabot
- after merge we need to remove branch protection requriement to include sonar due to it not being present for dependabot
- artifact sharing not fully tested due to requring default branch priviledges for workflow_run:

## Screenshots or gifs
