### PR TITLE
fix: wsl pre-hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-sh ./script/pre-push.sh
+./script/pre-push.sh


### PR DESCRIPTION
otherwise sh is used despite "#!/usr/bin/env bash" which has no fancy if "[["

