### PR TITLE
refactor: separate redux store from storeService

### DIFF
--- a/visualization/app/codeCharta/state/store.service.spec.ts
+++ b/visualization/app/codeCharta/state/store.service.spec.ts
@@ -18,7 +18,6 @@ describe("StoreService", () => {
 
 	beforeEach(() => {
 		restartSystem()
-		rebuildService()
 		withMockedEventMethods($rootScope)
 	})
 
@@ -26,16 +25,11 @@ describe("StoreService", () => {
 		instantiateModule("app.codeCharta.state")
 
 		$rootScope = getService<IRootScopeService>("$rootScope")
-	}
-
-	function rebuildService() {
-		storeService = new StoreService($rootScope)
+		storeService = getService<StoreService>("storeService")
 	}
 
 	describe("constructor", () => {
 		it("should initialize the store", () => {
-			rebuildService()
-
 			expect(storeService["store"]).not.toBeNull()
 		})
 	})

--- a/visualization/app/codeCharta/state/store.service.ts
+++ b/visualization/app/codeCharta/state/store.service.ts
@@ -1,5 +1,3 @@
-import { createStore, Store } from "redux"
-import rootReducer from "./store/state.reducer"
 import { IRootScopeService } from "angular"
 import { splitStateActions } from "./store/state.splitter"
 import { IsLoadingMapActions, setIsLoadingMap } from "./store/appSettings/isLoadingMap/isLoadingMap.actions"
@@ -13,6 +11,7 @@ import { IsAttributeSideBarVisibleActions } from "./store/appSettings/isAttribut
 import { PanelSelectionActions } from "./store/appSettings/panelSelection/panelSelection.actions"
 import { PresentationModeActions } from "./store/appSettings/isPresentationMode/isPresentationMode.actions"
 import { ExperimentalFeaturesEnabledActions } from "./store/appSettings/enableExperimentalFeatures/experimentalFeaturesEnabled.actions"
+import { Store } from "./store/store"
 
 export interface StoreSubscriber {
 	onStoreChanged(actionType: string)
@@ -29,11 +28,10 @@ export interface DispatchOptions {
 export class StoreService {
 	private static STORE_CHANGED_EVENT = "store-changed"
 	private static STORE_CHANGED_EXTENDED_EVENT = "store-changed-extended"
-	private store: Store
+	private store = Store.store
 
 	constructor(private $rootScope: IRootScopeService) {
 		"ngInject"
-		this.store = createStore(rootReducer)
 	}
 
 	dispatch(action: CCAction, options: DispatchOptions = { silent: false }) {

--- a/visualization/app/codeCharta/state/store/store.ts
+++ b/visualization/app/codeCharta/state/store/store.ts
@@ -1,0 +1,23 @@
+import { createStore } from "redux"
+
+import rootReducer from "./state.reducer"
+
+type CcStore = ReturnType<typeof Store["createStore"]>
+export type CcState = ReturnType<CcStore["getState"]>
+
+export class Store {
+	private static _store: CcStore
+
+	private static createStore() {
+		return createStore(rootReducer)
+	}
+
+	private static initialize() {
+		Store._store = Store.createStore()
+	}
+
+	static get store() {
+		if (!Store._store) Store.initialize()
+		return Store._store
+	}
+}

--- a/visualization/mocks/ng.mockhelper.ts
+++ b/visualization/mocks/ng.mockhelper.ts
@@ -1,5 +1,6 @@
 import angular, { IAngularStatic } from "angular"
 import "angular-mocks"
+import { Store } from "../app/codeCharta/state/store/store"
 
 export const NGMock: IAngularStatic = angular
 export const NG = angular
@@ -12,5 +13,6 @@ export function getService<T>(id: string): T {
 	// eslint-disable-next-line prefer-const
 	let service: T = null
 	eval(`NGMock.mock.inject(function(_${id}_) { service = _${id}_; });`)
+	if (id === "storeService") Store["initialize"]() // reset shared store
 	return service
 }


### PR DESCRIPTION
So that it is possible to directly connect new (Angular) components to it.

[Here](https://github.com/MaibornWolff/codecharta/commit/c1be15dc20f533c053b6cac79ad74a9ebc9a8f19#diff-e97d8e55741c147a9bf64cb21942a2f827bb4eda8ec4353fd3d8bb7bc8a2de6b) is a PoC how this might look.

closes #2068

