### PR TITLE
Fix/1312/calculate metrics only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
--   Custom metric scenarios which include the 'Color-Metric' (rloc) will now also save any changes made to the color scheme.
+-   Custom metric scenarios which include the 'Color-Metric' (rloc) will now also save any changes made to the color scheme. ([#1557](https://github.com/maibornwolff/codecharta/issues/1557))
+
+### Fixed 🐞
+
+-   Performance improvements when loading new files. ([#1312](https://github.com/maibornwolff/codecharta/issues/1312))
 
 ## [1.75.0] - 2021-07-05
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.spec.ts
@@ -206,26 +206,35 @@ describe("codeMapPreRenderService", () => {
 	})
 
 	describe("onMetricDataChanged", () => {
-		it("should decorate and set a new render map", () => {
+		it("should decorate and set a new render map", done => {
 			codeMapPreRenderService.onMetricDataChanged()
 
-			expect(codeMapPreRenderService.getRenderMap()).toMatchSnapshot()
+			setTimeout(() => {
+				expect(codeMapPreRenderService.getRenderMap()).toMatchSnapshot()
+				done()
+			}, CodeMapPreRenderService["DEBOUNCE_TIME"])
 		})
 
-		it("should update the isBlacklisted attribute on each node", () => {
+		it("should update the isBlacklisted attribute on each node", done => {
 			storeService.dispatch(addBlacklistItem({ path: map.path, type: BlacklistType.exclude }))
 
 			codeMapPreRenderService.onMetricDataChanged()
 
-			expect(allNodesToBeExcluded()).toBeTruthy()
+			setTimeout(() => {
+				expect(allNodesToBeExcluded()).toBeTruthy()
+				done()
+			}, CodeMapPreRenderService["DEBOUNCE_TIME"])
 		})
 
-		it("should change map to multiple mode and check that no id exists twice", () => {
+		it("should change map to multiple mode and check that no id exists twice", done => {
 			storeService.dispatch(setMultiple(getCCFiles(storeService.getState().files)))
 
 			codeMapPreRenderService.onMetricDataChanged()
 
-			expect(isIdUnique()).toBeTruthy()
+			setTimeout(() => {
+				expect(isIdUnique()).toBeTruthy()
+				done()
+			}, CodeMapPreRenderService["DEBOUNCE_TIME"])
 		})
 
 		it("should call DeltaGenerator with the right parameters", () => {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
@@ -50,6 +50,7 @@ export class CodeMapPreRenderService
 	private unifiedFileMeta: FileMeta
 
 	private readonly debounceRendering: () => void
+	private readonly debounceDecorate: () => void
 	private readonly debounceTracking: (actionType: string, payload?: unknown) => void
 	private DEBOUNCE_TIME = 0
 
@@ -69,6 +70,13 @@ export class CodeMapPreRenderService
 
 		this.debounceRendering = debounce(() => {
 			this.renderAndNotify()
+		}, this.DEBOUNCE_TIME)
+
+		this.debounceDecorate = debounce(() => {
+			this.decorateIfPossible()
+			if (this.allNecessaryRenderDataAvailable()) {
+				this.renderAndNotify()
+			}
 		}, this.DEBOUNCE_TIME)
 
 		this.debounceTracking = debounce(() => {
@@ -133,10 +141,7 @@ export class CodeMapPreRenderService
 	onMetricDataChanged() {
 		if (fileStatesAvailable(this.storeService.getState().files)) {
 			this.updateRenderMapAndFileMeta()
-			this.decorateIfPossible()
-			if (this.allNecessaryRenderDataAvailable()) {
-				this.debounceRendering()
-			}
+			this.debounceDecorate()
 		}
 	}
 


### PR DESCRIPTION
# Calculate metrics only once

Closes #1312 

## Description
 
- The metrics are currently calculated six times during loading and this is one of the main performance issues as noted in #1312.
- With debounce the metrics are only calculated once which reduces the time of `loadFiles` with a big map like [Apache OpenOffice](https://maibornwolff.github.io/codecharta/showcase/aoo/) from 4.5 seconds to 2.6 consistently during my tests.
- This seems like an easy fix. If anyone sees any possible problems that could occur by introducing this change please let me know.


## Screenshots or gifs
![image](https://user-images.githubusercontent.com/50167165/124921247-7acbeb80-dff8-11eb-97b3-e1c8e1f4866e.png)
![image](https://user-images.githubusercontent.com/50167165/124921259-7f909f80-dff8-11eb-916e-5922d59dc20c.png)

Sorry for the screenshot quality.