### PR TITLE
Show the numbers always on the distribution bar #1540

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
     -   Already loaded files can be individually removed.
     -   The 'Multiple' view will select the latest files.
 
+### Changed
+
+-   Numbers/Percentages are always shown on distribution bar.
+-   Toggle between percentage and absolute numbers by clicking anywhere on the (expanded) distribution bar.
+-   The old expanded distribution bar is
+    now accessible through a button.
+
 ### Fixed 🐞
 
 -   It is now possible to rotate the map by rotating the view cube ([#353](https://github.com/MaibornWolff/codecharta/issues/353))

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.html
@@ -3,10 +3,13 @@
 		<distribution-metric-chooser-component></distribution-metric-chooser-component>
 	</div>
 
+	<md-button class="expand-button" ng-click="$ctrl.toggleExtensiveMode()">
+		<i class="fa {{ $ctrl._viewModel.isExtensiveMode ? 'fa-caret-up' : 'fa-caret-down' }}" aria-hidden="true"></i>
+	</md-button>
 	<div class="bar">
 		<div
 			class="bar-section"
-			ng-click="$ctrl.toggleExtensiveMode()"
+			ng-click="$ctrl.togglePercentageAbsoluteValues()"
 			ng-repeat="item in $ctrl._viewModel.distribution track by $index"
 			ng-style="{ width: item.relativeMetricValue + '%', background: item.color }"
 		>
@@ -14,14 +17,27 @@
 				class="bar-section-text"
 				ng-mouseover="$ctrl.onHoverFileExtensionBar(item.fileExtension)"
 				ng-mouseleave="$ctrl.onUnhoverFileExtensionBar()"
-				title="{{ item.relativeMetricValue.toFixed(2) }}%"
+				title="{{
+					item.fileExtension.toString() +
+						' ' +
+						($ctrl._viewModel.isAbsoluteValueVisible
+							? item.absoluteMetricValue.toFixed(0)
+							: item.relativeMetricValue.toFixed(2) + '%')
+				}}"
 			>
 				<span ng-if="item.relativeMetricValue >= item.fileExtension.length / 2 + 1">
 					{{ item.fileExtension }}
 				</span>
+				<span class="metric-value" ng-class="{ hidden: $ctrl._viewModel.isAbsoluteValueVisible }"
+					>{{ item.relativeMetricValue.toFixed(2) }}%</span
+				>
+				<span class="metric-value" ng-class="{ hidden: !$ctrl._viewModel.isAbsoluteValueVisible }">{{
+					item.absoluteMetricValue.toFixed(0) | number
+				}}</span>
 			</p>
 		</div>
 	</div>
+
 	<div class="bar-details" ng-class="{ expanded: $ctrl._viewModel.isExtensiveMode }" ng-click="$ctrl.togglePercentageAbsoluteValues()">
 		<div class="bar-details-section" ng-repeat="item in $ctrl._viewModel.distribution track by $index">
 			<p class="bar-details-text">

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.scss
@@ -5,6 +5,16 @@ file-extension-bar-component {
 		float: left;
 	}
 
+	.expand-button {
+		float: right;
+		height: 17px;
+		min-height: 0;
+		line-height: 10px;
+		min-width: 45px;
+		margin: 0;
+		padding: 0;
+		background-color: rgba(230, 230, 230, 0.96);
+	}
 	.bar {
 		overflow: hidden;
 
@@ -16,14 +26,22 @@ file-extension-bar-component {
 			text-align: center;
 			cursor: pointer;
 			outline: none;
-
 			&:not(:last-child) {
 				border-right: 1px solid white;
 			}
 
 			.bar-section-text {
 				font-size: 10px;
-				margin-top: 2px;
+				margin: 2px 0px 2px 0px;
+				overflow: hidden;
+				white-space: nowrap;
+				padding: 0px 10px 0px 10px;
+				text-overflow: "";
+			}
+			.metric-value {
+				&.hidden {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Show the numbers always on the distribution bar 

Closes: #1540

## Description

- Always show number on distribution bar
- Toggle between percentage and absolute numbers by clicking anywhere
- The old expanded distribution bar, now accessible through a button
- Hover over any file extension to see a tooltip with the name and number

## Screenshots or gifs

![1540 2](https://user-images.githubusercontent.com/48621967/125120370-a7fcc480-e0f2-11eb-8e33-b0b9e30fa1c9.png)

![1540 1](https://user-images.githubusercontent.com/48621967/125120366-a7642e00-e0f2-11eb-9b63-5e439371ab5c.png)
