### PR TITLE
Fix/901/same size after reincluding buildings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Performance improvements when loading new files. ([#1312](https://github.com/maibornwolff/codecharta/issues/1312))
+-   It is no longer possible to exclude all files on the map ([#901](https://github.com/MaibornWolff/codecharta/issues/901))
 
 ## [1.75.0] - 2021-07-05
 

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.spec.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.spec.ts
@@ -2,11 +2,12 @@ import "../../../state.module"
 import { IRootScopeService } from "angular"
 import { StoreService } from "../../../store.service"
 import { getService, instantiateModule } from "../../../../../../mocks/ng.mockhelper"
+import * as FilesHelper from "../../../../model/files/files.helper"
 import { BlacklistService } from "./blacklist.service"
 import { BlacklistAction, BlacklistActions } from "./blacklist.actions"
 import { BlacklistItem, BlacklistType } from "../../../../codeCharta.model"
 import { PresentationModeActions } from "../../appSettings/isPresentationMode/isPresentationMode.actions"
-import { withMockedEventMethods } from "../../../../util/dataMocks"
+import { FILE_STATES, withMockedEventMethods } from "../../../../util/dataMocks"
 import { FilesService } from "../../files/files.service"
 
 describe("BlacklistService", () => {
@@ -64,6 +65,23 @@ describe("BlacklistService", () => {
 			blacklistService.onStoreChanged(PresentationModeActions.SET_PRESENTATION_MODE)
 
 			expect($rootScope.$broadcast).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("resultsInEmptyMap", () => {
+		it("should return true when all files are empty", () => {
+			jest.spyOn(FilesHelper, "getVisibleFileStates").mockReturnValue(FILE_STATES)
+			const blacklistItem: BlacklistItem[] = [{ path: "/root", type: BlacklistType.exclude }]
+
+			expect(blacklistService.resultsInEmptyMap(blacklistItem)).toBe(true)
+		})
+
+		it("should return false when files are left", () => {
+			blacklistService.isIncludedNode = jest.fn(() => true)
+			jest.spyOn(FilesHelper, "getVisibleFileStates").mockReturnValue(FILE_STATES)
+			const blacklistItem: BlacklistItem[] = [{ path: "/root/Parent Leaf", type: BlacklistType.exclude }]
+
+			expect(blacklistService.resultsInEmptyMap(blacklistItem)).toBe(false)
 		})
 	})
 })

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.ts
@@ -43,6 +43,10 @@ export class BlacklistService implements StoreSubscriber, FilesSelectionSubscrib
 		return true
 	}
 
+	isIncludedNode(node, blacklist: Array<BlacklistItem>) {
+		return isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, BlacklistType.exclude)
+	}
+
 	private isEmptyFile(file, blacklistItems: BlacklistItem[]) {
 		const blacklist = [...this.storeService.getState().fileSettings.blacklist]
 		for (const blacklistItem of blacklistItems) {
@@ -55,10 +59,6 @@ export class BlacklistService implements StoreSubscriber, FilesSelectionSubscrib
 			}
 		}
 		return true
-	}
-
-	private isIncludedNode(node, blacklist: Array<BlacklistItem>) {
-		return isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, BlacklistType.exclude)
 	}
 
 	private merge(files: FileState[]) {

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.service.ts
@@ -33,26 +33,25 @@ export class BlacklistService implements StoreSubscriber, FilesSelectionSubscrib
 		this.merge(files)
 	}
 
-	isEmptyMap() {
+	resultsInEmptyMap(blacklistItems: BlacklistItem[]) {
 		const fileStates = getVisibleFileStates(this.storeService.getState().files)
 		for (const { file } of fileStates) {
-			if (!this.isEmpty(file)) {
+			if (!this.isEmptyFile(file, blacklistItems)) {
 				return false
 			}
 		}
 		return true
 	}
 
-	private isEmpty(file) {
-		const blacklist = this.storeService.getState().fileSettings.blacklist
+	private isEmptyFile(file, blacklistItems: BlacklistItem[]) {
+		const blacklist = [...this.storeService.getState().fileSettings.blacklist]
+		for (const blacklistItem of blacklistItems) {
+			blacklist.push(blacklistItem)
+		}
 
-		let nodes = 0
 		for (const node of hierarchy(file.map)) {
 			if (this.isIncludedNode(node, blacklist)) {
-				nodes = nodes + 1
-				if (nodes > 1) {
-					return false
-				}
+				return false
 			}
 		}
 		return true

--- a/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.ts
+++ b/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.ts
@@ -8,16 +8,11 @@ import { NodeMetricDataService } from "./nodeMetricData.service"
 import { sortByMetricName } from "../metricData.reducer"
 
 export function nodeMetricData(state = setNodeMetricData().payload, action: NodeMetricDataAction) {
-	let newMetricData
 	switch (action.type) {
 		case NodeMetricDataActions.SET_NODE_METRIC_DATA:
 			return action.payload
 		case NodeMetricDataActions.CALCULATE_NEW_NODE_METRIC_DATA:
-			newMetricData = setNewMetricData(action.payload.fileStates, action.payload.blacklist)
-			if (newMetricData.length !== 1) {
-				return newMetricData
-			}
-			return state
+			return setNewMetricData(action.payload.fileStates, action.payload.blacklist)
 		default:
 			return state
 	}

--- a/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.ts
+++ b/visualization/app/codeCharta/state/store/metricData/nodeMetricData/nodeMetricData.reducer.ts
@@ -8,11 +8,16 @@ import { NodeMetricDataService } from "./nodeMetricData.service"
 import { sortByMetricName } from "../metricData.reducer"
 
 export function nodeMetricData(state = setNodeMetricData().payload, action: NodeMetricDataAction) {
+	let newMetricData
 	switch (action.type) {
 		case NodeMetricDataActions.SET_NODE_METRIC_DATA:
 			return action.payload
 		case NodeMetricDataActions.CALCULATE_NEW_NODE_METRIC_DATA:
-			return setNewMetricData(action.payload.fileStates, action.payload.blacklist)
+			newMetricData = setNewMetricData(action.payload.fileStates, action.payload.blacklist)
+			if (newMetricData.length !== 1) {
+				return newMetricData
+			}
+			return state
 		default:
 			return state
 	}

--- a/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.e2e.ts
+++ b/visualization/app/codeCharta/ui/blacklistPanel/blacklistPanel.e2e.ts
@@ -2,17 +2,27 @@ import { goto } from "../../../puppeteer.helper"
 import { BlacklistPanelPageObject } from "../blacklistPanel/blacklistPanel.po"
 import { SearchBarPageObject } from "../searchBar/searchBar.po"
 import { SearchPanelModeSelectorPageObject } from "../searchPanelModeSelector/searchPanelModeSelector.po"
+import { ERROR_MESSAGES } from "../../util/fileValidator"
+import { DialogErrorPageObject } from "../dialog/dialog.error.po"
 
 describe("Blacklist(TrackByEvaluation)", () => {
 	let searchBar: SearchBarPageObject
 	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
 	let blacklistPanelPageObject: BlacklistPanelPageObject
+	let dialogError: DialogErrorPageObject
 
 	beforeEach(async () => {
 		searchBar = new SearchBarPageObject()
 		searchPanelModeSelector = new SearchPanelModeSelectorPageObject()
 		blacklistPanelPageObject = new BlacklistPanelPageObject()
+		dialogError = new DialogErrorPageObject()
 		await goto()
+	})
+
+	it("should display error when all files are excluded", async () => {
+		await searchBar.enterAndExcludeSearchPattern("*")
+
+		expect(await dialogError.getMessage()).toEqual(ERROR_MESSAGES.blacklistError)
 	})
 
 	it("should have correct list entries in case of track by", async () => {

--- a/visualization/app/codeCharta/ui/customColorPicker/nodeContextMenuColorPicker/nodeContextMenuColorPicker.component.ts
+++ b/visualization/app/codeCharta/ui/customColorPicker/nodeContextMenuColorPicker/nodeContextMenuColorPicker.component.ts
@@ -5,7 +5,9 @@ import { hasValidHexLength } from "../colorHelper"
 export class NodeContextMenuColorPickerController {
 	private markFolder: ({ color: string }) => void
 
-	constructor(private $scope) {}
+	constructor(private $scope) {
+		"ngInject"
+	}
 
 	$onInit() {
 		this.$scope.color = "#FF0000" // without initial value the color-picker's popup would show a 100% transparent color initially

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
@@ -409,6 +409,15 @@ describe("nodeContextMenuController", () => {
 
 			expect(storeService.getState().fileSettings.blacklist).toContainEqual(expected)
 		})
+
+		it("should display error dialog when no files are left", () => {
+			blacklistService.resultsInEmptyMap = jest.fn(() => true)
+			dialogService.showErrorDialog = jest.fn()
+
+			nodeContextMenuController.excludeNode()
+
+			expect(dialogService.showErrorDialog).toBeCalled()
+		})
 	})
 
 	describe("nodeIsFolder", () => {

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.spec.ts
@@ -24,6 +24,8 @@ import { CodeMapMouseEventService } from "../codeMap/codeMap.mouseEvent.service"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { CodeMapBuilding } from "../codeMap/rendering/codeMapBuilding"
 import { setIdToBuilding } from "../../state/store/lookUp/idToBuilding/idToBuilding.actions"
+import { DialogService } from "../dialog/dialog.service"
+import { BlacklistService } from "../../state/store/fileSettings/blacklist/blacklist.service"
 
 describe("nodeContextMenuController", () => {
 	let element: Element
@@ -35,6 +37,8 @@ describe("nodeContextMenuController", () => {
 	let codeMapActionsService: CodeMapActionsService
 	let codeMapPreRenderService: CodeMapPreRenderService
 	let threeSceneService: ThreeSceneService
+	let dialogService: DialogService
+	let blacklistService: BlacklistService
 
 	beforeEach(() => {
 		restartSystem()
@@ -59,6 +63,8 @@ describe("nodeContextMenuController", () => {
 		codeMapActionsService = getService<CodeMapActionsService>("codeMapActionsService")
 		codeMapPreRenderService = getService<CodeMapPreRenderService>("codeMapPreRenderService")
 		threeSceneService = getService<ThreeSceneService>("threeSceneService")
+		dialogService = getService<DialogService>("dialogService")
+		blacklistService = getService<BlacklistService>("blacklistService")
 	}
 
 	function mockElement() {
@@ -79,7 +85,9 @@ describe("nodeContextMenuController", () => {
 			storeService,
 			codeMapActionsService,
 			codeMapPreRenderService,
-			threeSceneService
+			threeSceneService,
+			dialogService,
+			blacklistService
 		)
 	}
 
@@ -394,6 +402,7 @@ describe("nodeContextMenuController", () => {
 		})
 
 		it("should add exclude blacklistItem", () => {
+			blacklistService.resultsInEmptyMap = jest.fn(() => false)
 			const expected = { attributes: {}, nodeType: "Folder", path: "/root/Parent Leaf", type: BlacklistType.exclude }
 
 			nodeContextMenuController.excludeNode()

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -161,18 +161,18 @@ export class NodeContextMenuController
 	}
 
 	excludeNode() {
-		if (this.blacklistService.isEmptyMap()) {
+		const codeMapNode = this._viewModel.codeMapNode
+		const blacklistItem: BlacklistItem = {
+			path: codeMapNode.path,
+			type: BlacklistType.exclude,
+			nodeType: codeMapNode.type,
+			attributes: codeMapNode.attributes
+		}
+
+		if (this.blacklistService.resultsInEmptyMap([blacklistItem])) {
 			this.dialogService.showErrorDialog("Excluding all buildings is not possible.", "Blacklist Error")
 		} else {
-			const codeMapNode = this._viewModel.codeMapNode
-			this.storeService.dispatch(
-				addBlacklistItem({
-					path: codeMapNode.path,
-					type: BlacklistType.exclude,
-					nodeType: codeMapNode.type,
-					attributes: codeMapNode.attributes
-				})
-			)
+			this.storeService.dispatch(addBlacklistItem(blacklistItem))
 		}
 	}
 

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -13,6 +13,7 @@ import { getCodeMapNodeFromPath } from "../../util/codeMapHelper"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { DialogService } from "../dialog/dialog.service"
 import { BlacklistService } from "../../state/store/fileSettings/blacklist/blacklist.service"
+import { ERROR_MESSAGES } from "../../util/fileValidator"
 
 export enum ClickType {
 	RightClick = 2
@@ -170,7 +171,7 @@ export class NodeContextMenuController
 		}
 
 		if (this.blacklistService.resultsInEmptyMap([blacklistItem])) {
-			this.dialogService.showErrorDialog("Excluding all buildings is not possible.", "Blacklist Error")
+			this.dialogService.showErrorDialog(ERROR_MESSAGES.blacklistError, "Blacklist Error")
 		} else {
 			this.storeService.dispatch(addBlacklistItem(blacklistItem))
 		}

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.component.ts
@@ -11,6 +11,8 @@ import { BuildingRightClickedEventSubscriber, CodeMapMouseEventService } from ".
 import { MapColorsService, MapColorsSubscriber } from "../../state/store/appSettings/mapColors/mapColors.service"
 import { getCodeMapNodeFromPath } from "../../util/codeMapHelper"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
+import { DialogService } from "../dialog/dialog.service"
+import { BlacklistService } from "../../state/store/fileSettings/blacklist/blacklist.service"
 
 export enum ClickType {
 	RightClick = 2
@@ -52,7 +54,9 @@ export class NodeContextMenuController
 		private storeService: StoreService,
 		private codeMapActionsService: CodeMapActionsService,
 		private codeMapPreRenderService: CodeMapPreRenderService,
-		private threeSceneService: ThreeSceneService
+		private threeSceneService: ThreeSceneService,
+		private dialogService: DialogService,
+		private blacklistService: BlacklistService
 	) {
 		"ngInject"
 		MapColorsService.subscribe(this.$rootScope, this)
@@ -157,15 +161,19 @@ export class NodeContextMenuController
 	}
 
 	excludeNode() {
-		const codeMapNode = this._viewModel.codeMapNode
-		this.storeService.dispatch(
-			addBlacklistItem({
-				path: codeMapNode.path,
-				type: BlacklistType.exclude,
-				nodeType: codeMapNode.type,
-				attributes: codeMapNode.attributes
-			})
-		)
+		if (this.blacklistService.isEmptyMap()) {
+			this.dialogService.showErrorDialog("Excluding all buildings is not possible.", "Blacklist Error")
+		} else {
+			const codeMapNode = this._viewModel.codeMapNode
+			this.storeService.dispatch(
+				addBlacklistItem({
+					path: codeMapNode.path,
+					type: BlacklistType.exclude,
+					nodeType: codeMapNode.type,
+					attributes: codeMapNode.attributes
+				})
+			)
+		}
 	}
 
 	addNodeToConstantHighlight() {

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.e2e.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.e2e.ts
@@ -3,20 +3,32 @@ import { NodeContextMenuPageObject } from "./nodeContextMenu.po"
 import { SearchPanelModeSelectorPageObject } from "../searchPanelModeSelector/searchPanelModeSelector.po"
 import { MapTreeViewLevelPageObject } from "../mapTreeView/mapTreeView.level.po"
 import { CodeMapPageObject } from "../codeMap/codeMap.po"
+import { ERROR_MESSAGES } from "../../util/fileValidator"
+import { DialogErrorPageObject } from "../dialog/dialog.error.po"
 
 describe("NodeContextMenu", () => {
 	let contextMenu: NodeContextMenuPageObject
 	let searchPanelModeSelector: SearchPanelModeSelectorPageObject
 	let mapTreeViewLevel: MapTreeViewLevelPageObject
 	let codeMap: CodeMapPageObject
+	let dialogError: DialogErrorPageObject
 
 	beforeEach(async () => {
 		contextMenu = new NodeContextMenuPageObject()
 		searchPanelModeSelector = new SearchPanelModeSelectorPageObject()
 		mapTreeViewLevel = new MapTreeViewLevelPageObject()
 		codeMap = new CodeMapPageObject()
+		dialogError = new DialogErrorPageObject()
 
 		await goto()
+	})
+
+	it("should show error message when user excludes all files", async () => {
+		await searchPanelModeSelector.toggleTreeView()
+		await mapTreeViewLevel.openContextMenu("/root")
+		await contextMenu.clickOnExclude()
+
+		expect(await dialogError.getMessage()).toEqual(`${ERROR_MESSAGES.blacklistError}`)
 	})
 
 	it("right clicking a folder should open a context menu with color options", async () => {

--- a/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.po.ts
+++ b/visualization/app/codeCharta/ui/nodeContextMenu/nodeContextMenu.po.ts
@@ -19,4 +19,8 @@ export class NodeContextMenuPageObject {
 	async isClosed() {
 		await page.waitForSelector("#codemap-context-menu", { hidden: true })
 	}
+
+	async clickOnExclude() {
+		await clickButtonOnPageElement(`[id='exclude-button']`, { button: "left" })
+	}
 }

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.spec.ts
@@ -96,12 +96,10 @@ describe("SearchBarController", () => {
 			expect(storeService.getState().dynamicSettings.searchPattern).toBe("")
 		})
 
-		it("should display error message when all nodes would be excluded", () => {
+		it("should display error message when no files are left", () => {
 			blacklistService.resultsInEmptyMap = jest.fn(() => true)
 			dialogService.showErrorDialog = jest.fn()
-			const blacklistItem = { path: "/root/node/path", type: BlacklistType.exclude }
-			searchBarController["_viewModel"].searchPattern = blacklistItem.path
-			storeService.dispatch(setSearchPattern(blacklistItem.path))
+			const blacklistItem = { path: "/root", type: BlacklistType.exclude }
 
 			searchBarController.onClickBlacklistPattern(blacklistItem.type)
 

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -1,12 +1,13 @@
 import "./searchBar.component.scss"
-import { BlacklistType, BlacklistItem } from "../../codeCharta.model"
+import { BlacklistItem, BlacklistType } from "../../codeCharta.model"
 import { IRootScopeService } from "angular"
 import { StoreService } from "../../state/store.service"
 import { setSearchPattern } from "../../state/store/dynamicSettings/searchPattern/searchPattern.actions"
 import debounce from "lodash.debounce"
 import { BlacklistService, BlacklistSubscriber } from "../../state/store/fileSettings/blacklist/blacklist.service"
-import { addBlacklistItem } from "../../state/store/fileSettings/blacklist/blacklist.actions"
 import { SearchPatternService, SearchPatternSubscriber } from "../../state/store/dynamicSettings/searchPattern/searchPattern.service"
+import { DialogService } from "../dialog/dialog.service"
+import { addBlacklistItem } from "../../state/store/fileSettings/blacklist/blacklist.actions"
 
 export class SearchBarController implements BlacklistSubscriber, SearchPatternSubscriber {
 	private static DEBOUNCE_TIME = 400
@@ -21,7 +22,12 @@ export class SearchBarController implements BlacklistSubscriber, SearchPatternSu
 		isPatternExcluded: true
 	}
 
-	constructor(private $rootScope: IRootScopeService, private storeService: StoreService) {
+	constructor(
+		private $rootScope: IRootScopeService,
+		private storeService: StoreService,
+		private blacklistService: BlacklistService,
+		private dialogService: DialogService
+	) {
 		"ngInject"
 		BlacklistService.subscribe(this.$rootScope, this)
 		SearchPatternService.subscribe(this.$rootScope, this)
@@ -44,12 +50,26 @@ export class SearchBarController implements BlacklistSubscriber, SearchPatternSu
 	}
 
 	onClickBlacklistPattern(blacklistType: BlacklistType) {
+		const blacklistItems: BlacklistItem[] = this.parseValidBlacklistItems(blacklistType)
+
+		if (blacklistType === BlacklistType.exclude && this.blacklistService.resultsInEmptyMap(blacklistItems)) {
+			this.dialogService.showErrorDialog("Excluding all buildings is not possible.", "Blacklist Error")
+		} else {
+			for (const blackItem of blacklistItems) {
+				this.storeService.dispatch(addBlacklistItem(blackItem))
+				this.resetSearchPattern()
+			}
+		}
+	}
+
+	private parseValidBlacklistItems(blacklistType: BlacklistType) {
+		const blacklistItems: BlacklistItem[] = []
 		const paths: string[] = this._viewModel.searchPattern.split(",")
 		if (paths[0].startsWith("!")) {
 			paths[0] = paths[0].slice(1)
 			for (const path of paths) {
 				if (path.length > 0) {
-					this.storeService.dispatch(addBlacklistItem({ path: `!${this.unifyWildCard(path)}`, type: blacklistType }))
+					blacklistItems.push({ path: `!${this.unifyWildCard(path)}`, type: blacklistType })
 				}
 			}
 		} else {
@@ -60,11 +80,11 @@ export class SearchBarController implements BlacklistSubscriber, SearchPatternSu
 					} else {
 						path = this.unifyWildCard(path)
 					}
-					this.storeService.dispatch(addBlacklistItem({ path, type: blacklistType }))
+					blacklistItems.push({ path, type: blacklistType })
 				}
 			}
 		}
-		this.resetSearchPattern()
+		return blacklistItems
 	}
 
 	isSearchPatternEmpty() {

--- a/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
+++ b/visualization/app/codeCharta/ui/searchBar/searchBar.component.ts
@@ -8,6 +8,7 @@ import { BlacklistService, BlacklistSubscriber } from "../../state/store/fileSet
 import { SearchPatternService, SearchPatternSubscriber } from "../../state/store/dynamicSettings/searchPattern/searchPattern.service"
 import { DialogService } from "../dialog/dialog.service"
 import { addBlacklistItem } from "../../state/store/fileSettings/blacklist/blacklist.actions"
+import { ERROR_MESSAGES } from "../../util/fileValidator"
 
 export class SearchBarController implements BlacklistSubscriber, SearchPatternSubscriber {
 	private static DEBOUNCE_TIME = 400
@@ -53,7 +54,7 @@ export class SearchBarController implements BlacklistSubscriber, SearchPatternSu
 		const blacklistItems: BlacklistItem[] = this.parseValidBlacklistItems(blacklistType)
 
 		if (blacklistType === BlacklistType.exclude && this.blacklistService.resultsInEmptyMap(blacklistItems)) {
-			this.dialogService.showErrorDialog("Excluding all buildings is not possible.", "Blacklist Error")
+			this.dialogService.showErrorDialog(ERROR_MESSAGES.blacklistError, "Blacklist Error")
 		} else {
 			for (const blackItem of blacklistItems) {
 				this.storeService.dispatch(addBlacklistItem(blackItem))

--- a/visualization/app/codeCharta/util/fileValidator.ts
+++ b/visualization/app/codeCharta/util/fileValidator.ts
@@ -29,7 +29,8 @@ export const ERROR_MESSAGES = {
 	fixedFoldersOutOfBounds: "Coordinates of fixed folders must be within a range of 0 and 100.",
 	fixedFoldersOverlapped: "Folders may not overlap.",
 	fixedFoldersNotAllowed: "Fixated folders may not be defined in API-Version < 1.2.",
-	fileAlreadyExists: "File already exists."
+	fileAlreadyExists: "File already exists.",
+	blacklistError: "Excluding all buildings is not possible."
 }
 
 export function validate(nameDataPair: NameDataPair, storeService: StoreService) {


### PR DESCRIPTION
# Prohibits user from excluding every building on the map

Closes: #901 

## Description

  - It is no longer possible to exclude every building on the map
  - Displays an error message when the user tries to exclude every building
  - This also applies when the user excludes every building on the map with a search query like "*"

## Screenshots or gifs

<img src="https://user-images.githubusercontent.com/50167165/125629014-13b4776b-b25f-42b2-8514-b9adf87dc608.png" width="500">
