### PR TITLE
Mark color-section as unimportant in delta mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   The "Color Metric Options" panel and "Legend" panel display the maximum value of the selected metric instead of infinite. ([#1520](https://github.com/maibornwolff/codecharta/issues/1520))
+-   Mark color-section as unimportant in delta mode ([#769](https://github.com/maibornwolff/codecharta/issues/769))
 
 ### Changed
 

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
@@ -83,6 +83,7 @@
 	ng-class="{
 		expanded: $ctrl._viewModel.panelSelection === $ctrl._viewModel.panelSelectionValues.COLOR_PANEL_OPEN
 	}"
+	ng-show="!$ctrl._viewModel.isDeltaState"
 >
 	<div class="section">
 		<div class="section-header">
@@ -108,6 +109,7 @@
 	ng-class="{
 		expanded: $ctrl._viewModel.panelSelection === $ctrl._viewModel.panelSelectionValues.EDGE_PANEL_OPEN
 	}"
+	ng-show="!$ctrl._viewModel.isDeltaState"
 >
 	<div class="section">
 		<div class="section-header">
@@ -126,4 +128,25 @@
 			}"
 		></edge-settings-panel-component>
 	</div>
+</md-card>
+
+<md-card ng-attr-id="color-settings-card" class="color-settings-card" ng-show="$ctrl._viewModel.isDeltaState">
+	<div
+		class="color-section"
+		layout="row"
+		layout-align="space-between center"
+		ng-click="$ctrl.toggle($ctrl._viewModel.panelSelectionValues.COLOR_PANEL_OPEN)"
+		title="Show color settings"
+	>
+		<span>
+			<i class="fa fa-paint-brush color-icon"></i>
+			Color Settings
+		</span>
+		<i class="fa fa-sort-down color-dropdown-icon"></i>
+	</div>
+	<color-settings-panel-component
+		ng-class="{
+			hidden: $ctrl._viewModel.panelSelection !== $ctrl._viewModel.panelSelectionValues.COLOR_PANEL_OPEN
+		}"
+	></color-settings-panel-component>
 </md-card>

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
@@ -31,6 +31,19 @@ ribbon-bar-component {
 		min-width: 92px;
 		transition: 200ms width ease-in-out;
 
+		.color-section {
+			text-align: center;
+			height: 100%;
+			width: 100%;
+
+			.color-icon {
+				margin: 5%;
+			}
+			.color-dropdown-icon {
+				margin: 2%;
+			}
+		}
+
 		.section {
 			display: inline-block;
 			height: 100%;

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.spec.ts
@@ -9,6 +9,8 @@ import { setPanelSelection } from "../../state/store/appSettings/panelSelection/
 import { RibbonBarController } from "./ribbonBar.component"
 import { PanelSelectionService } from "../../state/store/appSettings/panelSelection/panelSelection.service"
 import { ExperimentalFeaturesEnabledService } from "../../state/store/appSettings/enableExperimentalFeatures/experimentalFeaturesEnabled.service"
+import { addFile, resetFiles, setDelta } from "../../state/store/files/files.actions"
+import { TEST_DELTA_MAP_A, TEST_DELTA_MAP_B } from "../../util/dataMocks"
 
 describe("RibbonBarController", () => {
 	let ribbonBarController: RibbonBarController
@@ -93,6 +95,19 @@ describe("RibbonBarController", () => {
 
 			expect(appSettings.searchPanelMode).toEqual(SearchPanelMode.minimized)
 			expect(appSettings.panelSelection).toEqual(PanelSelection.COLOR_PANEL_OPEN)
+		})
+	})
+
+	describe("onFilesSelectionChanged", () => {
+		it("should detect delta mode selection", () => {
+			storeService.dispatch(resetFiles())
+			storeService.dispatch(addFile(TEST_DELTA_MAP_A))
+			storeService.dispatch(addFile(TEST_DELTA_MAP_B))
+			storeService.dispatch(setDelta(TEST_DELTA_MAP_A, TEST_DELTA_MAP_B))
+			ribbonBarController.onFilesSelectionChanged(storeService.getState().files)
+
+			expect(ribbonBarController["_viewModel"].files).toEqual(storeService.getState().files)
+			expect(ribbonBarController["_viewModel"].isDeltaState).toEqual(true)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.ts
@@ -10,6 +10,9 @@ import {
 	ExperimentalFeaturesEnabledService,
 	ExperimentalFeaturesEnabledSubscriber
 } from "../../state/store/appSettings/enableExperimentalFeatures/experimentalFeaturesEnabled.service"
+import { FileState } from "../../model/files/files"
+import { isDeltaState } from "../../model/files/files.helper"
+import { FilesService } from "../../state/store/files/files.service"
 
 export class RibbonBarController implements PanelSelectionSubscriber, ExperimentalFeaturesEnabledSubscriber {
 	constructor(
@@ -20,16 +23,26 @@ export class RibbonBarController implements PanelSelectionSubscriber, Experiment
 		"ngInject"
 		PanelSelectionService.subscribe(this.$rootScope, this)
 		ExperimentalFeaturesEnabledService.subscribe(this.$rootScope, this)
+		FilesService.subscribe(this.$rootScope, this)
 	}
 
 	private _viewModel: {
 		panelSelection: PanelSelection
 		panelSelectionValues: typeof PanelSelection
 		experimentalFeaturesEnabled: boolean
+		isDeltaState: boolean
+		files: FileState[]
 	} = {
 		panelSelection: PanelSelection.NONE,
 		panelSelectionValues: PanelSelection,
-		experimentalFeaturesEnabled: false
+		experimentalFeaturesEnabled: false,
+		isDeltaState: null,
+		files: null
+	}
+
+	onFilesSelectionChanged(files: FileState[]) {
+		this._viewModel.files = files
+		this._viewModel.isDeltaState = isDeltaState(files)
 	}
 
 	onPanelSelectionChanged(panelSelection: PanelSelection) {


### PR DESCRIPTION
# color settings dropdown where the user can set the colors
closes: #769

## Description
As a user, I want color settings in the delta mode, so I can change the color. Further I don't want to see metrics which I cannot change in the delta mode like the color and edge metrics.

## Screenshots or gifs
![Screenshot 2021-07-26 at 19 14 53 (2)](https://user-images.githubusercontent.com/57844849/127032787-804439d4-9266-4821-9c1c-663a07b2259f.png)

