### PR TITLE
Fix/2328/empy label during hovering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Empty temporary label during hovering ([#2328](https://github.com/maibornwolff/codecharta/issues/2328))
+
 ## [1.77.0] - 2021-07-30
 
 ### Added 🚀

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -34,6 +34,8 @@ import { BufferGeometry, Material, Object3D, Raycaster, Vector3 } from "three"
 import { CodeMapPreRenderService } from "./codeMap.preRender.service"
 import { LazyLoader } from "../../util/lazyLoader"
 import { ThreeViewerService } from "./threeViewer/threeViewerService"
+import { setShowMetricLabelNameValue } from "../../state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.actions"
+import { setShowMetricLabelNodeName } from "../../state/store/appSettings/showMetricLabelNodeName/showMetricLabelNodeName.actions"
 
 describe("codeMapMouseEventService", () => {
 	let codeMapMouseEventService: CodeMapMouseEventService
@@ -865,6 +867,25 @@ describe("codeMapMouseEventService", () => {
 				0
 			)
 			expect(nodeHeight).toBeGreaterThan(0)
+		})
+
+		it("should call addLabel on codeMapLabelService with temporary label name even when both label options are set to false", () => {
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			codeMapLabelService.addLabel = jest.fn()
+			storeService.dispatch(setShowMetricLabelNameValue(false))
+			storeService.dispatch(setShowMetricLabelNodeName(false))
+
+			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
+
+			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(
+				codeMapBuilding.node,
+				{
+					showNodeName: true,
+					showNodeMetric: false
+				},
+				0
+			)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -887,5 +887,24 @@ describe("codeMapMouseEventService", () => {
 				0
 			)
 		})
+
+		it("should not generate names in temporary Label when metric option is set to true and name is set to false", () => {
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			codeMapLabelService.addLabel = jest.fn()
+			storeService.dispatch(setShowMetricLabelNameValue(true))
+			storeService.dispatch(setShowMetricLabelNodeName(false))
+
+			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
+
+			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
+			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(
+				codeMapBuilding.node,
+				{
+					showNodeName: false,
+					showNodeMetric: true
+				},
+				0
+			)
+		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -250,10 +250,16 @@ export class CodeMapMouseEventService
 		const showLabelNodeName = appSettings.showMetricLabelNodeName
 		const showLabelNodeMetric = appSettings.showMetricLabelNameValue
 
+		let displayLabelMetricName = true
+
+		if (showLabelNodeMetric && !showLabelNodeName) {
+			displayLabelMetricName = false
+		}
+
 		this.codeMapLabelService.addLabel(
 			codeMapBuilding.node,
 			{
-				showNodeName: showLabelNodeName,
+				showNodeName: displayLabelMetricName,
 				showNodeMetric: showLabelNodeMetric
 			},
 			0


### PR DESCRIPTION
# Empy temporary label when hovering 

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #2328 

## Description

- Disabling node names and node values will display node names for hovered labels isntead of an empty label

## Screenshots or gifs
