### PR TITLE
Documentation/1349/scm log parser v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/issues/1315))
+-   Add documentation for SCMLogParserV2 ([#1349](https://github.com/maibornwolff/codecharta/issues/1349))
 
 ### Fixed 🐞
 

--- a/analysis/import/SCMLogParser/src/main/dist/anongit
+++ b/analysis/import/SCMLogParser/src/main/dist/anongit
@@ -18,7 +18,7 @@ while read -r line; do
   if [[ "$line" =~ ^Author.*\<.*\>$ ]]; then
     aliasLine=$(grep -A1 "$line" ${HASHMAP_FILE} -m1 | tail -n 1)
     if [ -z "$aliasLine" ]; then
-      aliasLine="Author: anon$COUNTER <anon$COUNTER@email.com>"
+      aliasLine="Author: anon$COUNTER <anon$COUNTER@example.org>"
       echo -e "$line\n$aliasLine" >> ${HASHMAP_FILE}
       ((COUNTER++))
     fi

--- a/analysis/import/SCMLogParserV2/src/main/dist/anongit
+++ b/analysis/import/SCMLogParserV2/src/main/dist/anongit
@@ -18,7 +18,7 @@ while read -r line; do
   if [[ "$line" =~ ^Author.*\<.*\>$ ]]; then
     aliasLine=$(grep -A1 "$line" ${HASHMAP_FILE} -m1 | tail -n 1)
     if [ -z "$aliasLine" ]; then
-      aliasLine="Author: anon$COUNTER <anon$COUNTER@email.com>"
+      aliasLine="Author: anon$COUNTER <anon$COUNTER@example.org>"
       echo -e "$line\n$aliasLine" >> ${HASHMAP_FILE}
       ((COUNTER++))
     fi

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -4,7 +4,7 @@ The CodeCharta docs use [Jekyll](https://jekyllrb.com) and the [Minimal Mistakes
 
 ## Usage
 
-The generated docs can be viewed locally before being pushed to Github (see below). Please note that some files like the web version of CodeCharta are **generated** by `.travis.yml` with the help of the `script/build_gh_pages.sh`. They won't show up locally unless you call that script. If you run the script you should find a new folder called `gh-pages/visualization` though.
+The generated docs can be viewed locally before being pushed to Github (see below). Please note that some files like the web version of CodeCharta are **generated** by `release_gh_pages.yml` with the help of the `script/build_gh_pages.sh`. They won't show up locally unless you call that script. If you run the script you should find a new folder called `gh-pages/visualization` though.
 
 ### Local
 

--- a/gh-pages/_data/navigation.yml
+++ b/gh-pages/_data/navigation.yml
@@ -48,6 +48,8 @@ docs:
             url: /docs/raw-text-parser
           - title: "SCM Log Parser"
             url: /docs/scm-log-parser
+          - title: "SCM Log Parser V2"
+            url: /docs/scm-log-parser-2
           - title: "Sonar Importer"
             url: /docs/sonar-importer
           - title: "Tokei Importer"

--- a/gh-pages/_docs/04-12-scmlogparser2.md
+++ b/gh-pages/_docs/04-12-scmlogparser2.md
@@ -1,0 +1,70 @@
+---
+permalink: /docs/scm-log-parser-2
+title: "SCM Log Parser2"
+---
+
+# SCMLogParserV2 - Status: unstable/experimental!
+
+Generates visualisation data from git repository logs and repository file list.
+
+This parser specializes in tracking file changes across different file-renaming on different feature-branches and then merged main.
+Furthermore, special care is taken to avoid showing un-existing files that might show up in standard histories due to renaming actions on feature branches.
+
+Things to note:
+
+-   File deletions that get reverted later on are ignored by this parser.
+-   This parser is experimental, some features might not work correctly. If you encounter a bug, please report it over at https://github.com/MaibornWolff/codecharta/issues.
+
+It supports the following metrics per file:
+
+| Metric                 | Description                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| `age_in_weeks`         | age of the file in weeks                                                              |
+| `number_of_commits`    | total number of commits                                                               |
+| `highly_coupled_files` | Number of highly coupled files (>=35% of times modified the same time) with this file |
+| `median_coupled_files` | Median of number of other files that where commited with this file                    |
+| `number_of_renames`    | total number of renames                                                               |
+| `weeks_with_commits`   | weeks with commits                                                                    |
+| `number_of_authors`    | number of authors with commits                                                        |
+| `code_churn`           | code churn, i.e. number of additions plus deletions to file                           |
+
+Additionally, the following Edge Metrics are calculated:
+
+| Metric              | Description                                               |
+| ------------------- | --------------------------------------------------------- |
+| `temporal_coupling` | The degree of temporal coupling between two files (>=35%) |
+
+The names of authors are saved when the --add-author flag is set.
+
+## Usage
+
+### Creating the repository log for metric generation
+
+| SCM | Log format                   | Command for log creation                            | tracks renames | ignores deleted files | supports code churn |
+| --- | ---------------------------- | --------------------------------------------------- | -------------- | --------------------- | ------------------- |
+| git | GIT_LOG_NUMSTAT_RAW_REVERSED | `git log --numstat --raw --topo-order --reverse -m` | yes            | yes                   | yes                 |
+
+You can also use the bash script anongit which generates an anonymous git log with log format GIT_LOG for usage with CodeCharta.
+
+### Creating the git files list of the repository for metric generation
+
+> `git ls-files > file-name-list.txt`
+
+### Executing the SCMLogParser
+
+See `ccsh -h` for help. Standard usage:
+
+> `ccsh scmlogparserv2 <log_file> -n <file-name-list>`
+
+The result is written as JSON to standard out or into an output file (if specified by `-o` option).
+
+If a project is piped into the SCMLogParser, the results and the piped project are merged.
+The resulting project has the project name specified for the SCMLogParser.
+
+### Example using Git
+
+-   `cd <my_git_project>`
+-   `git log --numstat --raw --topo-order --reverse -m > git.log` (or `anongit > git.log`)
+-   `git ls-files > file-name-list.txt`
+-   `./ccsh scmlogparserv2 git.log -o output.cc.json -n file-name-list.txt`
+-   load `output.cc.json` in visualization

--- a/gh-pages/_docs/04-12-scmlogparser2.md
+++ b/gh-pages/_docs/04-12-scmlogparser2.md
@@ -48,7 +48,7 @@ You can also use the bash script anongit which generates an anonymous git log wi
 
 ### Creating the git files list of the repository for metric generation
 
-> `git ls-files > file-name-list.txt`
+> `git ls-files > file-name-list.tmp`
 
 ### Executing the SCMLogParser
 
@@ -64,7 +64,7 @@ The resulting project has the project name specified for the SCMLogParser.
 ### Example using Git
 
 -   `cd <my_git_project>`
--   `git log --numstat --raw --topo-order --reverse -m > git.log` (or `anongit > git.log`)
--   `git ls-files > file-name-list.txt`
--   `./ccsh scmlogparserv2 git.log -o output.cc.json -n file-name-list.txt`
+-   `git log --numstat --raw --topo-order --reverse -m > gitlog.tmp` (or `anongit --reverse > gitlog.tmp`)
+-   `git ls-files > file-name-list.tmp`
+-   `./ccsh scmlogparserv2 gitlog.tmp -o output.cc.json -n file-name-list.tmp`
 -   load `output.cc.json` in visualization

--- a/gh-pages/_docs/07-01-new-to-code.md
+++ b/gh-pages/_docs/07-01-new-to-code.md
@@ -11,27 +11,33 @@ Finally, it would be great if you looked at how we give and receive [feedback]({
 
 We create Pull Requests to the `main` branch after implementing a feature or fixing a bug. There is no release or development branch. We never push on `main` directly. Please take a look at our [contributing guidelines](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before you start comitting.
 
-# Travis CI
+# Github Actions
 
-In Travis CI, we defined stages, which group different jobs. Inside a stage, all jobs run in parallel. There is no data persistence between stages, so we have to rebuild our application in each stage. The CI consists of the following stages:
+In Github Actions, we defined stages, which group different jobs. Inside a stage, all jobs run in parallel. There is no data persistence between stages, so we have to rebuild our application in each stage. The CI consists of the following stages:
 
--   Testing (which runs all the time)
--   Sonar (only run when a PR is merged into `main`)
+-   Testing (which runs on every push on an active PR)
+-   Sonar Analysis(which runs on every push on an active PR after testing to ensure code quality metrics are met)
 -   Deploy (run by `make_release.py`)
+
+All workflow files can be found under `.github/workflows`
 
 ### Testing
 
 -   Runs Unit and E2E/UI-Tests
+-   Workflow: `test.yml`
 
 ### Sonar
 
--   Publishes Sonar-Analysis-Results to [Sonarcloud.io](https://sonarcloud.io)
+-   Publishes Sonar-Analysis-Results to [Sonarcloud.io](https://sonarcloud.io) and displays code-quality of the current PR
+-   Workflow: `test.yml`
 
 ### Deploy
 
 -   Deploys the application in a docker container to the github-pages
 -   Publishes the new version on npm
 -   Publishes a docker container on [Docker Hub](https://hub.docker.com/r/codecharta/codecharta-visualization)
+
+-   Workflow: `release_gh_pages.yml`
 
 # Analysis
 

--- a/gh-pages/_docs/07-01-new-to-code.md
+++ b/gh-pages/_docs/07-01-new-to-code.md
@@ -16,7 +16,7 @@ We create Pull Requests to the `main` branch after implementing a feature or fix
 In Github Actions, we defined stages, which group different jobs. Inside a stage, all jobs run in parallel. There is no data persistence between stages, so we have to rebuild our application in each stage. The CI consists of the following stages:
 
 -   Testing (which runs on every push on an active PR)
--   Sonar Analysis(which runs on every push on an active PR after testing to ensure code quality metrics are met)
+-   Sonar Analysis (which runs on every push on an active PR after testing to ensure code quality metrics are met)
 -   Deploy (run by `make_release.py`)
 
 All workflow files can be found under `.github/workflows`


### PR DESCRIPTION
# Add documentation for SCMLogParserV2

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #1349 

## Description

- Added SCMLogParserV2 documentation to github pages
- Updated github-pages new-to-code guide and Readme.md to say our CI is Github Actions and not travis

## Screenshots or gifs
