### PR TITLE
Remove data-mocks from analysis

### DIFF
--- a/visualization/sonar-project.properties
+++ b/visualization/sonar-project.properties
@@ -8,7 +8,8 @@ sonar.tests=./app
 sonar.test.exclusions=./app/puppeteer.helper.ts,**/node_modules/**,**/*.spec.ts,**/*.spec.js,**/*.e2e.ts,**/*.e2e.js,**/*.po.ts
 sonar.test.inclusions=**/*.spec.ts
 
-sonar.coverage.exclusions=./app/puppeteer.helper.ts,**/node_modules/**,**/*.spec.ts,**/*.spec.js,**/*.e2e.ts,**/*.e2e.js,**/*.po.ts,**/*.html,**/*.scss
+sonar.coverage.exclusions=./app/puppeteer.helper.ts,**/node_modules/**,**/*.spec.ts,**/*.spec.js,**/*.e2e.ts,**/*.e2e.js,**/*.po.ts,**/*.html,**/*.scss,./app/codeCharta/util/dataMocks.ts
+sonar.cpd.exclusions=./app/codeCharta/util/dataMocks.ts
 
 sonar.typescript.lcov.reportPaths=./dist/coverage/lcov.info
 


### PR DESCRIPTION
# Remove data.mocks from analysis

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

Keeping data.mocks in our analysis on sonar-qube has been screwing metrics for quite some time, e.g. showing security issue due to using http-link in mock data or tracking duplication on test data.
It makes our code-qualitylook worse then it is and makes development painful due to PRs being rejected because of mock-lines duplication. 
This PR removes the file from coverage and duplication analysis

## Screenshots or gifs
