### PR TITLE
Fix/2326/fix oudated naming screenshot to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Add metric descriptions to the frontend and show a translation next to the entry ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
     ![Bildschirmfoto 2021-09-13 um 15 34 31](https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png)
+-   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326)) ![Screenshot 2021-08-30 at 14 59 21](https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png)
+-   Add changelog guidelines ([#2358](https://github.com/MaibornWolff/codecharta/pull/2358))
+-   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/pull/2342))
+    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="450px"/>
+
+### Fixed 🐞
+
+-   Fix broken methode call in screenshot feature
+-   Improve changelog entries
 
 ### Changed
 
 -   Changing the background color and remove "outgoing" and "incoming" edges from the legend, if not applicable ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
--   Add changelog guidelines ([#2358](https://github.com/MaibornWolff/codecharta/pull/2358))
--   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/pull/2342))
-    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="450px"/>
 -   Improve the user experience for the AI Feature "Suspicious Metrics and Risk Profiles" and enable it for any programming language ([#2362](https://github.com/MaibornWolff/codecharta/pull/2362))
     <img src="https://user-images.githubusercontent.com/26900540/133250867-adf4583d-9d0e-4f81-b8a7-1407b93d9f40.png" width="450px"/>
 
@@ -26,7 +32,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/issues/1315))
--   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326)) ![Screenshot 2021-08-30 at 14 59 21](https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png)
 -   Add documentation for SCMLogParserV2 ([#1349](https://github.com/maibornwolff/codecharta/issues/1349))
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.component.html
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.component.html
@@ -65,7 +65,7 @@
 				<md-switch
 					class="md-primary"
 					ng-model="$ctrl._viewModel.screenshotToClipboardEnabled"
-					ng-change="$ctrl.applySettingsEnableClipboardFeatures()"
+					ng-change="$ctrl.applySettingsEnableScreenshotToClipboardFeatures()"
 				>
 					Screenshot to clipboard
 				</md-switch>


### PR DESCRIPTION
# fix oudated naming screenshot to clipboard

closes: #2326 

## Description

Fix broken naming in screenshot feature and improve some changelog entries

## Screenshots or gifs
