### PR TITLE
Spike: Apply slowMotion to stabilize test #2372

### DIFF
--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
@@ -43,12 +43,11 @@ describe("DialogGlobalSettings", () => {
 	})
 
 	describe("Display Quality", () => {
-		//Flaky since node 16; disabled for now
-		/*it("should should maximum-tree-map slider when TreeMapStreet is chosen as layout", async () => {
+		it("should should maximum-tree-map slider when TreeMapStreet is chosen as layout", async () => {
 			await globalSettingsPageObject.changeLayoutToTreeMapStreet()
 
 			await globalSettingsPageObject.isTreeMapFilesComponentVisible()
-		})*/
+		})
 
 		it("should change the display quality to Pixel Ratio without Antialiasing", async () => {
 			await globalSettingsPageObject.changedDisplayQuality()

--- a/visualization/jest-puppeteer.config.js
+++ b/visualization/jest-puppeteer.config.js
@@ -2,7 +2,6 @@ module.exports = {
 	launch: {
 		headless: true,
 		args: ["--allow-file-access-from-files", "--start-maximized"],
-		defaultViewport: { width: 1920, height: 1080 },
-		slowMo: 1
+		defaultViewport: { width: 1920, height: 1080 }
 	}
 }

--- a/visualization/jest-puppeteer.config.js
+++ b/visualization/jest-puppeteer.config.js
@@ -3,6 +3,6 @@ module.exports = {
 		headless: true,
 		args: ["--allow-file-access-from-files", "--start-maximized"],
 		defaultViewport: { width: 1920, height: 1080 },
-		slowMo: 1
+		slowMo: 25
 	}
 }

--- a/visualization/jest-puppeteer.config.js
+++ b/visualization/jest-puppeteer.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	launch: {
 		headless: true,
 		args: ["--allow-file-access-from-files", "--start-maximized"],
-		defaultViewport: { width: 1920, height: 1080 }
+		defaultViewport: { width: 1920, height: 1080 },
+		slowMo: 1
 	}
 }


### PR DESCRIPTION
# Stabilize E2E Tests by enabling slow motion

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Issue: #2372 

## Description
By setting `slowMo` to a low value, e2e tests seem to run more stably.
This PR could fix our current problems with flaky e2e tests, but this does not address the root cause at all.

The question is, why it works with a slow motion of 25ms!