### PR TITLE
Improve tolerance of E2E tests and add slow motion for more stability

### DIFF
--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.e2e.ts
@@ -43,12 +43,11 @@ describe("DialogGlobalSettings", () => {
 	})
 
 	describe("Display Quality", () => {
-		//Flaky since node 16; disabled for now
-		/*it("should should maximum-tree-map slider when TreeMapStreet is chosen as layout", async () => {
+		it("should show maximum-tree-map slider when TreeMapStreet is chosen as layout", async () => {
 			await globalSettingsPageObject.changeLayoutToTreeMapStreet()
 
 			await globalSettingsPageObject.isTreeMapFilesComponentVisible()
-		})*/
+		})
 
 		it("should change the display quality to Pixel Ratio without Antialiasing", async () => {
 			await globalSettingsPageObject.changedDisplayQuality()

--- a/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.globalSettings.po.ts
@@ -15,15 +15,11 @@ export class DialogGlobalSettingsPageObject {
 	}
 
 	async changeLayoutToTreeMapStreet() {
-		await page.waitForSelector("div.md-dialog-content layout-selection-component div md-input-container md-select", { visible: true })
-		// make tests more stable - we should definitely remove those sleeps when migrating this component
-		await new Promise(resolve => setTimeout(resolve, 100))
-		await page.click("div.md-dialog-content layout-selection-component div md-input-container md-select")
-		await page.waitForSelector('md-select-menu md-content [value="TreeMapStreet"]', { visible: true })
-		await page.click('md-select-menu md-content [value="TreeMapStreet"]')
-		// Switching a layout has a debounce time of at least one millisecond.
-		// Delay the execution by a few milliseconds.
-		await new Promise(resolve => setTimeout(resolve, 5))
+		await clickButtonOnPageElement("div.md-dialog-content layout-selection-component div md-input-container md-select", {
+			visible: true
+		})
+		await clickButtonOnPageElement('md-select-menu md-content [value="TreeMapStreet"]', { visible: true })
+		await page.waitForSelector(".md-select-menu-container.md-active", { visible: false })
 	}
 
 	async getLayout() {
@@ -36,16 +32,15 @@ export class DialogGlobalSettingsPageObject {
 	}
 
 	async changedDisplayQuality() {
-		await page.click("div.md-dialog-content sharpness-mode-selector-component div md-input-container md-select")
-		await page.waitForSelector(".md-select-menu-container.md-active", { visible: true })
-		await page.click('md-select-menu md-content [value="Pixel Ratio without Antialiasing"]')
-		// Switching settings that have influence on the rendered map has a
-		// debounce time of at least one millisecond.
-		await new Promise(resolve => setTimeout(resolve, 5))
+		await clickButtonOnPageElement("div.md-dialog-content sharpness-mode-selector-component div md-input-container md-select", {
+			visible: true
+		})
+		await clickButtonOnPageElement('md-select-menu md-content [value="Pixel Ratio without Antialiasing"]', { visible: true })
+		await page.waitForSelector(".md-select-menu-container.md-active", { visible: false })
 	}
 
 	async getDisplayQuality() {
-		await page.waitForSelector("sharpness-mode-selector-component .md-select-value")
-		return page.$eval("sharpness-mode-selector-component .md-select-value", element => element["innerText"])
+		await page.waitForSelector("sharpness-mode-selector-component .md-select-value .md-text")
+		return page.$eval("sharpness-mode-selector-component .md-select-value .md-text", element => element["innerText"])
 	}
 }

--- a/visualization/jest-puppeteer.config.js
+++ b/visualization/jest-puppeteer.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	launch: {
 		headless: true,
 		args: ["--allow-file-access-from-files", "--start-maximized"],
-		defaultViewport: { width: 1920, height: 1080 }
+		defaultViewport: { width: 1920, height: 1080 },
+		slowMo: 25
 	}
 }


### PR DESCRIPTION
# Improve tolerance of E2E tests and add slow motion for more stability

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Closes: #2372 

## Description
By setting slowMo to a low value, e2e tests seem to run more stably.
This PR could fix our current problems with flaky e2e tests, but this does not address the root cause at all.

The question is, why it works with a slow motion of 25ms!

## Note
We will merge this PR and have another look here #2383 after the Angular migration 