### PR TITLE
Fix/2377/improve metric descriptions in legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Hides legend block if label description is not available and adds new metric descriptions ([#2377](https://github.com/maibornwolff/codecharta/issues/2377)).
+
 ## [1.80.0] - 2021-10-04
 
 ### Added 🚀

--- a/visualization/app/codeCharta/ui/legendPanel/legendPanel.component.html
+++ b/visualization/app/codeCharta/ui/legendPanel/legendPanel.component.html
@@ -1,21 +1,21 @@
 <div class="block-wrapper" ng-class="{ visible: $ctrl._viewModel.isLegendVisible, sideBarVisible: $ctrl._viewModel.isSideBarVisible }">
 	<div ng-if="!$ctrl._viewModel.isDeltaState">
-		<div class="legend-block">
+		<div ng-if="$ctrl._viewModel.areaMetricDescription" class="legend-block">
 			Size metric (<span class="bold">{{ $ctrl._viewModel.areaMetric }}</span
 			>: {{ $ctrl._viewModel.areaMetricDescription }})
 		</div>
-		<div class="legend-block">
+		<div ng-if="$ctrl._viewModel.heightMetricDescription" class="legend-block">
 			Height metric (<span class="bold">{{ $ctrl._viewModel.heightMetric }}</span
 			>: {{ $ctrl._viewModel.heightMetricDescription }})
 		</div>
 		<div ng-if="$ctrl._viewModel.edgeMetricHasEdge">
-			<div class="legend-block">
+			<div ng-if="$ctrl._viewModel.edgeDescription" class="legend-block">
 				Edge metric (<span class="bold">{{ $ctrl._viewModel.edge }}</span
 				>: {{ $ctrl._viewModel.edgeDescription }})
 			</div>
 		</div>
 		<hr />
-		<div class="legend-block">
+		<div ng-if="$ctrl._viewModel.colorMetricDescription" class="legend-block">
 			Color metric (<span class="bold">{{ $ctrl._viewModel.colorMetric }}</span
 			>: {{ $ctrl._viewModel.colorMetricDescription }})
 		</div>

--- a/visualization/app/codeCharta/util/metric/metricDescriptions.ts
+++ b/visualization/app/codeCharta/util/metric/metricDescriptions.ts
@@ -3,7 +3,9 @@ This file contains descriptions of the metrics
 */
 
 export const metricDescriptions: Map<string, string> = new Map([
+	["loc", "lines of code"],
 	["rloc", "real lines of code"],
+	["comment_lines", "number of code lines with comments"],
 	["mcc", "cyclomatic complexity"],
 	["avgCommits", "average number of commits from this file"],
 	["functions", "number of files from this file"],


### PR DESCRIPTION
# Improve metric descriptions in legend

closes: #2377 

## Description

-The metric label is not shown, if no description is available.
-More basic metric descriptions are provided. Especially for loc and comment_lines


