### PR TITLE
Fix Changelog Inconsistencies #2420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add metric descriptions to the frontend and show a translation next to the entry ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
-    <img src="https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png" width="250px"/>
+
+<img src="https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png" width="250px"/>
 
 -   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326))
-    <img src="https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png" width="450px"/>
+
+<img src="https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png" width="450px"/>
 
 -   Add changelog guidelines ([#2358](https://github.com/MaibornWolff/codecharta/pull/2358))
 -   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/pull/2342))
-    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="350px"/>
+
+<img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="350px"/>
 
 ### Fixed 🐞
 
@@ -45,7 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Changing the background color and remove "outgoing" and "incoming" edges from the legend, if not applicable ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
 -   Improve the user experience for the AI Feature "Suspicious Metrics and Risk Profiles" and enable it for any programming language ([#2362](https://github.com/MaibornWolff/codecharta/pull/2362))
 
-      <img src="https://user-images.githubusercontent.com/26900540/133250867-adf4583d-9d0e-4f81-b8a7-1407b93d9f40.png" width="350px" alt=""/>
+       <img src="https://user-images.githubusercontent.com/26900540/133250867-adf4583d-9d0e-4f81-b8a7-1407b93d9f40.png" width="350px" alt=""/>
 
 ## [1.78.0] - 2021-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
     -   "Weighted Gradient" only mixes colors in a small interval around the preset values.
     -   "True Gradient" mixes colors from the 0 to the highest value, the two preset color range values determine the balance.
     -   "Absolute" represents the old behaviour without gradients.
-        <img src="https://user-images.githubusercontent.com/42114276/134924267-245c65c9-2893-43a8-9a0a-17e3182bf15a.JPG" width="350px" alt=""/>
+        <img src="https://user-images.githubusercontent.com/42114276/134924267-245c65c9-2893-43a8-9a0a-17e3182bf15a.JPG" width="350px"/>
 
 ### Fixed 🐞
 
@@ -26,14 +26,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add metric descriptions to the frontend and show a translation next to the entry ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
-    <img src="https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png" width="250px" alt=""/>
+    <img src="https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png" width="250px"/>
 
 -   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326))
-    <img src="https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png" width="450px" alt=""/>
+    <img src="https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png" width="450px"/>
 
 -   Add changelog guidelines ([#2358](https://github.com/MaibornWolff/codecharta/pull/2358))
 -   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/pull/2342))
-    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="350px" alt=""/>
+    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="350px"/>
 
 ### Fixed 🐞
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
     -   "Weighted Gradient" only mixes colors in a small interval around the preset values.
     -   "True Gradient" mixes colors from the 0 to the highest value, the two preset color range values determine the balance.
     -   "Absolute" represents the old behaviour without gradients.
-        <img src="https://user-images.githubusercontent.com/42114276/134924267-245c65c9-2893-43a8-9a0a-17e3182bf15a.JPG" width="450px"/>
+        <img src="https://user-images.githubusercontent.com/42114276/134924267-245c65c9-2893-43a8-9a0a-17e3182bf15a.JPG" width="350px" alt=""/>
 
 ### Fixed 🐞
 
@@ -26,22 +26,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add metric descriptions to the frontend and show a translation next to the entry ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
-    ![Bildschirmfoto 2021-09-13 um 15 34 31](https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png)
--   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326)) ![Screenshot 2021-08-30 at 14 59 21](https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png)
+    <img src="https://user-images.githubusercontent.com/31436472/133093437-eaa0efdc-9d8c-49a8-ab21-5c959e232a49.png" width="250px" alt=""/>
+
+-   An option has been added to the global settings to enable copying screenshots to clipboard instead of saving them in a file ([#2326](https://github.com/MaibornWolff/codecharta/issues/2326))
+    <img src="https://user-images.githubusercontent.com/57844849/131342771-a3c637e3-8241-49aa-8d51-71e3a8d38aef.png" width="450px" alt=""/>
+
 -   Add changelog guidelines ([#2358](https://github.com/MaibornWolff/codecharta/pull/2358))
 -   A changelog dialog with the latest additions to CodeCharta appears on version update ([#1315](https://github.com/MaibornWolff/codecharta/pull/2342))
-    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="450px"/>
+    <img src="https://user-images.githubusercontent.com/48621967/131360878-a8e1ef40-7f73-4de7-8b3f-4c8dc21448da.PNG" width="350px" alt=""/>
 
 ### Fixed 🐞
 
--   Fix broken methode call in screenshot feature
--   Improve changelog entries
+-   Fix broken methode call in screenshot feature.
+-   Improve changelog entries.
 
 ### Changed
 
 -   Changing the background color and remove "outgoing" and "incoming" edges from the legend, if not applicable ([#2330](https://github.com/MaibornWolff/codecharta/issues/2330))
 -   Improve the user experience for the AI Feature "Suspicious Metrics and Risk Profiles" and enable it for any programming language ([#2362](https://github.com/MaibornWolff/codecharta/pull/2362))
-    <img src="https://user-images.githubusercontent.com/26900540/133250867-adf4583d-9d0e-4f81-b8a7-1407b93d9f40.png" width="450px"/>
+
+      <img src="https://user-images.githubusercontent.com/26900540/133250867-adf4583d-9d0e-4f81-b8a7-1407b93d9f40.png" width="350px" alt=""/>
 
 ## [1.78.0] - 2021-09-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,9 +95,10 @@ To unify the appearance of all commit messages we only accept commit messages us
 -   [Description of what you changed] [Link to the pull request]
     [One picture (specify the width and/or height)]<br/>
     Example:<br/>
-    `- Add a changelog dialog with the latest additions to CodeCharta that appears on version update ([#1315](pull-request-linkl)) <img src="image-link" width="350px">`
-    The image should always have a width and/or a height attribute.
-    Example: width=”500px”
+    `- Add a changelog dialog with the latest additions to CodeCharta that appears on version update ([#1315](pull-request-link))`<br/>
+    _new line_<br/>
+    `<img src="image-link" width="350px">`<br/>
+    _new line_<br/>
 
 ###How to write a good description?
 
@@ -119,3 +120,6 @@ To unify the appearance of all commit messages we only accept commit messages us
 
 -   Link to the image can be copied from an image uploaded to the Pull Request
 -   If there are no Pull Requests associated to your change, link an issue.
+-   The image should always have a width and/or a height attribute.
+    -   Example: width=”350px”
+-   Please leave an empty line before and after the image tag so that prettier doesn't interfere with the formatting.


### PR DESCRIPTION
# Fix Changelog Inconsistencies

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Issue: #2420 

## Description

The images for the 1.79.0 version were not consistent. This PR fixes that and adds a new rule to the chnagelog guidelines. 
**Note** Prettier interferes with the indentation of the markdown (the img tag) which causes the images not to be parsed correctly for the what's new section 

## Screenshots or gifs
Before
![grafik](https://user-images.githubusercontent.com/48621967/135865999-64e0a021-eda5-4f0e-9503-846defab4700.png)
After
![changelog](https://user-images.githubusercontent.com/48621967/135866024-ee06119a-1a62-4912-90df-ac3aa9216608.PNG)

