### PR TITLE
Fix/2481/Remove nonfunctional buttons

### DIFF
--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.scss
@@ -40,7 +40,6 @@ attribute-side-bar-component {
 
 			.node-name {
 				width: 90%;
-				cursor: pointer;
 
 				.node-link {
 					font-size: 11pt;


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Remove pointer from sidebar building/file title when no link exists 

Issue: #2481 

Removes the hover (cursor: pointer) effect on the sidebar building/file title if a link is not associated with it - now the effect only occurs if there is a link associated with the node (see gif below).

## Screenshots or gif
![Screen Recording 2021-11-16 at 11 58 10 AM](https://user-images.githubusercontent.com/84106309/142020662-9a0a6ad3-9195-4885-a357-f0cb384e385c.gif)
s
