### PR TITLE
Refactor/2318/migrate attribute type selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Chore 👨‍💻 👩‍💻
 
 -   Refactor where metric data are calculated ([#2514](https://github.com/MaibornWolff/codecharta/pull/2514)).
+-   Migrate `attribute-type-selector-component` to Angular ([#2519](https://github.com/MaibornWolff/codecharta/pull/2519)).
 
 ### Changed
 

--- a/visualization/app/app.module.ts
+++ b/visualization/app/app.module.ts
@@ -12,11 +12,19 @@ import { MapTreeViewComponent } from "./codeCharta/ui/mapTreeView/mapTreeView.co
 import { MatchingFilesCounterComponent } from "./codeCharta/ui/matchingFilesCounter/matchingFilesCounter.component"
 import { MatchingFilesCounterModule } from "./codeCharta/ui/matchingFilesCounter/matchingFilesCounter.module"
 import { NodePathComponent } from "./codeCharta/ui/attributeSideBar/nodePath/nodePath.component"
+import { AttributeTypeSelectorModule } from "./codeCharta/ui/attributeTypeSelector/attributeTypeSelector.module"
+import { AttributeTypeSelectorComponent } from "./codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component"
 
 @NgModule({
-	imports: [BrowserModule, UpgradeModule, MaterialModule, MapTreeViewModule, MatchingFilesCounterModule],
+	imports: [BrowserModule, UpgradeModule, MaterialModule, MapTreeViewModule, MatchingFilesCounterModule, AttributeTypeSelectorModule],
 	declarations: [MetricDeltaSelectedComponent, NodePathComponent],
-	entryComponents: [MapTreeViewComponent, MetricDeltaSelectedComponent, MatchingFilesCounterComponent, NodePathComponent]
+	entryComponents: [
+		MapTreeViewComponent,
+		MetricDeltaSelectedComponent,
+		MatchingFilesCounterComponent,
+		NodePathComponent,
+		AttributeTypeSelectorComponent
+	]
 })
 export class AppModule {
 	constructor(@Inject(UpgradeModule) private upgrade: UpgradeModule) {}

--- a/visualization/app/codeCharta/state/selectors/getAttributeTypeOfNodesByMetric.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/getAttributeTypeOfNodesByMetric.selector.ts
@@ -1,7 +1,11 @@
 import { createSelector } from "../angular-redux/store"
 import { attributeTypesSelector } from "../store/fileSettings/attributeTypes/attributeTypes.selector"
+import { CcState } from "../store/store"
+import { AttributeTypeValue } from "../../codeCharta.model"
 
-export const getAttributeTypeOfNodesByMetricSelector = createSelector(
+export type GetAttributeTypeOfNodesByMetric = (metricName: string) => AttributeTypeValue
+
+export const getAttributeTypeOfNodesByMetricSelector: (state: CcState) => GetAttributeTypeOfNodesByMetric = createSelector(
 	[attributeTypesSelector],
 	attributeTypes => (metricName: string) => attributeTypes.nodes[metricName]
 )

--- a/visualization/app/codeCharta/state/selectors/getAttributeTypeOfNodesByMetric.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/getAttributeTypeOfNodesByMetric.selector.ts
@@ -1,0 +1,7 @@
+import { createSelector } from "../angular-redux/store"
+import { attributeTypesSelector } from "../store/fileSettings/attributeTypes/attributeTypes.selector"
+
+export const getAttributeTypeOfNodesByMetricSelector = createSelector(
+	[attributeTypesSelector],
+	attributeTypes => (metricName: string) => attributeTypes.nodes[metricName]
+)

--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.html
@@ -25,13 +25,12 @@
 					<td>
 						<i class="fa fa-arrows-alt"></i>
 						<div class="metric-value">
-							<attribute-type-selector-component
+							<cc-attribute-type-selector
 								class="attribute-type-select"
-								type="nodes"
 								metric="{{::$ctrl._viewModel.primaryMetricKeys.node.area}}"
 								ng-if="!$ctrl._viewModel.node.isLeaf"
 							>
-							</attribute-type-selector-component>
+							</cc-attribute-type-selector>
 							<span>
 								{{ $ctrl._viewModel.node.attributes[$ctrl._viewModel.primaryMetricKeys.node.area] | number: 0 }}
 							</span>
@@ -43,13 +42,12 @@
 					<td>
 						<i class="fa fa-arrows-v"></i>
 						<div class="metric-value">
-							<attribute-type-selector-component
+							<cc-attribute-type-selector
 								class="attribute-type-select"
-								type="nodes"
 								metric="{{::$ctrl._viewModel.primaryMetricKeys.node.height}}"
 								ng-if="!$ctrl._viewModel.node.isLeaf"
 							>
-							</attribute-type-selector-component>
+							</cc-attribute-type-selector>
 							<span>
 								{{ $ctrl._viewModel.node.attributes[$ctrl._viewModel.primaryMetricKeys.node.height] | number: 0 }}
 							</span>
@@ -65,13 +63,12 @@
 					<td>
 						<i class="fa fa-paint-brush"></i>
 						<div class="metric-value">
-							<attribute-type-selector-component
+							<cc-attribute-type-selector
 								class="attribute-type-select"
-								type="nodes"
 								metric="{{::$ctrl._viewModel.primaryMetricKeys.node.color}}"
 								ng-if="!$ctrl._viewModel.node.isLeaf"
 							>
-							</attribute-type-selector-component>
+							</cc-attribute-type-selector>
 							<span>
 								{{ $ctrl._viewModel.node.attributes[$ctrl._viewModel.primaryMetricKeys.node.color] | number: 0 }}
 							</span>
@@ -106,13 +103,12 @@
 					<tr ng-repeat="attributeKey in $ctrl._viewModel.secondaryMetrics track by $index" class="metric-row">
 						<td class="metric-summary">
 							<span class="metric-type">
-								<attribute-type-selector-component
+								<cc-attribute-type-selector
 									class="attribute-type-select"
-									type="nodes"
 									metric="{{::attributeKey.name}}"
 									ng-if="!$ctrl._viewModel.node.isLeaf"
 								>
-								</attribute-type-selector-component>
+								</cc-attribute-type-selector>
 							</span>
 							<span class="metric-value">{{ $ctrl._viewModel.node.attributes[attributeKey.name] | number: 0 }}</span>
 						</td>

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.spec.ts
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.spec.ts
@@ -1,0 +1,19 @@
+import { AttributeTypeValue } from "../../codeCharta.model"
+import { AggregationSymbolPipe } from "./aggregationSymbol.pipe"
+
+describe("aggregationSymbolPipe", () => {
+	it("should map `AttributeTypeValue.relative` to x͂", () => {
+		const getAttributeTypeOfNodesByMetricSelector = () => AttributeTypeValue.relative
+		expect(new AggregationSymbolPipe().transform("some-metric-name", getAttributeTypeOfNodesByMetricSelector)).toBe("x͂")
+	})
+
+	it("should map `AttributeTypeValue.absolute` to Σ", () => {
+		const getAttributeTypeOfNodesByMetricSelector = () => AttributeTypeValue.absolute
+		expect(new AggregationSymbolPipe().transform("some-metric-name", getAttributeTypeOfNodesByMetricSelector)).toBe("Σ")
+	})
+
+	it("should default to Σ", () => {
+		const getAttributeTypeOfNodesByMetricSelector = () => "" as AttributeTypeValue
+		expect(new AggregationSymbolPipe().transform("some-metric-name", getAttributeTypeOfNodesByMetricSelector)).toBe("Σ")
+	})
+})

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.ts
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.ts
@@ -1,10 +1,11 @@
 import { Pipe, PipeTransform } from "@angular/core"
 
 import { AttributeTypeValue } from "../../codeCharta.model"
+import { GetAttributeTypeOfNodesByMetric } from "../../state/selectors/getAttributeTypeOfNodesByMetric.selector"
 
 @Pipe({ name: "aggregationSymbolPipe" })
 export class AggregationSymbolPipe implements PipeTransform {
-	transform(metricName: string, getAttributeTypeOfNodesByMetricSelector: (metricName: string) => AttributeTypeValue): string {
+	transform(metricName: string, getAttributeTypeOfNodesByMetricSelector: GetAttributeTypeOfNodesByMetric): string {
 		const type = getAttributeTypeOfNodesByMetricSelector(metricName)
 		switch (type) {
 			case AttributeTypeValue.relative:

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.ts
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/aggregationSymbol.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from "@angular/core"
+
+import { AttributeTypeValue } from "../../codeCharta.model"
+
+@Pipe({ name: "aggregationSymbolPipe" })
+export class AggregationSymbolPipe implements PipeTransform {
+	transform(metricName: string, getAttributeTypeOfNodesByMetricSelector: (metricName: string) => AttributeTypeValue): string {
+		const type = getAttributeTypeOfNodesByMetricSelector(metricName)
+		switch (type) {
+			case AttributeTypeValue.relative:
+				return "x͂"
+			case AttributeTypeValue.absolute:
+			default:
+				return "Σ"
+		}
+	}
+}

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.html
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.html
@@ -1,21 +1,12 @@
-<md-menu>
-	<div class="small-action-button transparent">
-		<md-button class="md-fab" ng-click="$mdMenu.open($event)" title="Select attribute type">
-			<span class="symbol">{{ $ctrl._viewModel.aggregationSymbol }}</span>
-		</md-button>
-	</div>
-	<md-menu-content width="2">
-		<md-menu-item style="min-height: 20px; height: 20px">
-			<md-button style="min-height: 20px; height: 20px; line-height: 20px; font-size: 9pt; text-align: center" ng-disabled="true"
-				>Set global aggregation for {{ $ctrl.metric }}</md-button
-			>
-		</md-menu-item>
-		<md-divider></md-divider>
-		<md-menu-item>
-			<md-button ng-click="$ctrl.setToAbsolute($ctrl.metric, $ctrl.type)">Σ Sum</md-button>
-		</md-menu-item>
-		<md-menu-item>
-			<md-button ng-click="$ctrl.setToRelative($ctrl.metric, $ctrl.type)">x͂ Median</md-button>
-		</md-menu-item>
-	</md-menu-content>
-</md-menu>
+<div class="small-action-button transparent">
+	<button mat-button [matMenuTriggerFor]="menu" title="Select attribute type" class="menu-button">
+		<span class="symbol">{{ metric | aggregationSymbolPipe: (getAttributeTypeOfNodesByMetric$ | async) }}</span>
+	</button>
+</div>
+
+<mat-menu #menu>
+	<div class="menu-header" mat-menu-item disabled>Set global aggregation for rloc</div>
+	<mat-divider></mat-divider>
+	<button mat-menu-item (click)="setToAbsolute()">Σ Sum</button>
+	<button mat-menu-item (click)="setToRelative()">x͂ Median</button>
+</mat-menu>

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
@@ -1,14 +1,22 @@
 cc-attribute-type-selector {
-	background-color: white;
-	border-radius: 16px;
 	display: inline-block;
-	height: 24px;
-	width: 24px;
-	vertical-align: top;
 
-	.menu-button .symbol {
-		position: absolute;
-		top: -20px;
-		left: 8px;
+	.menu-button {
+		height: 24px;
+		width: 24px;
+		min-width: 0 !important;
+		background-color: white;
+		border-radius: 16px;
+		padding: 0;
+
+		&:hover {
+			background-color: rgb(200, 200, 200);
+		}
+
+		.symbol {
+			position: absolute;
+			top: -6px;
+			left: 8px;
+		}
 	}
 }

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
@@ -6,7 +6,7 @@ cc-attribute-type-selector {
 	.menu-button {
 		height: 24px;
 		width: 24px;
-		min-width: 0 !important;
+		min-width: 0;
 		padding: 0;
 
 		&:hover {

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
@@ -8,14 +8,17 @@ cc-attribute-type-selector {
 		width: 24px;
 		min-width: 0;
 		padding: 0;
+		border-radius: 12px;
+		vertical-align: top;
+		transition: background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 
 		&:hover {
-			background-color: rgb(200, 200, 200);
+			background-color: #c8c8c8;
 		}
 
 		.symbol {
 			position: absolute;
-			top: -7px;
+			top: -5px;
 			left: 8px;
 		}
 	}

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
@@ -1,33 +1,14 @@
-attribute-type-selector-component {
-	& .small-action-button {
-		background-color: white;
-		border-radius: 16px;
-		display: inline-block;
-		height: 24px;
-		width: 24px;
-		vertical-align: top;
+cc-attribute-type-selector {
+	background-color: white;
+	border-radius: 16px;
+	display: inline-block;
+	height: 24px;
+	width: 24px;
+	vertical-align: top;
 
-		.md-fab {
-			min-height: 0;
-			width: 100%;
-			height: 100%;
-			margin: 0;
-			text-transform: unset !important;
-
-			.symbol {
-				position: absolute;
-				top: -16px;
-				left: 8px;
-			}
-		}
-
-		&.transparent .md-fab {
-			background-color: rgba(230, 230, 230, 0.96);
-			box-shadow: none;
-
-			&:hover {
-				background-color: rgb(200, 200, 200) !important;
-			}
-		}
+	.menu-button .symbol {
+		position: absolute;
+		top: -20px;
+		left: 8px;
 	}
 }

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.scss
@@ -1,12 +1,12 @@
 cc-attribute-type-selector {
 	display: inline-block;
+	background-color: white;
+	border-radius: 12px;
 
 	.menu-button {
 		height: 24px;
 		width: 24px;
 		min-width: 0 !important;
-		background-color: white;
-		border-radius: 16px;
 		padding: 0;
 
 		&:hover {
@@ -15,7 +15,7 @@ cc-attribute-type-selector {
 
 		.symbol {
 			position: absolute;
-			top: -6px;
+			top: -7px;
 			left: 8px;
 		}
 	}

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.ts
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.component.ts
@@ -4,7 +4,10 @@ import { Observable } from "rxjs"
 import { AttributeTypeValue } from "../../codeCharta.model"
 import { updateAttributeType } from "../../state/store/fileSettings/attributeTypes/attributeTypes.actions"
 import { Store } from "../../state/angular-redux/store"
-import { getAttributeTypeOfNodesByMetricSelector } from "../../state/selectors/getAttributeTypeOfNodesByMetric.selector"
+import {
+	GetAttributeTypeOfNodesByMetric,
+	getAttributeTypeOfNodesByMetricSelector
+} from "../../state/selectors/getAttributeTypeOfNodesByMetric.selector"
 
 @Component({
 	selector: "cc-attribute-type-selector",
@@ -13,7 +16,7 @@ import { getAttributeTypeOfNodesByMetricSelector } from "../../state/selectors/g
 export class AttributeTypeSelectorComponent {
 	@Input() metric: string
 
-	getAttributeTypeOfNodesByMetric$: Observable<(metricName: string) => AttributeTypeValue>
+	getAttributeTypeOfNodesByMetric$: Observable<GetAttributeTypeOfNodesByMetric>
 
 	constructor(@Inject(Store) private store: Store) {
 		this.getAttributeTypeOfNodesByMetric$ = this.store.select(getAttributeTypeOfNodesByMetricSelector)

--- a/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.module.ts
+++ b/visualization/app/codeCharta/ui/attributeTypeSelector/attributeTypeSelector.module.ts
@@ -1,7 +1,13 @@
-import "../../state/state.module"
-import angular from "angular"
-import { attributeTypeSelectorComponent } from "./attributeTypeSelector.component"
+import { NgModule } from "@angular/core"
+import { CommonModule } from "@angular/common"
 
-angular
-	.module("app.codeCharta.ui.attributeTypeSelector", ["app.codeCharta.state"])
-	.component(attributeTypeSelectorComponent.selector, attributeTypeSelectorComponent)
+import { AttributeTypeSelectorComponent } from "./attributeTypeSelector.component"
+import { MaterialModule } from "../../../material/material.module"
+import { AggregationSymbolPipe } from "./aggregationSymbol.pipe"
+
+@NgModule({
+	imports: [CommonModule, MaterialModule],
+	declarations: [AttributeTypeSelectorComponent, AggregationSymbolPipe],
+	exports: [AttributeTypeSelectorComponent]
+})
+export class AttributeTypeSelectorModule {}

--- a/visualization/app/codeCharta/ui/ui.ts
+++ b/visualization/app/codeCharta/ui/ui.ts
@@ -4,7 +4,6 @@ import { downgradeComponent } from "@angular/upgrade/static"
 import "./artificialIntelligence/artificialIntelligence.module"
 import "./customColorPicker/customColorPicker.module"
 import "./customConfigs/customConfigs.module"
-import "./attributeTypeSelector/attributeTypeSelector.module"
 import "./unfocusButton/unfocusButton.module"
 import "./metricValueHovered/metricValueHovered.module"
 import "./downloadButton/downloadButton.module"
@@ -47,13 +46,13 @@ import { MapTreeViewComponent } from "./mapTreeView/mapTreeView.component"
 import { SortingOptionComponent } from "./sortingOption/sortingOption.component"
 import { MatchingFilesCounterComponent } from "./matchingFilesCounter/matchingFilesCounter.component"
 import { SortingButtonComponent } from "./sortingButton/sortingButton.component"
+import { AttributeTypeSelectorComponent } from "./attributeTypeSelector/attributeTypeSelector.component"
 
 angular
 	.module("app.codeCharta.ui", [
 		"app.codeCharta.ui.artificialIntelligence",
 		"app.codeCharta.ui.customColorPicker",
 		"app.codeCharta.ui.customConfigs",
-		"app.codeCharta.ui.attributeTypeSelector",
 		"app.codeCharta.ui.unfocusButton",
 		"app.codeCharta.ui.metricValueHovered",
 		"app.codeCharta.ui.downloadButton",
@@ -98,3 +97,4 @@ angular
 	.directive("ccMetricDeltaSelected", downgradeComponent({ component: MetricDeltaSelectedComponent }))
 	.directive("ccMapTreeView", downgradeComponent({ component: MapTreeViewComponent }))
 	.directive("ccMatchingFilesCounter", downgradeComponent({ component: MatchingFilesCounterComponent }))
+	.directive("ccAttributeTypeSelector", downgradeComponent({ component: AttributeTypeSelectorComponent }))

--- a/visualization/app/material/matMenu.scss
+++ b/visualization/app/material/matMenu.scss
@@ -1,16 +1,16 @@
 .mat-menu-content {
+	// overwrite global app.scss style
+	button {
+		margin: unset;
+	}
+
 	.menu-header {
 		font-size: 9pt;
 		height: 20px;
 		line-height: 20px;
 	}
 
-	// overwrite global app.scss style
-	button {
-		margin: unset;
+	.mat-menu-item {
+		font-size: 16px;
 	}
-}
-
-.mat-menu-item {
-	font-size: 16px;
 }

--- a/visualization/app/material/matMenu.scss
+++ b/visualization/app/material/matMenu.scss
@@ -4,9 +4,7 @@
 		height: 20px;
 		line-height: 20px;
 	}
-}
 
-.mat-menu-content {
 	// overwrite global app.scss style
 	button {
 		margin: unset;

--- a/visualization/app/material/matMenu.scss
+++ b/visualization/app/material/matMenu.scss
@@ -1,0 +1,18 @@
+.mat-menu-content {
+	.menu-header {
+		font-size: 9pt;
+		height: 20px;
+		line-height: 20px;
+	}
+}
+
+.mat-menu-content {
+	// overwrite global app.scss style
+	button {
+		margin: unset;
+	}
+}
+
+.mat-menu-item {
+	font-size: 16px;
+}

--- a/visualization/app/material/material.module.ts
+++ b/visualization/app/material/material.module.ts
@@ -1,11 +1,14 @@
 import { NgModule } from "@angular/core"
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations"
 import { MatSelectModule } from "@angular/material/select"
+import { MatMenuModule } from "@angular/material/menu"
+import { MatButtonModule } from "@angular/material/button"
+import { MatDividerModule } from "@angular/material/divider"
 
-const materialComponents = [MatSelectModule]
+const materialModules = [MatSelectModule, MatMenuModule, MatButtonModule, MatDividerModule]
 
 @NgModule({
-	imports: [BrowserAnimationsModule, materialComponents],
-	exports: [materialComponents]
+	imports: [BrowserAnimationsModule, materialModules],
+	exports: [materialModules]
 })
 export class MaterialModule {}

--- a/visualization/app/material/material.scss
+++ b/visualization/app/material/material.scss
@@ -1,3 +1,4 @@
 @import "~@angular/material/prebuilt-themes/indigo-pink.css";
 
 @import "./matSelect.scss";
+@import "./matMenu.scss";


### PR DESCRIPTION
- Removed type `"edges"` as it was unused.
- Marginal changes in look like menu items `font-size: 15px` -> `font-size: 16px` as it looks better to me. I think not worth any discussion or mention in changelog.