### PR TITLE
Remove deprecated and conflicting webpack 4 loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Remove `secondaryMetrics` from store and remove `secondaryMetrics.service` as the data can be derived from selected node [#2527](https://github.com/MaibornWolff/codecharta/pull/2527).
 -   Migrate `attribute-side-bar-component` to Angular [#2527](https://github.com/MaibornWolff/codecharta/pull/2527).
+-   Switch from Webpack 4 Loaders to Asset Module to load icons properly with css-loader 6.x [#2542](https://github.com/MaibornWolff/codecharta/pull/2542).
 
 ## [1.84.1] - 2021-11-29
 

--- a/visualization/conf/webpack.loaders.js
+++ b/visualization/conf/webpack.loaders.js
@@ -20,12 +20,8 @@ module.exports = {
 			use: ["style-loader", "css-loader", "sass-loader"]
 		},
 		{
-			test: /\.(png|svg|jpg|gif)$/,
-			use: ["file-loader"]
-		},
-		{
-			test: /\.(woff|woff2|eot|ttf|otf)$/,
-			use: ["file-loader"]
+			test: /\.(jpe?g|svg|png|gif|ico|eot|otf|ttf|woff2?)(\?v=\d+\.\d+\.\d+)?$/i,
+			type: "asset/resource"
 		},
 		{
 			test: /\.ts(x?)$/,


### PR DESCRIPTION
# Fix broken font-awesome icons

- Remove deprecated and conflicting webpack 4 loaders and use Asset Module loaders as described [here](https://stackoverflow.com/questions/68839232/webpack-5-issues-with-fonts-getting-failed-to-decode-ots-parsing-error)

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Close: #2541
