### PR TITLE
Fix/2480/loading formerly loaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Fix delta values of secondary metrics not shown in delta mode within attribute side bar [#2539](https://github.com/MaibornWolff/codecharta/issues/2539).
 -   Use icon tag instead of font awesome icon [#2537](https://github.com/MaibornWolff/codecharta/pull/2537).
+-   Identical files and files with identical file names but different hashes can be loaded [#2548](https://github.com/MaibornWolff/codecharta/pull/2548)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/assets/sample1.cc.json
+++ b/visualization/app/codeCharta/assets/sample1.cc.json
@@ -1,7 +1,7 @@
 {
 	"projectName": "Sample Project with Edges",
 	"apiVersion": "1.2",
-	"fileChecksum": "invalid-md5-sample",
+	"fileChecksum": "valid-md5-sample1",
 	"nodes": [
 		{
 			"name": "root",

--- a/visualization/app/codeCharta/assets/sample2.cc.json
+++ b/visualization/app/codeCharta/assets/sample2.cc.json
@@ -1,7 +1,7 @@
 {
 	"projectName": "Sample Project",
 	"apiVersion": "1.2",
-	"fileChecksum": "invalid-md5-sample",
+	"fileChecksum": "valid-md5-sample2",
 	"nodes": [
 		{
 			"name": "root",

--- a/visualization/app/codeCharta/assets/sample3.cc.json
+++ b/visualization/app/codeCharta/assets/sample3.cc.json
@@ -1,6 +1,6 @@
 {
 	"projectName": "Sample Project",
-	"fileChecksum": "invalid-md5-sample",
+	"fileChecksum": "valid-md5-sample",
 	"apiVersion": "1.2",
 	"nodes": [
 		{

--- a/visualization/app/codeCharta/assets/sample4.cc.json
+++ b/visualization/app/codeCharta/assets/sample4.cc.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Sample Project 4",
-  "fileChecksum": "invalid-md5-sample",
+  "fileChecksum": "valid-md5-sample-1",
   "apiVersion": "1.2",
   "nodes": [
     {

--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -162,13 +162,7 @@ describe("codeChartaService", () => {
 			const validContent2ndFile = klona(validFileContent)
 			validContent2ndFile.fileChecksum = "validHash_1"
 
-			await codeChartaService.loadFiles([
-				{
-					fileName: "FirstFile",
-					content: validFileContent,
-					fileSize: 42
-				}
-			])
+			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
 			await codeChartaService.loadFiles([
 				{ fileName: "FirstFile", content: validFileContent, fileSize: 42 },
@@ -177,7 +171,56 @@ describe("codeChartaService", () => {
 
 			expect(getCCFiles(storeService.getState().files).length).toEqual(2)
 			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
 			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("SecondFile")
+			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
+		})
+
+		it("should load files with equal file name but different checksum and rename uploaded files ", async () => {
+			const validContent2ndFile = klona(validFileContent)
+			validContent2ndFile.fileChecksum = "validHash_1"
+			const validContent3ndFile = klona(validFileContent)
+			validContent3ndFile.fileChecksum = "validHash_2"
+
+			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
+
+			await codeChartaService.loadFiles([
+				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 },
+				{ fileName: "FirstFile", content: validContent3ndFile, fileSize: 42 }
+			])
+
+			expect(getCCFiles(storeService.getState().files).length).toEqual(3)
+			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
+			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("FirstFile_1")
+			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileName).toEqual("FirstFile_2")
+			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileChecksum).toEqual("validHash_2")
+		})
+
+		it("should not load files with equal file name and checksum when there was a renaming of file names in previous uploads", async () => {
+			const validContent2ndFile = klona(validFileContent)
+			validContent2ndFile.fileChecksum = "validHash_1"
+			const validContent3ndFile = klona(validFileContent)
+			validContent3ndFile.fileChecksum = "validHash_2"
+
+			await codeChartaService.loadFiles([
+				{ fileName: "FirstFile", content: validFileContent, fileSize: 42 },
+				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 }
+			])
+
+			await codeChartaService.loadFiles([
+				{ fileName: "FirstFile", content: validContent3ndFile, fileSize: 42 },
+				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 }
+			])
+
+			expect(getCCFiles(storeService.getState().files).length).toEqual(3)
+			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
+			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("FirstFile_1")
+			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileName).toEqual("FirstFile_2")
+			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileChecksum).toEqual("validHash_2")
 		})
 
 		it("should select the newly added file", async () => {

--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -159,68 +159,89 @@ describe("codeChartaService", () => {
 		})
 
 		it("should replace files with equal file name and checksum when loading new files", async () => {
-			const validContent2ndFile = klona(validFileContent)
-			validContent2ndFile.fileChecksum = "validHash_1"
+			const valid2ndFileContent = klona(validFileContent)
+			valid2ndFileContent.fileChecksum = "validHash_1"
 
 			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
 			await codeChartaService.loadFiles([
 				{ fileName: "FirstFile", content: validFileContent, fileSize: 42 },
-				{ fileName: "SecondFile", content: validContent2ndFile, fileSize: 42 }
+				{ fileName: "SecondFile", content: valid2ndFileContent, fileSize: 42 }
 			])
 
-			expect(getCCFiles(storeService.getState().files).length).toEqual(2)
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("SecondFile")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			const CCFilesUnderTest = getCCFiles(storeService.getState().files)
+
+			expect(CCFilesUnderTest.length).toEqual(2)
+			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
+			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("SecondFile")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
 		})
 
 		it("should load files with equal file name but different checksum and rename uploaded files ", async () => {
-			const validContent2ndFile = klona(validFileContent)
-			validContent2ndFile.fileChecksum = "validHash_1"
-			const validContent3ndFile = klona(validFileContent)
-			validContent3ndFile.fileChecksum = "validHash_2"
+			const valid2ndFileContent = klona(validFileContent)
+			valid2ndFileContent.fileChecksum = "validHash_1"
+			const valid3rdFileContent = klona(validFileContent)
+			valid3rdFileContent.fileChecksum = "validHash_2"
 
 			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
 			await codeChartaService.loadFiles([
-				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 },
-				{ fileName: "FirstFile", content: validContent3ndFile, fileSize: 42 }
+				{ fileName: "FirstFile", content: valid2ndFileContent, fileSize: 42 },
+				{ fileName: "FirstFile", content: valid3rdFileContent, fileSize: 42 }
 			])
 
-			expect(getCCFiles(storeService.getState().files).length).toEqual(3)
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("FirstFile_1")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
-			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileName).toEqual("FirstFile_2")
-			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileChecksum).toEqual("validHash_2")
+			const CCFilesUnderTest = getCCFiles(storeService.getState().files)
+
+			expect(CCFilesUnderTest.length).toEqual(3)
+			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
+			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("FirstFile_1")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(CCFilesUnderTest[2].fileMeta.fileName).toEqual("FirstFile_2")
+			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("validHash_2")
 		})
 
 		it("should not load files with equal file name and checksum when there was a renaming of file names in previous uploads", async () => {
-			const validContent2ndFile = klona(validFileContent)
-			validContent2ndFile.fileChecksum = "validHash_1"
-			const validContent3ndFile = klona(validFileContent)
-			validContent3ndFile.fileChecksum = "validHash_2"
+			const valid2ndFileContent = klona(validFileContent)
+			valid2ndFileContent.fileChecksum = "validHash_1"
+			const valid3rdFileContent = klona(validFileContent)
+			valid3rdFileContent.fileChecksum = "validHash_2"
 
 			await codeChartaService.loadFiles([
 				{ fileName: "FirstFile", content: validFileContent, fileSize: 42 },
-				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 }
+				{ fileName: "FirstFile", content: valid2ndFileContent, fileSize: 42 }
 			])
 
 			await codeChartaService.loadFiles([
-				{ fileName: "FirstFile", content: validContent3ndFile, fileSize: 42 },
-				{ fileName: "FirstFile", content: validContent2ndFile, fileSize: 42 }
+				{ fileName: "FirstFile", content: valid3rdFileContent, fileSize: 42 },
+				{ fileName: "FirstFile", content: valid2ndFileContent, fileSize: 42 }
 			])
 
-			expect(getCCFiles(storeService.getState().files).length).toEqual(3)
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileName).toEqual("FirstFile")
-			expect(getCCFiles(storeService.getState().files)[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileName).toEqual("FirstFile_1")
-			expect(getCCFiles(storeService.getState().files)[1].fileMeta.fileChecksum).toEqual("validHash_1")
-			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileName).toEqual("FirstFile_2")
-			expect(getCCFiles(storeService.getState().files)[2].fileMeta.fileChecksum).toEqual("validHash_2")
+			const CCFilesUnderTest = getCCFiles(storeService.getState().files)
+
+			expect(CCFilesUnderTest.length).toEqual(3)
+			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
+			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("FirstFile_1")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(CCFilesUnderTest[2].fileMeta.fileName).toEqual("FirstFile_2")
+			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("validHash_2")
+		})
+
+		it("should not load broken file but after fixing this problem manually it should possible to load this file again", async () => {
+			const invalidFileContent = klona(validFileContent)
+			invalidFileContent.apiVersion = ""
+
+			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: invalidFileContent, fileSize: 42 }])
+
+			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
+
+			const CCFilesUnderTest = getCCFiles(storeService.getState().files)
+
+			expect(CCFilesUnderTest.length).toEqual(1)
+			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
+			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
 		})
 
 		it("should select the newly added file", async () => {

--- a/visualization/app/codeCharta/codeCharta.service.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.service.spec.ts
@@ -160,7 +160,7 @@ describe("codeChartaService", () => {
 
 		it("should replace files with equal file name and checksum when loading new files", async () => {
 			const valid2ndFileContent = klona(validFileContent)
-			valid2ndFileContent.fileChecksum = "validHash_1"
+			valid2ndFileContent.fileChecksum = "hash_1"
 
 			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
@@ -175,14 +175,14 @@ describe("codeChartaService", () => {
 			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
 			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
 			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("SecondFile")
-			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("hash_1")
 		})
 
 		it("should load files with equal file name but different checksum and rename uploaded files ", async () => {
 			const valid2ndFileContent = klona(validFileContent)
-			valid2ndFileContent.fileChecksum = "validHash_1"
+			valid2ndFileContent.fileChecksum = "hash_1"
 			const valid3rdFileContent = klona(validFileContent)
-			valid3rdFileContent.fileChecksum = "validHash_2"
+			valid3rdFileContent.fileChecksum = "hash_2"
 
 			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
@@ -197,16 +197,16 @@ describe("codeChartaService", () => {
 			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
 			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
 			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("FirstFile_1")
-			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("hash_1")
 			expect(CCFilesUnderTest[2].fileMeta.fileName).toEqual("FirstFile_2")
-			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("validHash_2")
+			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("hash_2")
 		})
 
 		it("should not load files with equal file name and checksum when there was a renaming of file names in previous uploads", async () => {
 			const valid2ndFileContent = klona(validFileContent)
-			valid2ndFileContent.fileChecksum = "validHash_1"
+			valid2ndFileContent.fileChecksum = "hash_1"
 			const valid3rdFileContent = klona(validFileContent)
-			valid3rdFileContent.fileChecksum = "validHash_2"
+			valid3rdFileContent.fileChecksum = "hash_2"
 
 			await codeChartaService.loadFiles([
 				{ fileName: "FirstFile", content: validFileContent, fileSize: 42 },
@@ -224,9 +224,9 @@ describe("codeChartaService", () => {
 			expect(CCFilesUnderTest[0].fileMeta.fileName).toEqual("FirstFile")
 			expect(CCFilesUnderTest[0].fileMeta.fileChecksum).toEqual("invalid-md5-sample")
 			expect(CCFilesUnderTest[1].fileMeta.fileName).toEqual("FirstFile_1")
-			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("validHash_1")
+			expect(CCFilesUnderTest[1].fileMeta.fileChecksum).toEqual("hash_1")
 			expect(CCFilesUnderTest[2].fileMeta.fileName).toEqual("FirstFile_2")
-			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("validHash_2")
+			expect(CCFilesUnderTest[2].fileMeta.fileChecksum).toEqual("hash_2")
 		})
 
 		it("should not load broken file but after fixing this problem manually it should possible to load this file again", async () => {
@@ -245,12 +245,12 @@ describe("codeChartaService", () => {
 		})
 
 		it("should select the newly added file", async () => {
-			const validContent2ndFile = klona(validFileContent)
-			validContent2ndFile.fileChecksum = "validHash_1"
+			const valid2ndFileContent = klona(validFileContent)
+			valid2ndFileContent.fileChecksum = "hash_1"
 
 			await codeChartaService.loadFiles([{ fileName: "FirstFile", content: validFileContent, fileSize: 42 }])
 
-			await codeChartaService.loadFiles([{ fileName: "SecondFile", content: validContent2ndFile, fileSize: 42 }])
+			await codeChartaService.loadFiles([{ fileName: "SecondFile", content: valid2ndFileContent, fileSize: 42 }])
 
 			expect(storeService.getState().files[0].selectedAs).toEqual("None")
 			expect(storeService.getState().files[1].selectedAs).toEqual("Single")

--- a/visualization/app/codeCharta/codeCharta.service.ts
+++ b/visualization/app/codeCharta/codeCharta.service.ts
@@ -75,7 +75,7 @@ export class CodeChartaService {
 		const isDuplicate = storedFileChecksums.has(currentFileChecksum)
 
 		if (storedFileNames.has(currentFileName)) {
-			currentFileName = this.findFileName(currentFileName, isDuplicate, storedFileNames, currentFileChecksum)
+			currentFileName = this.getFileName(currentFileName, storedFileNames, currentFileChecksum)
 			ccFile.fileMeta.fileName = currentFileName
 		}
 		if (isDuplicate) {
@@ -89,7 +89,7 @@ export class CodeChartaService {
 		this.recentFiles.push(currentFileName)
 	}
 
-	private findFileName(currentFileName: string, isDuplicate: boolean, storedFileNames: Map<string, string>, currentFileChecksum: string) {
+	private getFileName(currentFileName: string, storedFileNames: Map<string, string>, currentFileChecksum: string) {
 		if (storedFileNames.get(currentFileName) === currentFileChecksum) {
 			return currentFileName
 		}
@@ -97,22 +97,21 @@ export class CodeChartaService {
 		let nameFound = false
 		let fileNameOccurrence = 1
 		let newFileName = currentFileName
+
 		while (!nameFound) {
-			newFileName = currentFileName.replace(currentFileName, `${currentFileName.split(".")[0]}_${fileNameOccurrence}.cc.json`)
 			const endOfNameIndex = currentFileName.indexOf(".")
 			newFileName =
 				endOfNameIndex >= 0
 					? [currentFileName.slice(0, endOfNameIndex), "_", fileNameOccurrence, currentFileName.slice(endOfNameIndex)].join("")
 					: `${currentFileName}_${fileNameOccurrence}`
 			// resolve if uploaded file has identical checksum and different already occurring name
-			if (isDuplicate && storedFileNames.has(newFileName) && storedFileNames.get(newFileName) === currentFileChecksum) {
+			if (storedFileNames.get(newFileName) === currentFileChecksum) {
 				nameFound = true
 			}
 			if (!storedFileNames.has(newFileName)) {
 				nameFound = true
-			} else {
-				fileNameOccurrence++
 			}
+			fileNameOccurrence++
 		}
 		return newFileName
 	}

--- a/visualization/app/codeCharta/codeCharta.service.ts
+++ b/visualization/app/codeCharta/codeCharta.service.ts
@@ -107,8 +107,7 @@ export class CodeChartaService {
 			// resolve if uploaded file has identical checksum and different already occurring name
 			if (storedFileNames.get(newFileName) === currentFileChecksum) {
 				nameFound = true
-			}
-			if (!storedFileNames.has(newFileName)) {
+			} else if (!storedFileNames.has(newFileName)) {
 				nameFound = true
 			}
 			fileNameOccurrence++

--- a/visualization/app/codeCharta/util/fileValidator.spec.ts
+++ b/visualization/app/codeCharta/util/fileValidator.spec.ts
@@ -12,28 +12,13 @@ import assert from "assert"
 import { fileWithFixedFolders, fileWithFixedOverlappingSubFolders } from "../resources/fixed-folders/fixed-folders-example"
 import { APIVersions, ExportCCFile } from "../codeCharta.api.model"
 import { clone } from "./clone"
-import { getService } from "../../../mocks/ng.mockhelper"
-import { StoreService } from "../state/store.service"
-import { IRootScopeService } from "angular"
 
 describe("FileValidator", () => {
 	let file: ExportCCFile
-	let storeService: StoreService
-	let $rootScope: IRootScopeService
 
 	beforeEach(() => {
-		restartSystem()
-		rebuildService()
 		file = clone(TEST_FILE_CONTENT)
 	})
-
-	function restartSystem() {
-		$rootScope = getService<IRootScopeService>("$rootScope")
-	}
-
-	function rebuildService() {
-		storeService = new StoreService($rootScope)
-	}
 
 	it("API version exists in package.json", () => {
 		expect(packageJson.codecharta.apiVersion).toEqual("1.3")
@@ -46,7 +31,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(null, storeService)
+			validate(null)
 		}, expectedError)
 	})
 
@@ -63,7 +48,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -80,7 +65,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -97,7 +82,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -114,7 +99,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -132,7 +117,7 @@ describe("FileValidator", () => {
 
 		const nameDataPair: NameDataPair = { fileName: "fileName", fileSize: 30, content: file }
 
-		validate(nameDataPair, storeService)
+		validate(nameDataPair)
 	})
 
 	it("should not throw on a file without edges", () => {
@@ -140,7 +125,7 @@ describe("FileValidator", () => {
 
 		const nameDataPair: NameDataPair = { fileName: "fileName", fileSize: 30, content: file }
 
-		validate(nameDataPair, storeService)
+		validate(nameDataPair)
 	})
 
 	it("should not throw on a file when numbers are floating point values", () => {
@@ -148,7 +133,7 @@ describe("FileValidator", () => {
 
 		const nameDataPair: NameDataPair = { fileName: "fileName", fileSize: 30, content: file }
 
-		validate(nameDataPair, storeService)
+		validate(nameDataPair)
 	})
 
 	it("should throw when children are not unique in name+type", () => {
@@ -164,7 +149,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -179,7 +164,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -200,7 +185,7 @@ describe("FileValidator", () => {
 		}
 
 		assert.throws(() => {
-			validate(nameDataPair, storeService)
+			validate(nameDataPair)
 		}, expectedError)
 	})
 
@@ -221,7 +206,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 	})
@@ -244,7 +229,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -259,7 +244,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -274,7 +259,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -289,7 +274,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -318,7 +303,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -347,7 +332,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -376,7 +361,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -400,7 +385,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -414,7 +399,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 
@@ -428,7 +413,7 @@ describe("FileValidator", () => {
 			}
 
 			assert.throws(() => {
-				validate(nameDataPair, storeService)
+				validate(nameDataPair)
 			}, expectedError)
 		})
 	})

--- a/visualization/app/codeCharta/util/fileValidator.ts
+++ b/visualization/app/codeCharta/util/fileValidator.ts
@@ -4,7 +4,6 @@ import packageJson from "../../../package.json"
 import { ExportCCFile } from "../codeCharta.api.model"
 import jsonSchema from "./generatedSchema.json"
 import { isLeaf } from "./codeMapHelper"
-import { FileState } from "../model/files/files"
 
 const latestApiVersion = packageJson.codecharta.apiVersion
 
@@ -33,9 +32,8 @@ export const ERROR_MESSAGES = {
 	blacklistError: "Excluding all buildings is not possible."
 }
 
-export function validate(nameDataPair: NameDataPair, fileStates: FileState[]) {
+export function validate(nameDataPair: NameDataPair) {
 	const file = nameDataPair?.content
-	const fileName = nameDataPair?.fileName
 	const result: CCValidationResult = { error: [], warning: [] }
 	switch (true) {
 		case !file:
@@ -49,9 +47,6 @@ export function validate(nameDataPair: NameDataPair, fileStates: FileState[]) {
 			break
 		case fileHasHigherMinorVersion(file):
 			result.warning.push(`${ERROR_MESSAGES.minorApiVersionOutdated} Found: ${file.apiVersion}`)
-			break
-		case fileAlreadyExists(fileName, file, fileStates):
-			result.error.push(ERROR_MESSAGES.fileAlreadyExists)
 			break
 	}
 
@@ -91,16 +86,6 @@ function fileHasHigherMajorVersion(file: ExportCCFile) {
 function fileHasHigherMinorVersion(file: ExportCCFile) {
 	const apiVersion = getAsApiVersion(file.apiVersion)
 	return apiVersion.minor > getAsApiVersion(latestApiVersion).minor
-}
-
-function fileAlreadyExists(currentFileName: string, file: ExportCCFile, fileStates: FileState[]) {
-	for (const recentFile of fileStates) {
-		const { fileName, fileChecksum } = recentFile.file.fileMeta
-		if (fileName === currentFileName && fileChecksum === file.fileChecksum) {
-			return true
-		}
-	}
-	return false
 }
 
 export function getAsApiVersion(version: string): ApiVersion {


### PR DESCRIPTION
# Loading formerly loaded files

Close: #2480 

## Description

Problem:
- User could not load identical files (equal file name and MD5 hash) into CodeCharta

Solution:
- Now user can upload identical files (equal file name and MD5 hash) without any error messages into CodeCharta, but only one file is showed
- Now user can upload files with different files names but same MD5 hashes, replacing the previous file name with the new one
- Now user can upload files with equal file names but different MD5 hashes, adding a number to the file names to better distinguish the files

