### PR TITLE
chore: skip sonar-java-plugin updates with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
 		{
 			"matchPaths": ["build.gradle"],
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"excludePackageNames": ["org.sonarsource.java:sonar-java-plugin"],
 			"groupName": "gradle dependencies not Major update",
 			"enabled": true
 		},
@@ -29,6 +30,12 @@
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
 			"groupName": "other updates",
 			"enabled": true
+		},
+		{
+			"matchPackageNames": ["@types/three", "org.sonarsource.java:sonar-java-plugin", "three"],
+			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"groupName": "Almost always breaking changes",
+			"enabled": false
 		}
 	],
 	"timezone": "Europe/Berlin",


### PR DESCRIPTION
As discussed. I am not certain if it works as expected but this is likely a good starting point.