### PR TITLE
Feature/2489/remove-notification-when-deleting-custom-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Migrate `attribute-side-bar-component` to Angular [#2527](https://github.com/MaibornWolff/codecharta/pull/2527).
 -   Switch from Webpack 4 Loaders to Asset Module to load icons properly with css-loader 6.x [#2542](https://github.com/MaibornWolff/codecharta/pull/2542).
 
+### Removed 🗑
+
+-   Remove notification dialog when deleting a custom config [#2553](https://github.com/MaibornWolff/codecharta/pull/2553)
+
 ## [1.84.1] - 2021-11-29
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.html
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.html
@@ -50,21 +50,21 @@
 							class="button-hovering"
 							ng-click="$ctrl.applyCustomConfig(customConfig.id)"
 							ng-disabled="!customConfig.isApplicable"
+						>
 							title="{{
 								customConfig.isApplicable
-									? 'Apply Custom Config'
-									: 'This one is applicable for map(s) ' +
+									? "Apply Custom Config"
+									: "This one is applicable for map(s) " +
 									  customConfig.mapNames +
-									  ' in ' +
+									  " in " +
 									  customConfig.mapSelectionMode +
-									  ' mode only.'
-							}}"
-						>
+									  " mode only."
+							}}" >
 							{{ customConfig.name }}
 						</md-button>
 
 						<md-button
-							ng-click="$ctrl.removeCustomConfig(customConfig.id, customConfig.name)"
+							ng-click="$ctrl.removeCustomConfig(customConfig.id)"
 							class="action-button remove button-hovering"
 							title="Remove Custom Config"
 						>

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.spec.ts
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.spec.ts
@@ -132,16 +132,13 @@ describe("CustomConfigsController", () => {
 	})
 
 	describe("removeCustomConfig", () => {
-		it("should call deleteCustomConfig and show InfoDialog afterwards", () => {
+		it("should call deleteCustomConfig", () => {
 			CustomConfigHelper.deleteCustomConfig = jest.fn()
-			dialogService.showInfoDialog = jest.fn()
 
-			const configNameToRemove = "CustomConfigName1"
 			const configIdToRemove = 1
-			customConfigsController.removeCustomConfig(configIdToRemove, configNameToRemove)
+			customConfigsController.removeCustomConfig(configIdToRemove)
 
 			expect(CustomConfigHelper.deleteCustomConfig).toHaveBeenCalledWith(configIdToRemove)
-			expect(dialogService.showInfoDialog).toHaveBeenCalledWith(expect.stringContaining(`${configNameToRemove} deleted`))
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.ts
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.ts
@@ -74,9 +74,8 @@ export class CustomConfigsController implements FilesSelectionSubscriber {
 		CustomConfigHelper.applyCustomConfig(configId, this.storeService, this.threeCameraService, this.threeOrbitControlsService)
 	}
 
-	removeCustomConfig(configId, configName) {
+	removeCustomConfig(configId) {
 		CustomConfigHelper.deleteCustomConfig(configId)
-		this.dialogService.showInfoDialog(`${configName} deleted.`)
 	}
 
 	downloadPreloadedCustomConfigs() {

--- a/visualization/app/codeCharta/ui/dialog/dialog.service.ts
+++ b/visualization/app/codeCharta/ui/dialog/dialog.service.ts
@@ -34,10 +34,6 @@ export class DialogService {
 		this.$mdDialog.show(dialog)
 	}
 
-	showInfoDialog(message, title = "Info", button = "Ok") {
-		this.$mdDialog.show(this.$mdDialog.alert().clickOutsideToClose(true).title(title).htmlContent(message).ok(button))
-	}
-
 	async showErrorDialog(message = "An error occurred.", title = "Error", button = "Ok") {
 		await this.$mdDialog.show(this.$mdDialog.alert().clickOutsideToClose(true).title(title).htmlContent(message).ok(button))
 	}


### PR DESCRIPTION
# Removing of notification dialog when custom config is deleted

Issue: #2489 

## Description

  - When a user deletes a custom config then a notification dialog (that something is deleted) appears that disrupts the user experience.
  - Removing this notification dialog solves this problem.