### PR TITLE
Fix/2556/Broken-Custom-Config-Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+## Fixed 🐞
+
+-   Fix showing names of custom configs properly [#2557](https://github.com/MaibornWolff/codecharta/pull/2557)
+
 ## [1.85.0] - 2021-12-13
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.html
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigs.component.html
@@ -50,16 +50,16 @@
 							class="button-hovering"
 							ng-click="$ctrl.applyCustomConfig(customConfig.id)"
 							ng-disabled="!customConfig.isApplicable"
-						>
 							title="{{
 								customConfig.isApplicable
-									? "Apply Custom Config"
-									: "This one is applicable for map(s) " +
+									? 'Apply Custom Config'
+									: 'This one is applicable for map(s) ' +
 									  customConfig.mapNames +
-									  " in " +
+									  ' in ' +
 									  customConfig.mapSelectionMode +
-									  " mode only."
-							}}" >
+									  ' mode only.'
+							}}"
+						>
 							{{ customConfig.name }}
 						</md-button>
 


### PR DESCRIPTION
# Broken Custom Config Names

Closes: #2556

## Description

  - Custom config names weren't displayed correctly because a html element was broken.
