### PR TITLE
Fix/2523/Relink to news page when clicking 'Know more' button in changelog dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   User-friendly renaming for display quality options [#2601](https://github.com/MaibornWolff/codecharta/pull/2601)
 
+### Fixed 🐞
+
+-   Fix link to news page when clicking 'Know more' button changelog dialog [#2602](https://github.com/MaibornWolff/codecharta/pull/2602)
+
 ## [1.87.0] - 2022-01-11
 
 ### Chore 👨‍💻 👩‍💻

--- a/visualization/app/codeCharta/ui/dialog/dialog.changelog.component.html
+++ b/visualization/app/codeCharta/ui/dialog/dialog.changelog.component.html
@@ -15,7 +15,7 @@
 	</md-dialog-content>
 
 	<md-dialog-actions>
-		<a href="https://maibornwolff.github.io/codecharta/news/" class="md-primary">Know more</a>
+		<a class="md-primary" href="https://maibornwolff.github.io/codecharta/news/" target="_blank" rel="noopener noreferrer">Know more</a>
 		<md-button ng-click="$ctrl.hide()" class="md-secondary">Close</md-button>
 	</md-dialog-actions>
 </md-dialog>


### PR DESCRIPTION
# Relink to news page when clicking 'Know more' button in changelog dialog

Closes: #2523

## Description

- when clicking 'Know more' button in changelog dialog it will open the news page in a new tab