### PR TITLE
refactor: simplify tracking

### DIFF
--- a/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.preRender.service.ts
@@ -20,8 +20,7 @@ import { PresentationModeActions } from "../../state/store/appSettings/isPresent
 import { MetricDataService, MetricDataSubscriber } from "../../state/store/metricData/metricData.service"
 import { ExperimentalFeaturesEnabledActions } from "../../state/store/appSettings/enableExperimentalFeatures/experimentalFeaturesEnabled.actions"
 import { LayoutAlgorithmService, LayoutAlgorithmSubscriber } from "../../state/store/appSettings/layoutAlgorithm/layoutAlgorithm.service"
-import { trackEventUsageData, trackMapMetaData } from "../../util/usageDataTracker"
-import { ColorRangeFromSubscriber, ColorRangeToSubscriber, RangeSliderController } from "../rangeSlider/rangeSlider.component"
+import { trackMapMetaData } from "../../util/usageDataTracker"
 import { HoveredBuildingPathActions } from "../../state/store/appStatus/hoveredBuildingPath/hoveredBuildingPath.actions"
 import { accumulatedDataSelector } from "../../state/selectors/accumulatedData/accumulatedData.selector"
 import { areAllNecessaryRenderDataAvailableSelector } from "../../state/selectors/allNecessaryRenderDataAvailable/areAllNecessaryRenderDataAvailable.selector"
@@ -31,15 +30,7 @@ export interface CodeMapPreRenderServiceSubscriber {
 	onRenderMapChanged(map: CodeMapNode)
 }
 
-export class CodeMapPreRenderService
-	implements
-		StoreSubscriber,
-		MetricDataSubscriber,
-		ScalingSubscriber,
-		LayoutAlgorithmSubscriber,
-		ColorRangeFromSubscriber,
-		ColorRangeToSubscriber
-{
+export class CodeMapPreRenderService implements StoreSubscriber, MetricDataSubscriber, ScalingSubscriber, LayoutAlgorithmSubscriber {
 	private static RENDER_MAP_CHANGED_EVENT = "render-map-changed"
 
 	private unifiedMap: CodeMapNode
@@ -59,8 +50,6 @@ export class CodeMapPreRenderService
 		StoreService.subscribe(this.$rootScope, this)
 		ScalingService.subscribe(this.$rootScope, this)
 		LayoutAlgorithmService.subscribe(this.$rootScope, this)
-		RangeSliderController.subscribeToColorRangeFromUpdated(this.$rootScope, this)
-		RangeSliderController.subscribeToColorRangeToUpdated(this.$rootScope, this)
 
 		this.debounceRendering = debounce(() => {
 			this.renderAndNotify()
@@ -101,14 +90,6 @@ export class CodeMapPreRenderService
 		} else {
 			this.codeMapRenderService.update()
 		}
-	}
-
-	onColorRangeFromUpdated(colorMetric: string, fromValue: number) {
-		trackEventUsageData(RangeSliderController.COLOR_RANGE_FROM_UPDATED, this.storeService.getState().files, { colorMetric, fromValue })
-	}
-
-	onColorRangeToUpdated(colorMetric: string, toValue: number) {
-		trackEventUsageData(RangeSliderController.COLOR_RANGE_TO_UPDATED, this.storeService.getState().files, { colorMetric, toValue })
 	}
 
 	onLayoutAlgorithmChanged() {

--- a/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.ts
+++ b/visualization/app/codeCharta/ui/rangeSlider/rangeSlider.component.ts
@@ -11,14 +11,7 @@ import { isDeltaState } from "../../model/files/files.helper"
 import { BlacklistService, BlacklistSubscriber } from "../../state/store/fileSettings/blacklist/blacklist.service"
 import { NodeMetricDataService } from "../../state/store/metricData/nodeMetricData/nodeMetricData.service"
 import { MapColorsService, MapColorsSubscriber } from "../../state/store/appSettings/mapColors/mapColors.service"
-
-export interface ColorRangeFromSubscriber {
-	onColorRangeFromUpdated(colorMetric: string, fromValue: number)
-}
-
-export interface ColorRangeToSubscriber {
-	onColorRangeToUpdated(colorMetric: string, toValue: number)
-}
+import { trackEventUsageData } from "../../util/usageDataTracker"
 
 export class RangeSliderController
 	implements ColorMetricSubscriber, ColorRangeSubscriber, FilesSelectionSubscriber, BlacklistSubscriber, MapColorsSubscriber
@@ -29,9 +22,6 @@ export class RangeSliderController
 	private MIN_DIGITS = 4
 	private MAX_DIGITS = 6
 	private FULL_WIDTH_SLIDER = 235
-
-	static COLOR_RANGE_FROM_UPDATED = "color-range-from-updated"
-	static COLOR_RANGE_TO_UPDATED = "color-range-to-updated"
 
 	private _viewModel: {
 		colorRangeFrom: number
@@ -145,30 +135,16 @@ export class RangeSliderController
 
 	private applySliderUpdateDone(modelValue, highValue, pointerType) {
 		if (pointerType === "min") {
-			this.broadcastColorRangeFromUpdated(this.storeService.getState().dynamicSettings.colorMetric, modelValue)
+			trackEventUsageData("color-range-from-updated", this.storeService.getState().files, {
+				colorMetric: this.storeService.getState().dynamicSettings.colorMetric,
+				fromValue: modelValue
+			})
 		} else if (pointerType === "max") {
-			this.broadcastColorRangeToUpdated(this.storeService.getState().dynamicSettings.colorMetric, highValue)
+			trackEventUsageData("color-range-to-updated", this.storeService.getState().files, {
+				colorMetric: this.storeService.getState().dynamicSettings.colorMetric,
+				toValue: highValue
+			})
 		}
-	}
-
-	private broadcastColorRangeFromUpdated(colorMetric: string, fromValue: number) {
-		this.$rootScope.$broadcast(RangeSliderController.COLOR_RANGE_FROM_UPDATED, { colorMetric, fromValue })
-	}
-
-	private broadcastColorRangeToUpdated(colorMetric: string, toValue: number) {
-		this.$rootScope.$broadcast(RangeSliderController.COLOR_RANGE_TO_UPDATED, { colorMetric, toValue })
-	}
-
-	static subscribeToColorRangeFromUpdated($rootScope: IRootScopeService, subscriber: ColorRangeFromSubscriber) {
-		$rootScope.$on(RangeSliderController.COLOR_RANGE_FROM_UPDATED, (_event, data) => {
-			subscriber.onColorRangeFromUpdated(data.colorMetric, data.fromValue)
-		})
-	}
-
-	static subscribeToColorRangeToUpdated($rootScope: IRootScopeService, subscriber: ColorRangeToSubscriber) {
-		$rootScope.$on(RangeSliderController.COLOR_RANGE_TO_UPDATED, (_event, data) => {
-			subscriber.onColorRangeToUpdated(data.colorMetric, data.toValue)
-		})
 	}
 
 	private updateInputFieldWidth() {

--- a/visualization/app/codeCharta/util/__snapshots__/usageDataTracker.spec.ts.snap
+++ b/visualization/app/codeCharta/util/__snapshots__/usageDataTracker.spec.ts.snap
@@ -1,23 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UsageDataTracker trackEventUsageData should track node interaction blacklist event 1`] = `
-"some-already-tracked-events-from-file-storage
-{\\"mapId\\":\\"invalid-md5-sample-checksum\\",\\"eventType\\":\\"node_interaction\\",\\"eventTime\\":1612428357566,\\"payload\\":{\\"eventName\\":\\"ADD_BLACKLIST_ITEM\\",\\"id\\":\\"098f6bcd4621d373cade4e832627b4f6\\",\\"type\\":\\"exclude\\",\\"attributes\\":{}}}"
-`;
-
-exports[`UsageDataTracker trackEventUsageData should track node interaction focus event 1`] = `
-"some-already-tracked-events-from-file-storage
-{\\"mapId\\":\\"invalid-md5-sample-checksum\\",\\"eventType\\":\\"node_interaction\\",\\"eventTime\\":1612428357566,\\"payload\\":{\\"eventName\\":\\"FOCUS_NODE\\",\\"id\\":\\"9d1e46ce2260c90b8b7600a11ca08972\\"}}"
-`;
-
-exports[`UsageDataTracker trackEventUsageData should track setting changed event 1`] = `
+exports[`UsageDataTracker trackEventUsageData should track an event 1`] = `
 "some-already-tracked-events-from-file-storage
 {\\"mapId\\":\\"invalid-md5-sample-checksum\\",\\"eventType\\":\\"setting_changed\\",\\"eventTime\\":1612428357566,\\"payload\\":{\\"eventName\\":\\"SET_HEIGHT_METRIC\\",\\"newValue\\":\\"newHeightMetricValue\\"}}"
-`;
-
-exports[`UsageDataTracker trackEventUsageData should track setting changed event for resetting the blacklist 1`] = `
-"some-already-tracked-events-from-file-storage
-{\\"mapId\\":\\"invalid-md5-sample-checksum\\",\\"eventType\\":\\"setting_changed\\",\\"eventTime\\":1612428357566,\\"payload\\":{\\"eventName\\":\\"SET_BLACKLIST\\",\\"newValue\\":[]}}"
 `;
 
 exports[`UsageDataTracker trackMetaUsageData should not consider files with divergent metrics for statistic calculation 1`] = `"{\\"mapId\\":\\"invalid-md5-sample-checksum\\",\\"codeChartaApiVersion\\":\\"1.1\\",\\"creationTime\\":1612369999999,\\"exportedFileSizeInBytes\\":999,\\"statisticsPerLanguage\\":{\\"ts\\":{\\"metrics\\":{\\"rloc\\":{\\"avg\\":33.333333333333336,\\"max\\":70,\\"median\\":30,\\"min\\":0,\\"numberOfFiles\\":3,\\"totalSum\\":100,\\"firstQuantile\\":0,\\"thirdQuantile\\":70,\\"variance\\":822.2222222222223,\\"standardDeviation\\":28.674417556808756,\\"variationCoefficient\\":0.8602325267042626,\\"outliers\\":[],\\"metricValues\\":[0,30,70]}},\\"numberOfFiles\\":3,\\"maxFilePathDepth\\":4,\\"avgFilePathDepth\\":3.6666666666666665},\\"java\\":{\\"metrics\\":{\\"rloc\\":{\\"avg\\":55,\\"max\\":100,\\"median\\":50,\\"min\\":20,\\"numberOfFiles\\":4,\\"totalSum\\":220,\\"firstQuantile\\":25,\\"thirdQuantile\\":85,\\"variance\\":1025,\\"standardDeviation\\":32.01562118716424,\\"variationCoefficient\\":0.5821022034029862,\\"outliers\\":[],\\"metricValues\\":[100,30,70,20]},\\"functions\\":{\\"avg\\":280,\\"max\\":1000,\\"median\\":55,\\"min\\":10,\\"numberOfFiles\\":4,\\"totalSum\\":1120,\\"firstQuantile\\":10,\\"thirdQuantile\\":550,\\"variance\\":174150,\\"standardDeviation\\":417.31283229730667,\\"variationCoefficient\\":1.490402972490381,\\"outliers\\":[],\\"metricValues\\":[10,100,1000,10]},\\"mcc\\":{\\"avg\\":28.25,\\"max\\":100,\\"median\\":6,\\"min\\":1,\\"numberOfFiles\\":4,\\"totalSum\\":113,\\"firstQuantile\\":1.5,\\"thirdQuantile\\":55,\\"variance\\":1728.1875,\\"standardDeviation\\":41.57147459496716,\\"variationCoefficient\\":1.4715566228306958,\\"outliers\\":[],\\"metricValues\\":[1,100,10,2]}},\\"numberOfFiles\\":4,\\"maxFilePathDepth\\":4,\\"avgFilePathDepth\\":3.75}}}"`;

--- a/visualization/app/codeCharta/util/usageDataTracker.spec.ts
+++ b/visualization/app/codeCharta/util/usageDataTracker.spec.ts
@@ -1,4 +1,4 @@
-import { BlacklistItem, CCFile, CodeMapNode, NodeType, State } from "../codeCharta.model"
+import { CCFile, CodeMapNode, NodeType, State } from "../codeCharta.model"
 import { trackEventUsageData, trackMapMetaData } from "./usageDataTracker"
 import * as EnvironmentDetector from "./envDetector"
 import * as FilesHelper from "../model/files/files.helper"
@@ -6,8 +6,6 @@ import { FileState } from "../model/files/files"
 import { APIVersions } from "../codeCharta.api.model"
 import { CodeChartaStorage } from "./codeChartaStorage"
 import { HeightMetricActions } from "../state/store/dynamicSettings/heightMetric/heightMetric.actions"
-import { BlacklistActions } from "../state/store/fileSettings/blacklist/blacklist.actions"
-import { FocusedNodePathActions } from "../state/store/dynamicSettings/focusedNodePath/focusedNodePath.actions"
 import { klona } from "klona"
 jest.mock("./codeChartaStorage")
 
@@ -158,34 +156,17 @@ describe("UsageDataTracker", () => {
 			expect(expectSetItemSnapshot).toHaveBeenCalledTimes(1)
 		}
 
-		it("should not track on not allowed events", () => {
-			trackEventUsageData("EVENT_ACTION_WHICH_SHOULD_NOT_BE_TRACKED", stateStub.files)
+		it("should not track when tracking is not allowed", () => {
+			jest.spyOn(EnvironmentDetector, "isStandalone").mockReturnValue(false)
+
+			trackEventUsageData(HeightMetricActions.SET_HEIGHT_METRIC, stateStub.files, "newHeightMetricValue")
 
 			// A second call would indicate that the tracking has not been cancelled as expected
 			expect(FilesHelper.getVisibleFileStates).toHaveBeenCalledTimes(1)
 		})
 
-		it("should track setting changed event", () => {
+		it("should track an event", () => {
 			trackEventUsageData(HeightMetricActions.SET_HEIGHT_METRIC, stateStub.files, "newHeightMetricValue")
-			expectEventHasBeenTracked()
-		})
-
-		it("should track setting changed event for resetting the blacklist", () => {
-			trackEventUsageData(BlacklistActions.SET_BLACKLIST, stateStub.files, [])
-			expectEventHasBeenTracked()
-		})
-
-		it("should track node interaction blacklist event", () => {
-			trackEventUsageData(BlacklistActions.ADD_BLACKLIST_ITEM, stateStub.files, {
-				path: "test",
-				attributes: {},
-				type: "exclude"
-			} as BlacklistItem)
-			expectEventHasBeenTracked()
-		})
-
-		it("should track node interaction focus event", () => {
-			trackEventUsageData(FocusedNodePathActions.FOCUS_NODE, stateStub.files, "focusedPathPayload")
 			expectEventHasBeenTracked()
 		})
 	})

--- a/visualization/app/codeCharta/util/usageDataTracker.ts
+++ b/visualization/app/codeCharta/util/usageDataTracker.ts
@@ -15,7 +15,6 @@ import { APIVersions } from "../codeCharta.api.model"
 import { getAsApiVersion } from "./fileValidator"
 import { hierarchy } from "d3-hierarchy"
 import { getMedian, pushSorted } from "./nodeDecorator"
-import { RangeSliderController } from "../ui/rangeSlider/rangeSlider.component"
 import { ColorRangeActions } from "../state/store/dynamicSettings/colorRange/colorRange.actions"
 import { FileState } from "../model/files/files"
 
@@ -271,18 +270,7 @@ interface EventTrackingItem {
 }
 
 export function trackEventUsageData(actionType: string, files: FileState[], payload?: any) {
-	if (
-		!isTrackingAllowed(files) ||
-		(!isActionOfType(actionType, AreaMetricActions) &&
-			!isActionOfType(actionType, HeightMetricActions) &&
-			!isActionOfType(actionType, ColorMetricActions) &&
-			!isActionOfType(actionType, ColorRangeActions) &&
-			!isActionOfType(actionType, BlacklistActions) &&
-			!isActionOfType(actionType, FocusedNodePathActions) &&
-			![RangeSliderController.COLOR_RANGE_FROM_UPDATED, RangeSliderController.COLOR_RANGE_TO_UPDATED].includes(actionType))
-	) {
-		return
-	}
+	if (!isTrackingAllowed(files)) return
 
 	const singleFileStates = getVisibleFileStates(files)
 	const fileMeta = singleFileStates[0].file.fileMeta


### PR DESCRIPTION
- remove dependency of ColorRangeFrom/ToSubscriber, what will make Angular migration easier
- remove doupled if checks
- delete doubled tests as the filtering is done (and tested) in the TrackEventUsageDataEffect

ref #2318