### PR TITLE
fix: apply changes from PR 2709 to main

### DIFF
--- a/visualization/app/codeCharta/assets/testMap.cc.json
+++ b/visualization/app/codeCharta/assets/testMap.cc.json
@@ -1,0 +1,114 @@
+{
+	"projectName": "Sample Project with Edges",
+	"apiVersion": "1.2",
+	"fileChecksum": "invalid-md5-sample",
+	"nodes": [
+		{
+			"name": "root",
+			"type": "Folder",
+			"attributes": {},
+			"children": [
+				{
+					"name": "testFile.ts",
+					"type": "File",
+					"attributes": {
+						"rloc": 100,
+						"functions": 10,
+						"mcc": 100,
+						"pairingRate": 32,
+						"avgCommits": 17
+					},
+					"link": "http://www.google.de"
+				},
+				{
+					"name": "FOLDER",
+					"type": "Folder",
+					"attributes": {},
+					"children": [
+						{
+							"name": "smallLeaf.html",
+							"type": "File",
+							"attributes": {
+								"rloc": 30,
+								"functions": 100,
+								"mcc": 100,
+								"pairingRate": 60,
+								"avgCommits": 51
+							}
+						},
+						{
+							"name": "otherSmallLeaf.ts",
+							"type": "File",
+							"attributes": {
+								"rloc": 70,
+								"functions": 1000,
+								"mcc": 50,
+								"pairingRate": 65,
+								"avgCommits": 22
+							}
+						}
+					]
+				},
+				{
+					"name": "FOLDER_MATH",
+					"type": "Folder",
+					"attributes": {},
+					"children": [
+						{
+							"name": "leaf1.html",
+							"type": "File",
+							"attributes": {
+								"rloc": 14,
+								"functions": 100,
+								"mcc": 100,
+								"pairingRate": 60,
+								"avgCommits": 51
+							}
+						},
+						{
+							"name": "leaf2.ts",
+							"type": "File",
+							"attributes": {
+								"rloc": 50,
+								"functions": 1000,
+								"mcc": 10,
+								"pairingRate": 65,
+								"avgCommits": 22
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"edges": [
+		{
+			"fromNodeName": "/root/bigLeaf.ts",
+			"toNodeName": "/root/ParentLeaf/smallLeaf.html",
+			"attributes": {
+				"pairingRate": 89,
+				"avgCommits": 34
+			}
+		},
+		{
+			"fromNodeName": "/root/sample1OnlyLeaf.scss",
+			"toNodeName": "/root/ParentLeaf/smallLeaf.html",
+			"attributes": {
+				"pairingRate": 32,
+				"avgCommits": 17
+			}
+		},
+		{
+			"fromNodeName": "/root/ParentLeaf/otherSmallLeaf.ts",
+			"toNodeName": "/root/bigLeaf.ts",
+			"attributes": {
+				"pairingRate": 65,
+				"avgCommits": 22
+			}
+		}
+	],
+	"attributeTypes": {
+		"nodes": { "rloc": "absolute", "functions": "absolute", "mcc": "absolute", "pairingRate": "relative" },
+		"edges": { "pairingRate": "relative", "avgCommits": "absolute" }
+	}
+}

--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -399,3 +399,5 @@ export interface AppStatus {
 	selectedBuildingId: number | null
 	rightClickedNodeData: RightClickedNodeData
 }
+
+export const HEIGHT_OFFSET = 0.3

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -151,7 +151,7 @@ describe("CodeMapLabelService", () => {
 		})
 	})
 
-	describe("addLabel", () => {
+	describe("addLeafLabel", () => {
 		beforeEach(() => {
 			storeService.dispatch(setAmountOfTopLabels(1))
 			storeService.dispatch(setHeightMetric("mcc"))
@@ -162,7 +162,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			expect(codeMapLabelService["labels"].length).toBe(1)
 		})
@@ -173,7 +173,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			expect(codeMapLabelService["labels"].length).toBe(1)
 		})
@@ -182,7 +182,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(35.5)
@@ -192,7 +192,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(35.5)
@@ -206,7 +206,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(133.5)
@@ -218,7 +218,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(43.5)
@@ -228,7 +228,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(50.5)
@@ -238,7 +238,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeafDelta, 0)
+			codeMapLabelService.addLeafLabel(sampleLeafDelta, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(48.5)
@@ -249,7 +249,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeafDelta, 20)
+			codeMapLabelService.addLeafLabel(sampleLeafDelta, 20)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(53.5)
@@ -262,7 +262,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeafDelta, 0)
+			codeMapLabelService.addLeafLabel(sampleLeafDelta, 0)
 
 			const positionSampleDeltaLeaf: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionSampleDeltaLeaf.y).toBe(48.5)
@@ -270,7 +270,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 			const positionSampleLeafWithAppliedDeltaNodeHeight: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionSampleLeafWithAppliedDeltaNodeHeight.y).toBe(48.5)
 		})
@@ -279,7 +279,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(2)
@@ -289,7 +289,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const lineCount = codeMapLabelService["labels"][0].lineCount
 			expect(lineCount).toBe(1)
@@ -305,8 +305,8 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const originalSpritePositionsA = codeMapLabelService["labels"][0].sprite.position.clone()
 
@@ -349,7 +349,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 
 			const positionWithoutDelta: Vector3 = codeMapLabelService["labels"][0].sprite.position
 			expect(positionWithoutDelta.y).toBe(43.5)
@@ -389,8 +389,8 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
-			codeMapLabelService.addLabel(otherSampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(otherSampleLeaf, 0)
 
 			threeSceneService.labels.children = generateSceneLabelChild(4)
 
@@ -412,7 +412,7 @@ describe("CodeMapLabelService", () => {
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(true))
 
-			codeMapLabelService.addLabel(sampleLeaf, 0)
+			codeMapLabelService.addLeafLabel(sampleLeaf, 0)
 			threeSceneService.labels.children.length = 2
 
 			codeMapLabelService.clearTemporaryLabel(otherSampleLeaf)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -798,40 +798,40 @@ describe("codeMapMouseEventService", () => {
 	})
 
 	describe("drawTemporaryLabelFor", () => {
-		it("should call addLabel on codeMapLabelService with given node and the corresponding height that is different from 0", () => {
+		it("should call addLeafLabel on codeMapLabelService with given node and the corresponding height that is different from 0", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
-			codeMapLabelService.addLabel = jest.fn()
+			codeMapLabelService.addLeafLabel = jest.fn()
 
 			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
 			const nodeHeight = codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
 			expect(nodeHeight).toBeGreaterThan(0)
 		})
 
-		it("should call addLabel on codeMapLabelService with temporary label name even when both label options are set to false", () => {
+		it("should call addLeafLabel on codeMapLabelService with temporary label name even when both label options are set to false", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
-			codeMapLabelService.addLabel = jest.fn()
+			codeMapLabelService.addLeafLabel = jest.fn()
 			storeService.dispatch(setShowMetricLabelNameValue(false))
 			storeService.dispatch(setShowMetricLabelNodeName(false))
 
 			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
 		})
 
 		it("should not generate names in temporary Label when metric option is set to true and name is set to false", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
-			codeMapLabelService.addLabel = jest.fn()
+			codeMapLabelService.addLeafLabel = jest.fn()
 			storeService.dispatch(setShowMetricLabelNameValue(true))
 			storeService.dispatch(setShowMetricLabelNodeName(false))
 
 			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -255,7 +255,7 @@ export class CodeMapMouseEventService implements ViewCubeEventPropagationSubscri
 
 	private drawTemporaryLabelFor(codeMapBuilding: CodeMapBuilding, labels: Object3D[]) {
 		const enforceLabel = true
-		this.codeMapLabelService.addLabel(codeMapBuilding.node, 0, enforceLabel)
+		this.codeMapLabelService.addLeafLabel(codeMapBuilding.node, 0, enforceLabel)
 
 		labels = this.threeSceneService.labels?.children
 		const labelForBuilding = this.threeSceneService.getLabelForHoveredNode(codeMapBuilding, labels)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -108,7 +108,7 @@ describe("codeMapRenderService", () => {
 		codeMapLabelService = codeMapRenderService["codeMapLabelService"] = jest.fn().mockReturnValue({
 			scale: jest.fn(),
 			clearLabels: jest.fn(),
-			addLabel: jest.fn()
+			addLeafLabel: jest.fn()
 		})()
 	}
 
@@ -215,7 +215,7 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["setLabels"]([])
 
 			expect(codeMapLabelService.clearLabels).toHaveBeenCalled()
-			expect(codeMapLabelService.addLabel).not.toHaveBeenCalled()
+			expect(codeMapLabelService.addLeafLabel).not.toHaveBeenCalled()
 		})
 
 		it("should call codeMapLabelService.clearLabels", () => {
@@ -224,10 +224,10 @@ describe("codeMapRenderService", () => {
 			expect(codeMapLabelService.clearLabels).toHaveBeenCalled()
 		})
 
-		it("should call codeMapLabelService.addLabels for each shown leaf label", () => {
+		it("should call codeMapLabelService.addLeafLabels for each shown leaf label", () => {
 			codeMapRenderService["setLabels"](nodes)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(2)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(2)
 		})
 
 		it("should not generate labels when showMetricLabelNodeName and showMetricLabelNameValue are both false", () => {
@@ -236,7 +236,7 @@ describe("codeMapRenderService", () => {
 
 			codeMapRenderService["setLabels"](nodes)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(0)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(0)
 		})
 
 		it("should not generate labels for flattened nodes", () => {
@@ -245,7 +245,7 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["getNodes"] = jest.fn().mockReturnValue(nodes)
 			codeMapRenderService.render(null)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(1)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(1)
 		})
 
 		it("should generate labels for color if option is toggled on", () => {
@@ -259,7 +259,7 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["getNodesMatchingColorSelector"](COLOR_TEST_NODES)
 			codeMapRenderService["setLabels"](COLOR_TEST_NODES)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(1)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(1)
 		})
 
 		it("should generate labels for multiple colors if corresponding options are toggled on", () => {
@@ -273,7 +273,7 @@ describe("codeMapRenderService", () => {
 			codeMapRenderService["getNodesMatchingColorSelector"](COLOR_TEST_NODES)
 			codeMapRenderService["setLabels"](COLOR_TEST_NODES)
 
-			expect(codeMapLabelService.addLabel).toHaveBeenCalledTimes(2)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(2)
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -124,8 +124,11 @@ export class CodeMapRenderService implements IsLoadingFileSubscriber {
 	}
 
 	private setBuildingLabel(nodes: Node[], highestNodeInSet: number) {
-		for (const node of nodes) {
-			this.codeMapLabelService.addLabel(node, highestNodeInSet)
+		for (const [index, node] of nodes.entries()) {
+			if (index === 0) {
+				this.codeMapLabelService.addLeafLabel(node, highestNodeInSet, false, true)
+			}
+			this.codeMapLabelService.addLeafLabel(node, highestNodeInSet)
 		}
 	}
 

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
@@ -4,7 +4,7 @@ import { CodeMapBuilding } from "../rendering/codeMapBuilding"
 import { CodeMapPreRenderService, CodeMapPreRenderServiceSubscriber } from "../codeMap.preRender.service"
 import { IRootScopeService } from "angular"
 import { StoreService } from "../../../state/store.service"
-import { CodeMapNode, LayoutAlgorithm, MapColors, Node } from "../../../codeCharta.model"
+import { CodeMapNode, HEIGHT_OFFSET, LayoutAlgorithm, MapColors, Node } from "../../../codeCharta.model"
 import { hierarchy } from "d3-hierarchy"
 import { ColorConverter } from "../../../util/color/colorConverter"
 import { MapColorsService, MapColorsSubscriber } from "../../../state/store/appSettings/mapColors/mapColors.service"
@@ -140,7 +140,7 @@ export class ThreeSceneService implements CodeMapPreRenderServiceSubscriber, Map
 		const { mapSize } = this.storeService.getState().treeMap
 		const scale = this.storeService.getState().appSettings.scaling
 
-		this.mapGeometry.scale.set(scale.x, scale.y, scale.z)
+		this.mapGeometry.scale.set(scale.x, scale.y * HEIGHT_OFFSET, scale.z)
 		this.mapGeometry.position.set(-mapSize * scale.x, 0, -mapSize * scale.z)
 		this.mapMesh.setScale(scale)
 	}

--- a/visualization/app/codeCharta/ui/heightSettingsPanel/heightSettingsPanel.component.ts
+++ b/visualization/app/codeCharta/ui/heightSettingsPanel/heightSettingsPanel.component.ts
@@ -97,6 +97,7 @@ export class HeightSettingsPanelController
 
 	onScalingChanged(scaling) {
 		this._viewModel.scalingY = scaling.y
+		this.applyDebouncedTopLabels()
 	}
 
 	onFilesSelectionChanged(files: FileState[]) {
@@ -126,7 +127,7 @@ export class HeightSettingsPanelController
 	applySettingsScaling() {
 		const oldScaling = this.storeService.getState().appSettings.scaling
 		const newScaling = new Vector3(oldScaling.x, this._viewModel.scalingY, oldScaling.z)
-
+		this.applyDebouncedTopLabels()
 		this.applyDebouncedScaling(newScaling)
 	}
 }


### PR DESCRIPTION
I skimmed the changes from #2709 and copied those into latest main, which seemed relevant.

No warranty that I got everything correctly. It is not clear to me, if those changes were already finished. On a first glance I see the following todos; tests needs to be adjusted, due to changes of calculated `y` values and how often `addLeafLabel` is called:

- [ ] test everything manual
- [ ] adjust codeMap.label.service.spec.ts
- [ ] adjust codeMap.render.service.spec.ts
- [ ] adjust threeSceneService.spec.ts
- [ ] do we want to keep added testMap.cc.json?
- [ ] add a changelog entry

ref #1609
ref #2709

