### PR TITLE
fix: prevent submitting invalid number input in slider component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Update slider of area metric options correctly on changes of related input field [#2787](https://github.com/MaibornWolff/codecharta/pull/2787)
+-   Prevent invalid input for margin in area metric options to be submitted [#2799](https://github.com/MaibornWolff/codecharta/pull/2799)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/slider/slider.component.html
+++ b/visualization/app/codeCharta/ui/slider/slider.component.html
@@ -10,6 +10,14 @@
 	>
 	</mat-slider>
 	<mat-form-field>
-		<input matInput [disabled]="disabled" type="number" [value]="this.value" (input)="this.handleInputOnChange($event)" />
+		<input
+			matInput
+			[disabled]="disabled"
+			type="number"
+			[value]="this.value"
+			(input)="this.handleInputOnChange($event)"
+			[min]="this.min"
+			[max]="this.max"
+		/>
 	</mat-form-field>
 </div>

--- a/visualization/app/codeCharta/ui/slider/slider.component.ts
+++ b/visualization/app/codeCharta/ui/slider/slider.component.ts
@@ -1,6 +1,7 @@
 import "./slider.component.scss"
 import { Component, Input } from "@angular/core"
 import { MatSliderChange } from "@angular/material/slider"
+import { parseNumberInput } from "./util/parseNumberInput"
 
 @Component({
 	selector: "cc-slider",
@@ -22,8 +23,8 @@ export class SliderComponent {
 	}
 
 	handleInputOnChange($event: InputEvent) {
-		const newValue = Number.parseInt(($event.target as HTMLInputElement).value)
-		if (newValue !== this.value) {
+		const newValue = parseNumberInput($event, this.min, this.max)
+		if (newValue !== this.value && !Number.isNaN(newValue)) {
 			this.onChange(newValue)
 		}
 	}

--- a/visualization/app/codeCharta/ui/slider/util/parseNumberInput.spec.ts
+++ b/visualization/app/codeCharta/ui/slider/util/parseNumberInput.spec.ts
@@ -1,0 +1,18 @@
+import { parseNumberInput } from "./parseNumberInput"
+
+describe("parseNumberInput", () => {
+	it("should get value", () => {
+		const fakeEvent = { target: { value: 42 } } as unknown as InputEvent
+		expect(parseNumberInput(fakeEvent, 0, 100)).toBe(42)
+	})
+
+	it("should return min value in case of too small entered valued", () => {
+		const fakeEvent = { target: { value: 1 } } as unknown as InputEvent
+		expect(parseNumberInput(fakeEvent, 2, 100)).toBe(2)
+	})
+
+	it("should return max value in case of too large entered valued", () => {
+		const fakeEvent = { target: { value: 9999 } } as unknown as InputEvent
+		expect(parseNumberInput(fakeEvent, 0, 9000)).toBe(9000)
+	})
+})

--- a/visualization/app/codeCharta/ui/slider/util/parseNumberInput.ts
+++ b/visualization/app/codeCharta/ui/slider/util/parseNumberInput.ts
@@ -1,0 +1,10 @@
+export const parseNumberInput = (event: InputEvent, min: number, max: number) => {
+	const value = Number.parseInt((event.target as HTMLInputElement).value)
+	if (value < min) {
+		return min
+	}
+	if (value > max) {
+		return max
+	}
+	return value
+}


### PR DESCRIPTION
 Prevent submitting invalid number input in slider component. The original reported bug of slider being stuck was already fixed with migration of the slider (#2787).

close #2627
