### PR TITLE
use interface for interactive parsers + implement in ValidatorTool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,6 @@ quote_type = unset
 
 [*.md]
 indent_size = 4
+
+[*.gradle]
+indent_size = 4

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeFilter.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/EdgeFilter.kt
@@ -3,6 +3,7 @@ package de.maibornwolff.codecharta.filter.edgefilter
 import de.maibornwolff.codecharta.filter.edgefilter.ParserDialog.Companion.collectParserArgs
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
+import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
 import picocli.CommandLine
 import java.io.File
 import java.util.concurrent.Callable
@@ -12,7 +13,7 @@ import java.util.concurrent.Callable
     description = ["aggregtes edgeAttributes as nodeAttributes into a new cc.json file"],
     footer = ["Copyright(c) 2022, MaibornWolff GmbH"]
 )
-class EdgeFilter : Callable<Void?> {
+class EdgeFilter : Callable<Void?>, InteractiveParser {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
@@ -37,12 +38,9 @@ class EdgeFilter : Callable<Void?> {
         return null
     }
 
-    companion object {
-        @JvmStatic
-        fun main(args: Array<String>) {
-            val commandLine = CommandLine(EdgeFilter())
-            val collectedArgs = collectParserArgs()
-            commandLine.execute(*collectedArgs.toTypedArray())
-        }
+    override fun callInteractive() {
+        val commandLine = CommandLine(EdgeFilter())
+        val collectedArgs = collectParserArgs()
+        commandLine.execute(*collectedArgs.toTypedArray())
     }
 }

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
@@ -10,13 +10,10 @@ private val logger = KotlinLogging.logger {}
 class ParserDialog {
     companion object : ParserDialogInterface {
         private const val EXTENSION = "cc.json"
-        private val extensionPattern = Regex(".($EXTENSION)$")
 
         override fun collectParserArgs(): List<String> {
 
-            var inputFileName = KInquirer.promptInput(message = "What is the $EXTENSION file that has to be parsed?")
-            if (!extensionPattern.containsMatchIn(inputFileName))
-                inputFileName += ".$EXTENSION"
+            val inputFileName = KInquirer.promptInput(message = "What is the $EXTENSION file that has to be parsed?")
             logger.info { "File path: $inputFileName" }
 
             val defaultOutputFileName = getOutputFileName(inputFileName)

--- a/analysis/tools/InteractiveParser/src/main/kotlin/de/maibornwolff/codecharta/tools/interactiveparser/InteractiveParser.kt
+++ b/analysis/tools/InteractiveParser/src/main/kotlin/de/maibornwolff/codecharta/tools/interactiveparser/InteractiveParser.kt
@@ -1,0 +1,5 @@
+package de.maibornwolff.codecharta.tools.interactiveparser
+
+interface InteractiveParser {
+    fun callInteractive()
+}

--- a/analysis/tools/ValidationTool/build.gradle
+++ b/analysis/tools/ValidationTool/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spek2_version") {
         exclude group: 'org.jetbrains.kotlin'
     }
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: assertj_version
+    testImplementation group: 'io.mockk', name: 'mockk', version: mockk_version
 
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spek2_version") {
         exclude group: 'org.jetbrains.kotlin'

--- a/analysis/tools/ValidationTool/build.gradle
+++ b/analysis/tools/ValidationTool/build.gradle
@@ -5,8 +5,11 @@ repositories {
 }
 
 dependencies {
+    implementation project(':tools:InteractiveParser')
     implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: json_schema_version
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
+    implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
+    implementation "com.github.kotlin-inquirer:kotlin-inquirer:$kotlin_inquirer_version"
 
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spek2_version") {

--- a/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialog.kt
+++ b/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialog.kt
@@ -1,0 +1,21 @@
+package de.maibornwolff.codecharta.tools.validation
+
+import com.github.kinquirer.KInquirer
+import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class ParserDialog {
+    companion object : ParserDialogInterface {
+        private const val EXTENSION = "cc.json"
+
+        override fun collectParserArgs(): List<String> {
+            val inputFileName = KInquirer.promptInput(message = "Which $EXTENSION file do you want to validate?")
+            logger.info { "File path: $inputFileName" }
+
+            return listOf(inputFileName)
+        }
+    }
+}

--- a/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ValidationTool.kt
+++ b/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ValidationTool.kt
@@ -1,5 +1,7 @@
 package de.maibornwolff.codecharta.tools.validation
 
+import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
+import de.maibornwolff.codecharta.tools.validation.ParserDialog.Companion.collectParserArgs
 import picocli.CommandLine
 import java.io.File
 import java.io.FileInputStream
@@ -10,9 +12,7 @@ import java.util.concurrent.Callable
     description = ["validates cc.json files"],
     footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
-class ValidationTool : Callable<Void?> {
-
-    private val schemaPath = "cc.json"
+class ValidationTool : Callable<Void?>, InteractiveParser {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
@@ -21,17 +21,19 @@ class ValidationTool : Callable<Void?> {
     var file: String = ""
 
     override fun call(): Void? {
-        EveritValidator(schemaPath).validate(FileInputStream(File(file).absoluteFile))
+        EveritValidator(SCHEMA_PATH).validate(FileInputStream(File(file).absoluteFile))
 
         return null
     }
 
-    companion object {
-        var SCHEMA_PATH = "cc.json"
-
-        @JvmStatic
-        fun main(args: Array<String>) {
-            CommandLine.call(ValidationTool(), System.out, *args)
-        }
+    override fun callInteractive() {
+        val commandLine = CommandLine(ValidationTool())
+        val collectedArgs = collectParserArgs()
+        commandLine.execute(*collectedArgs.toTypedArray())
     }
+
+    companion object {
+        val SCHEMA_PATH = "cc.json"
+    }
+
 }

--- a/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ValidationTool.kt
+++ b/analysis/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/tools/validation/ValidationTool.kt
@@ -35,5 +35,4 @@ class ValidationTool : Callable<Void?>, InteractiveParser {
     companion object {
         val SCHEMA_PATH = "cc.json"
     }
-
 }

--- a/analysis/tools/ValidationTool/src/test/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialogTest.kt
+++ b/analysis/tools/ValidationTool/src/test/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialogTest.kt
@@ -1,4 +1,4 @@
-package de.maibornwolff.codecharta.filter.edgefilter
+package de.maibornwolff.codecharta.tools.validation
 
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
@@ -11,15 +11,15 @@ import org.spekframework.spek2.style.specification.describe
 
 class ParserDialogTest: Spek({
     describe("Parser dialog for Validator") {
-        it("should output correct arguments for file with correct extension") {
+        it("should output correct arguments for some input file") {
             mockkStatic("com.github.kinquirer.components.InputKt")
             every {
                 KInquirer.promptInput(any(), any(), any())
-            } returns "sampleFile.cc.json" andThen "sampleOutputFile" andThen "/"
+            } returns "sampleFile.cc.json"
 
             val parserArguments = ParserDialog.collectParserArgs()
 
-            Assertions.assertThat(parserArguments).isEqualTo(listOf("sampleFile.cc.json", "-o sampleOutputFile", "--path-separator=/"))
+            Assertions.assertThat(parserArguments).isEqualTo(listOf("sampleFile.cc.json"))
         }
 
         afterEachTest {

--- a/analysis/tools/ccsh/build.gradle
+++ b/analysis/tools/ccsh/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     def validationTool = project(':tools:ValidationTool')
     def csvExporter = project(':export:CSVExporter')
     def rawTextParser = project(':parser:RawTextParser')
+    def interactiveParser = project(':tools:InteractiveParser')
 
     // first implementation is for dependency in main, testImplementation is so our test suite can find all other tests
     implementation codeMaatImporter; testImplementation codeMaatImporter.sourceSets.test.output
@@ -53,6 +54,7 @@ dependencies {
     implementation csvExporter; testImplementation csvExporter.sourceSets.test.output
     implementation structureModifier; testImplementation structureModifier.sourceSets.test.output
     implementation rawTextParser; testImplementation rawTextParser.sourceSets.test.output
+    implementation interactiveParser; testImplementation interactiveParser.sourceSets.test.output
 
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -84,9 +84,9 @@ class Ccsh : Callable<Void?> {
         }
 
         private fun executeInteractiveParser(commandLine: CommandLine) {
-                val selectedParser = ParserService.selectParser(commandLine)
-                logger.info { "Executing $selectedParser" }
-                ParserService.executeSelectedParser(selectedParser)
+            val selectedParser = ParserService.selectParser(commandLine)
+            logger.info { "Executing $selectedParser" }
+            ParserService.executeSelectedParser(commandLine, selectedParser)
         }
 
         private fun isParserUnknown(args: Array<String>, commandLine: CommandLine): Boolean {

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
@@ -2,7 +2,7 @@ package de.maibornwolff.codecharta.tools.ccsh.parser
 
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptList
-import de.maibornwolff.codecharta.filter.edgefilter.EdgeFilter
+import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
 import picocli.CommandLine
 
 class ParserService {
@@ -16,37 +16,26 @@ class ParserService {
             return extractParserName(selectedParser)
         }
 
-        fun executeSelectedParser(selectedParser: String) {
-            val args = emptyArray<String>()
-
-            when (selectedParser) {
-                "check" -> printNotSupported(selectedParser)
-                "merge" -> printNotSupported(selectedParser)
-                "edgefilter" -> EdgeFilter.main(args)
-                "modify" -> printNotSupported(selectedParser)
-                "csvimport" -> printNotSupported(selectedParser)
-                "sonarimport" -> printNotSupported(selectedParser)
-                "sourcemonitorimport" -> printNotSupported(selectedParser)
-                "gitlogparser" -> printNotSupported(selectedParser)
-                "svnlogparser" -> printNotSupported(selectedParser)
-                "csvexport" -> printNotSupported(selectedParser)
-                "sourcecodeparser" -> printNotSupported(selectedParser)
-                "codemaatimport" -> printNotSupported(selectedParser)
-                "tokeiimporter" -> printNotSupported(selectedParser)
-                "rawtextparser" -> printNotSupported(selectedParser)
-                else -> {
-                    println("No valid parser was selected.")
-                }
+        fun executeSelectedParser(commandLine: CommandLine, selectedParser: String) {
+            val subCommand = commandLine.subcommands.getValue(selectedParser)
+            val parserObject = subCommand.commandSpec.userObject()
+            val interactive = parserObject as? InteractiveParser
+            if (interactive != null) {
+                interactive.callInteractive()
+            } else {
+                printNotSupported(selectedParser)
             }
         }
 
         private fun getParserNamesWithDescription(commandLine: CommandLine): List<String> {
             val subCommands = commandLine.subcommands.values
-            return subCommands.map { subCommand ->
+            return subCommands.mapNotNull { subCommand ->
                 val parserName = subCommand.commandName
-                val parserDescriptions = subCommand.commandSpec.usageMessage().description()
-                val parserDescription = parserDescriptions[0]
-                "$parserName - $parserDescription"
+                if (subCommand.commandSpec.userObject() is InteractiveParser) {
+                    val parserDescriptions = subCommand.commandSpec.usageMessage().description()
+                    val parserDescription = parserDescriptions[0]
+                    "$parserName - $parserDescription"
+                } else null
             }
         }
 

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -49,22 +49,22 @@ class CcshTest {
 
         Assertions.assertThat(exitCode).isEqualTo(0)
         Assertions.assertThat(contentOutput.toString()).contains("Usage: ccsh [-hv] [COMMAND]", "Command Line Interface for CodeCharta analysis")
-        verify(exactly = 0) { ParserService.executeSelectedParser(any()) }
+        verify(exactly = 0) { ParserService.executeSelectedParser(any(), any()) }
     }
 
     @Test
-    fun `should star interactive parser when no arguments or parameters are passed`() {
+    fun `should start interactive parser when no arguments or parameters are passed`() {
         mockkObject(ParserService)
         every {
             ParserService.selectParser(any())
         } returns "someparser"
         every {
-            ParserService.executeSelectedParser(any())
+            ParserService.executeSelectedParser(any(), any())
         } just Runs
 
         Ccsh.main(emptyArray())
 
-        verify { ParserService.executeSelectedParser(any()) }
+        verify { ParserService.executeSelectedParser(any(), any()) }
     }
 
     @Test
@@ -74,11 +74,11 @@ class CcshTest {
             ParserService.selectParser(any())
         } returns "someparser"
         every {
-            ParserService.executeSelectedParser(any())
+            ParserService.executeSelectedParser(any(), any())
         } just Runs
 
         Ccsh.main(arrayOf("unknownparser"))
 
-        verify { ParserService.executeSelectedParser(any()) }
+        verify { ParserService.executeSelectedParser(any(), any()) }
     }
 }

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/ParserServiceTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/ParserServiceTest.kt
@@ -50,94 +50,108 @@ class ParserServiceTest {
 
     @Test
     fun `should execute check parser`() {
-        ParserService.executeSelectedParser("check")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "check")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute merge parser`() {
-        ParserService.executeSelectedParser("merge")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "merge")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute edgefilter parser`() {
-        mockkObject(EdgeFilter)
+        val cmdLine = CommandLine(Ccsh())
+        val parser = cmdLine.subcommands["edgefilter"]!!.commandSpec.userObject() as EdgeFilter
+        mockkObject(parser)
         every {
-            EdgeFilter.main(any())
+            parser.callInteractive()
         } just Runs
-        ParserService.executeSelectedParser("edgefilter")
-        verify { EdgeFilter.main(emptyArray()) }
+        ParserService.executeSelectedParser(cmdLine, "edgefilter")
+        verify { parser.callInteractive() }
     }
 
     @Test
     fun `should execute modify parser`() {
-        ParserService.executeSelectedParser("modify")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "modify")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute sonarimport parser`() {
-        ParserService.executeSelectedParser("sonarimport")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "sonarimport")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute sourcemonitorimport parser`() {
-        ParserService.executeSelectedParser("sourcemonitorimport")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "sourcemonitorimport")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute gitlogparser parser`() {
-        ParserService.executeSelectedParser("gitlogparser")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "gitlogparser")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute svnlogparser parser`() {
-        ParserService.executeSelectedParser("svnlogparser")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "svnlogparser")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute csvexport parser`() {
-        ParserService.executeSelectedParser("csvexport")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "csvexport")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute sourcecodeparser parser`() {
-        ParserService.executeSelectedParser("sourcecodeparser")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "sourcecodeparser")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute tokeiimporter parser`() {
-        ParserService.executeSelectedParser("tokeiimporter")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "tokeiimporter")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should execute rawtextparser parser`() {
-        ParserService.executeSelectedParser("rawtextparser")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "rawtextparser")
 
         Assertions.assertThat(outContent.toString()).contains("not supported yet")
     }
 
     @Test
     fun `should not execute any parser`() {
-        ParserService.executeSelectedParser("unkownparser")
+        val cmdLine = CommandLine(Ccsh())
+        ParserService.executeSelectedParser(cmdLine, "unkownparser")
 
         Assertions.assertThat(outContent.toString()).contains("No valid parser was selected.")
     }


### PR DESCRIPTION
# use interface for interactive parsers + implement in ValidatorTool

Issue: #2341

## Description

- Use interface for interactive parsers (this allows us to automatically detect them from the subcommands, and makes a separate map unnecessary)
- Add the interactive dialog for the ValidatorTool 
- Add the tests for the dialog using Spek framework

## Screenshots or gifs

