### PR TITLE
feature: implement interactive dialog for CSVImporter

### DIFF
--- a/analysis/import/CSVImporter/build.gradle
+++ b/analysis/import/CSVImporter/build.gradle
@@ -6,6 +6,8 @@ repositories {
 
 dependencies {
     implementation project(':model')
+    implementation project(':tools:InteractiveParser')
+
 
     implementation group: 'com.univocity', name: 'univocity-parsers', version: univocity_parsers_version
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
@@ -13,11 +15,13 @@ dependencies {
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
 
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: slf4j_version
+    implementation group: 'com.github.kotlin-inquirer', name: 'kotlin-inquirer', version: kotlin_inquirer_version
 
     testImplementation group: 'org.assertj', name: 'assertj-core', version: assertj_version
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junit5_version
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrest_version
+    testImplementation group: 'io.mockk', name: 'mockk', version: mockk_version
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spek2_version") {
         exclude group: 'org.jetbrains.kotlin'
     }

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.Callable
 @CommandLine.Command(
     name = "csvimport",
     description = ["generates cc.json from csv with header"],
-    footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
+    footer = ["Copyright(c) 2022, MaibornWolff GmbH"]
 )
 class CSVImporter : Callable<Void>, InteractiveParser {
 

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/CSVImporter.kt
@@ -1,6 +1,8 @@
 package de.maibornwolff.codecharta.importer.csv
 
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
+import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
+import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import picocli.CommandLine
 import java.io.BufferedWriter
 import java.io.File
@@ -16,12 +18,12 @@ import java.util.concurrent.Callable
     description = ["generates cc.json from csv with header"],
     footer = ["Copyright(c) 2020, MaibornWolff GmbH"]
 )
-class CSVImporter : Callable<Void> {
+class CSVImporter : Callable<Void>, InteractiveParser {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
 
-    @CommandLine.Option(names = ["-d", "--delimeter"], description = ["delimeter in csv file"])
+    @CommandLine.Option(names = ["-d", "--delimiter"], description = ["delimiter in csv file"])
     private var csvDelimiter = ','
 
     @CommandLine.Option(names = ["--path-separator"], description = ["path separator (default = '/')"])
@@ -64,4 +66,6 @@ class CSVImporter : Callable<Void> {
             CommandLine.call(CSVImporter(), System.out, *args)
         }
     }
+
+    override fun getDialog(): ParserDialogInterface = ParserDialog
 }

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialog.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialog.kt
@@ -1,0 +1,46 @@
+package de.maibornwolff.codecharta.importer.csv
+
+import com.github.kinquirer.KInquirer
+import com.github.kinquirer.components.promptConfirm
+import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+
+class ParserDialog {
+    companion object : ParserDialogInterface {
+
+        override fun collectParserArgs(): List<String> {
+            val inputFileName = KInquirer.promptInput(
+                    message = "What is the sourcemonitor CSV file that has to be parsed?",
+                    hint = "sourcemonitor.csv"
+            )
+
+            val outputFileName: String = KInquirer.promptInput(
+                    message = "What is the name of the output file?",
+                    hint = "output.cc.json"
+            )
+
+            val delimiter = KInquirer.promptInput(
+                    message = "Which column delimiter is used in the CSV file?",
+                    hint = ",",
+                    default = ","
+            )
+
+            val pathSeparator = KInquirer.promptInput(
+                    message = "Which path separator is used in the path names?",
+                    hint = "/",
+                    default = "/"
+            )
+
+            val isCompressed: Boolean =
+                    KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+
+            return listOfNotNull(
+                    inputFileName,
+                    "--output-file=$outputFileName",
+                    "--delimiter=$delimiter",
+                    "--path-separator=$pathSeparator",
+                    if (isCompressed) null else "--not-compressed",
+            )
+        }
+    }
+}

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
@@ -1,0 +1,52 @@
+package de.maibornwolff.codecharta.importer.csv
+
+import com.github.kinquirer.KInquirer
+import com.github.kinquirer.components.promptConfirm
+import com.github.kinquirer.components.promptInput
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import picocli.CommandLine
+import java.io.File
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ParserDialogTest {
+
+    @AfterAll
+    fun afterTest() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `should output correct arguments`() {
+        val fileName = "in.csv"
+        val outputFileName = "out.cc.json"
+        val delimiter = ";"
+        val pathSeparator = "/"
+        val isCompressed = false
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns fileName andThen outputFileName andThen delimiter andThen pathSeparator
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed
+
+        val parserArguments = ParserDialog.collectParserArgs()
+
+        val cmdLine = CommandLine(CSVImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<File>().name)
+                .isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
+        Assertions.assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+    }
+}

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
@@ -23,6 +23,8 @@ class ParserService {
             if (interactive != null) {
                 val collectedArgs = interactive.getDialog().collectParserArgs()
                 val subCommandLine = CommandLine(interactive)
+                println("You can run the same command again by using the following command line arguments:")
+                println("ccsh " + selectedParser + " " + collectedArgs.map { x -> '"' + x + '"' }.joinToString(" "))
                 subCommandLine.execute(*collectedArgs.toTypedArray())
             } else {
                 printNotSupported(selectedParser)


### PR DESCRIPTION
# implement interactive dialog for CSVImporter

Issue: #2341

## Description

- **Implements interactive dialog for CSVImporter**
- displays the command line after answering the questions, to easily run the same action again

## Screenshots or gifs
<img width="888" alt="grafik" src="https://user-images.githubusercontent.com/388142/171443530-f29d4468-a35b-4287-aea0-5d1bdc8c609f.png">
