### PR TITLE
fix: hide migrated settings components correctly on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Add interactive dialog support for the remaining parsers [#2833](https://github.com/MaibornWolff/codecharta/pull/2833) [#2836](https://github.com/MaibornWolff/codecharta/pull/2836) [#2842](https://github.com/MaibornWolff/codecharta/pull/2842) [#2843](https://github.com/MaibornWolff/codecharta/pull/2843) [#2846](https://github.com/MaibornWolff/codecharta/pull/2846)
 
+### Fixed 🐞
+
+-   Close height metric option instead of making it only invisible on close [#2853](https://github.com/MaibornWolff/codecharta/pull/2853)
+
 ### Chore 👨‍💻 👩‍💻
 
 -   Migrate changelog dialog to Angular [#2849](https://github.com/MaibornWolff/codecharta/pull/2849)

--- a/visualization/app/codeCharta/ui/ribbonBar/areaSettingsPanel/areaSettingsPanel.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/areaSettingsPanel/areaSettingsPanel.component.scss
@@ -1,30 +1,10 @@
 cc-area-settings-panel {
-	background: white;
-	border: 1px solid #b5b5b5;
-	box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
-	display: block;
-	padding: 6px;
-	position: absolute;
-	overflow: hidden;
-	font-size: 0.9em;
 	text-align: left;
 	max-height: 300px;
-	opacity: 1;
-	width: 240px;
-	transition: opacity 0ms, max-height 200ms ease-in-out;
-
-	top: 45px;
-	right: 0;
 
 	.bottom-row {
 		align-items: center;
 		display: flex;
 		justify-content: space-between;
 	}
-}
-
-cc-area-settings-panel.hidden {
-	max-height: 0;
-	opacity: 0;
-	transition: max-height 200ms ease-in-out, opacity 0ms 200ms;
 }

--- a/visualization/app/codeCharta/ui/ribbonBar/heightSettingsPanel/heightSettingsPanel.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/heightSettingsPanel/heightSettingsPanel.component.scss
@@ -1,21 +1,5 @@
 cc-height-settings-panel {
-	background: white;
-	border: 1px solid #b5b5b5;
-	box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
-	padding: 8px;
-	position: absolute;
-	font-size: 0.9em;
-	width: 240px;
-	transition: opacity 0ms, max-height 200ms ease-in-out;
-	top: 45px;
-	right: 0;
-
-	&.hidden {
-		max-height: 0;
-		opacity: 0;
-		transition: max-height 200ms ease-in-out, opacity 0ms 200ms;
-	}
-
+	max-height: 240px;
 	.cc-height-settings-panel-row {
 		margin: 8px 0;
 	}

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
@@ -39,7 +39,10 @@
 			>Area Metric Options <i class="fa fa-angle-down"></i
 		></span>
 	</div>
-	<cc-area-settings-panel ng-class="{ hidden: $ctrl._viewModel.panelSelection !== 'AREA_PANEL_OPEN' }"></cc-area-settings-panel>
+	<cc-area-settings-panel
+		class="cc-metric-settings-panel"
+		ng-class="{ hidden: $ctrl._viewModel.panelSelection !== 'AREA_PANEL_OPEN' }"
+	></cc-area-settings-panel>
 </md-card>
 
 <md-card
@@ -55,7 +58,10 @@
 			>Height Metric Options <i class="fa fa-angle-down"></i
 		></span>
 	</div>
-	<cc-height-settings-panel ng-class="{ hidden: $ctrl._viewModel.panelSelection !== 'HEIGHT_PANEL_OPEN' }"></cc-height-settings-panel>
+	<cc-height-settings-panel
+		class="cc-metric-settings-panel"
+		ng-class="{ hidden: $ctrl._viewModel.panelSelection !== 'HEIGHT_PANEL_OPEN' }"
+	></cc-height-settings-panel>
 </md-card>
 
 <md-card

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
@@ -156,4 +156,26 @@ ribbon-bar-component {
 			margin-right: 8px;
 		}
 	}
+
+	.cc-metric-settings-panel {
+		display: block;
+		position: absolute;
+		top: 45px;
+		right: 0;
+		padding: 8px;
+		width: 240px;
+		background: white;
+		border: 1px solid #b5b5b5;
+		box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
+		overflow: hidden;
+		opacity: 1;
+		font-size: 0.9em;
+		transition: max-height 200ms ease-in-out;
+
+		&.hidden {
+			max-height: 0;
+			opacity: 0;
+			transition: opacity 0ms 200ms, max-height 200ms ease-in-out;
+		}
+	}
 }


### PR DESCRIPTION
- this PR prevents clicking of invisible height metric settings panel after it was closed (#2852)
- makes the closing animation smoother
- refactors / unifies common css

close #2852
