### PR TITLE
fix: set default value for compressed in ParserDialogs to true

### DIFF
--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
@@ -18,7 +18,7 @@ class ParserDialog {
             )
 
             val compress: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val addMissing: Boolean =
                 KInquirer.promptConfirm(message = "Do you want to add missing nodes to reference?", default = false)

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialog.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialog.kt
@@ -42,7 +42,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = false)
+                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             return inputFileNames + listOfNotNull(
                     "--output-file=$outputFileName",

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialog.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialog.kt
@@ -30,7 +30,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = false)
+                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             return inputFileNames + listOfNotNull(
                     "--output-file=$outputFileName",

--- a/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
+++ b/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
@@ -25,7 +25,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = true)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             return listOfNotNull(
                 inputFileName,

--- a/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialog.kt
+++ b/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialog.kt
@@ -34,7 +34,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val isSilent: Boolean =
                 KInquirer.promptConfirm(message = "Do you want to suppress command line output?", default = false)

--- a/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
+++ b/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
@@ -4,9 +4,6 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 class ParserDialog {
     companion object : ParserDialogInterface {
@@ -30,7 +27,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val isSilent: Boolean =
                 KInquirer.promptConfirm(message = "Do you want to suppress command line output?", default = false)

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
@@ -34,7 +34,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val mergeModules: Boolean =
                 KInquirer.promptConfirm(message = "Do you want to merge modules in multi-module projects?", default = false)

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
@@ -51,7 +51,7 @@ class ParserDialog {
             }
 
             val isCompressed: Boolean =
-                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = false)
+                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val isVerbose: Boolean =
                     KInquirer.promptConfirm(message = "Display info messages from sonar plugins?", default = false)

--- a/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
+++ b/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
@@ -32,7 +32,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = false)
+                    KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             return listOfNotNull(
                     inputFileName,

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -20,7 +20,7 @@ class ParserDialog {
             )
 
             val isCompressed: Boolean =
-                KInquirer.promptConfirm(message = "Do you want to compress the file?", default = false)
+                KInquirer.promptConfirm(message = "Do you want to compress the output file?", default = true)
 
             val verbose: Boolean =
                 KInquirer.promptConfirm(message = "Do you want to suppress command line output?", default = false)


### PR DESCRIPTION
issue #2341

# set default value for compressed in ParserDialogs to true

The default value on command line is true (files are not compressed only if the -nc param is specified), so it should be the same in interactive dialogs.