### PR TITLE
fix: install wine32 in release workflow to fix windows packaging

### DIFF
--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -25,7 +25,10 @@ jobs:
           node-version: '16'
 
       - name: Install wine
-        run: sudo apt-get install -y wine-stable
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt-get install -y wine-stable wine32
 
       - name: Build analysis
         working-directory: ./analysis


### PR DESCRIPTION

# install wine32 in release workflow to fix windows packaging

issue #2823


