### PR TITLE
Update node-forge version back to 1.3.1 (from 1.2.1)

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -17769,9 +17769,9 @@
 			}
 		},
 		"node_modules/node-forge": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-			"integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 6.13.0"
@@ -38555,9 +38555,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-			"integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
 			"dev": true
 		},
 		"node-gyp": {


### PR DESCRIPTION
# Fix/Chore Re-bumping node-forge version to 1.3.1

Fixes: #2898 

## Description

Version bump node-forge to 1.3.1 to fix security problem [25](https://github.com/MaibornWolff/codecharta/security/dependabot/25), [26](https://github.com/MaibornWolff/codecharta/security/dependabot/26), and [27](https://github.com/MaibornWolff/codecharta/security/dependabot/27).


