### PR TITLE
Add automatic changelog inclusion to release

### DIFF
--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           asset_paths: '["visualization/dist/packages/*.zip", "analysis/build/distributions/*.tar"]'
 
+      - name: Add Changelog Entries to Release
+        uses: rasmus-saks/release-a-changelog-action@v1.0.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
       - name: Publish visualization npm package
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# Add changelog to releases (automatically)

This PR adds [release-a-changlog](https://github.com/marketplace/actions/release-a-changelog) to the github action for the release.

I tested this action in a small repo and it worked fine. It is specifically made for [keep-a-changelog](https://keepachangelog.com/en/1.0.0/)-style changelogs.

Issue: #2684 
