### PR TITLE
ccsh merge throws NoSuchMethodException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix SonarImporter requesting no metrics from SonarQube when the list of metrics was left empty [#2913](https://github.com/MaibornWolff/codecharta/pull/2913)
--   Change CompressionStreamHandler usage of Java11 Method to Java9 [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
+-   Change CompressionStreamHandler's wrapInput usage of method readNBytes to read (java8) [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
 
 ## [1.101.1] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix SonarImporter requesting no metrics from SonarQube when the list of metrics was left empty [#2913](https://github.com/MaibornWolff/codecharta/pull/2913)
--   Fix of NoSuchMethodException due to a call of method readNBytes() that is not available in Java 9. Replaced with read() [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
+-   Fix of NoSuchMethodException due to a call of method `readNBytes()` that is not available in Java 9 with replacement call `read()` [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
 
 ## [1.101.1] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix SonarImporter requesting no metrics from SonarQube when the list of metrics was left empty [#2913](https://github.com/MaibornWolff/codecharta/pull/2913)
--   Change CompressionStreamHandler's wrapInput usage of method readNBytes to read (java8) [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
+-   Fix of NoSuchMethodException due to a call of method readNBytes() that is not available in Java 9. Replaced with read() [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
 
 ## [1.101.1] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix SonarImporter requesting no metrics from SonarQube when the list of metrics was left empty [#2913](https://github.com/MaibornWolff/codecharta/pull/2913)
+-   Change CompressionStreamHandler usage of Java11 Method to Java9 [#2930](https://github.com/MaibornWolff/codecharta/pull/2930)
 
 ## [1.101.1] - 2022-07-27
 

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
@@ -11,7 +11,8 @@ object CompressedStreamHandler {
         var content = input
         if (!input.markSupported()) { content = BufferedInputStream(input) }
         content.mark(2)
-        val byteArray = content.readNBytes(2)
+        val byteArray = ByteArray(2)
+        content.readNBytes(byteArray, 0, 2)
         content.reset()
         if (isGzipByteHeader(byteArray)) { return GZIPInputStream(content) }
         return content

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
@@ -7,12 +7,23 @@ import java.util.zip.GZIPInputStream
 object CompressedStreamHandler {
 
     fun wrapInput(input: InputStream): InputStream {
-        if (input.available() == 0) { return input }
+        if (input.available() == 2) { return input }
         var content = input
         if (!input.markSupported()) { content = BufferedInputStream(input) }
         content.mark(2)
-        val byteArray = ByteArray(2)
-        content.readNBytes(byteArray, 0, 2)
+
+        val firstValue = content.read()
+        if (firstValue == -1) {
+            content.reset()
+            return content
+        }
+        val secondValue = content.read()
+        if (secondValue == -1) {
+            content.reset()
+            return content
+        }
+        val byteArray = byteArrayOf(firstValue.toByte(), secondValue.toByte())
+
         content.reset()
         if (isGzipByteHeader(byteArray)) { return GZIPInputStream(content) }
         return content


### PR DESCRIPTION
# Change CompressedStreamHandler usage of java11 method to java8 #2923 

Close: #2923

## Description

Fix for the NoSuchMethodException in CompressedStreamHandler through a switch of the java11 method to the java8 equivalent.


