### PR TITLE
Fix permission location syntax to act on job level

### DIFF
--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -9,6 +9,10 @@ jobs:
     name: Build Project
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -56,8 +60,6 @@ jobs:
         run: sh ./script/build_gh_pages.sh
 
       - name: Upload Release Files to tagged release
-        permissions:
-          contents: write
         uses: alexellis/upload-assets@0.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
-## [1.103.4] - 2022-08-12
-
 ### Changed
 
 -   Update visualization readme file [#2932](https://github.com/MaibornWolff/codecharta/pull/2932)
 
 ### Fixed 🐞
 
--   Add permission to upload-assets action [#2979](https://github.com/MaibornWolff/codecharta/pull/2979)
+-   Add permission to upload-assets action [#2979](https://github.com/MaibornWolff/codecharta/pull/2979), [#2982](https://github.com/MaibornWolff/codecharta/pull/2982)
 
 ### Chore 👨‍💻 👩‍💻
 


### PR DESCRIPTION
# Change permission command to top level location of job pipeline 'build project'

Permissions are applied at top-level of any given job, so the command was moved out of the step from the job to job top-level.
This should fix the syntax error in our build pipeline, so that a release can be accomplished.

Issue: #2978 
Pr: #2979

Closes #2978 
