### PR TITLE
Fix stuck merge process by correcting input stream validation Issue #2953 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix bug in CompressionStreamHandler's input stream validation, that caused endless blocking reads from System.In [#2987](https://github.com/MaibornWolff/codecharta/pull/2987)
+
 ## [1.103.5] - 2022-08-12
 
 ### Changed

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/CompressedStreamHandler.kt
@@ -7,7 +7,7 @@ import java.util.zip.GZIPInputStream
 object CompressedStreamHandler {
 
     fun wrapInput(input: InputStream): InputStream {
-        if (input.available() == 2) { return input }
+        if (input.available() == 0) { return input }
         var content = input
         if (!input.markSupported()) { content = BufferedInputStream(input) }
         content.mark(2)


### PR DESCRIPTION
# Fix for importers who were stuck on merge process

This fixes a typo that caused the parsing to fail on nearly every OS, on different terminals, depending on, if they send an EOF token or not. 
The typo was introduced during the compatibility conversion to java8: #2930
This available check is required, because of a workaround described here #2854 

Root of the problem is that we always wait for stdin: #2858 

Issue: #2953

