### PR TITLE
Fix OutputFileHandler not ignoring a correctly named gz filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
--   Correct file types now get appended to the name of the output file when using the interactive ccsh [2914](https://github.com/MaibornWolff/codecharta/pull/2914)
+-   Correct file types now get appended to the name of the output file when using the interactive ccsh [#2914](https://github.com/MaibornWolff/codecharta/pull/2914)
 
 ## [1.103.6] - 2022-08-17
 

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandler.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandler.kt
@@ -19,16 +19,20 @@ object OutputFileHandler {
     }
 
     fun checkAndFixFileExtension(outputName: String): String {
-        if (outputName.endsWith("cc.json")) {
+        if (outputName.endsWith("cc.json") || outputName.endsWith(".cc.json.gz")) {
             return outputName
         }
         val sb = StringBuilder()
+        appendFilePathIfSpecified(sb, outputName)
+        sb.append(extractFileName(outputName))
+        return sb.toString()
+    }
+
+    private fun appendFilePathIfSpecified(sb: StringBuilder, outputName: String) {
         sb.append(Paths.get(outputName).parent?.toString() ?: "")
         if (sb.isNotEmpty()) {
             sb.append(File.separator)
         }
-        sb.append(extractFileName(outputName))
-        return sb.toString()
     }
 
     private fun extractFileName(outputName: String): String {

--- a/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandlerTest.kt
+++ b/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandlerTest.kt
@@ -25,7 +25,8 @@ internal class OutputFileHandlerTest {
 
     @Test
     fun checkAndFixFileExtensionPathWithFilenameBackslash() {
-        val correctFilename = OutputFileHandler.checkAndFixFileExtension("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService")
+        val correctFilename =
+            OutputFileHandler.checkAndFixFileExtension("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService")
         assertEquals("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.cc.json", correctFilename)
     }
 
@@ -33,6 +34,12 @@ internal class OutputFileHandlerTest {
     fun checkAndFixFileExtensionPathFilenameWithDotsAndSuffix() {
         val correctFilename = OutputFileHandler.checkAndFixFileExtension("my.long.map.name.cc.json")
         assertEquals("my.long.map.name.cc.json", correctFilename)
+    }
+
+    @Test
+    fun checkAndFixFileExtensionPathFilenameWithDotsAndGzSuffix() {
+        val correctFilename = OutputFileHandler.checkAndFixFileExtension("my.long.map.name.cc.json.gz")
+        assertEquals("my.long.map.name.cc.json.gz", correctFilename)
     }
 
     @Test


### PR DESCRIPTION
# Fix OutputFileHandler not ignoring a correctly named gz filename

Issue: #2800 

## Description

Addendum to PR #2914 to fix a bug that was discovered after the merge :(

