### PR TITLE
change clipboard to show file path + no name #2992

### DIFF
--- a/visualization/app/codeCharta/ui/copyToClipboardButton/util/clipboardString.spec.ts
+++ b/visualization/app/codeCharta/ui/copyToClipboardButton/util/clipboardString.spec.ts
@@ -11,27 +11,27 @@ describe("buildTextOfFiles", () => {
 	it("should return valid string if there two attributes", () => {
 		const result = buildTextOfFiles(WITH_TWO_ATTRIBUTES)
 
-		expect(result).toBe(`RLOC\n` + `\t• fileA (12)\n` + `COMMENTS\n` + `\t• fileA (14)\n`)
+		expect(result).toBe(`RLOC\n` + `\t• root/app/fileA (12)\n` + `COMMENTS\n` + `\t• root/app/fileA (14)\n`)
 	})
 
 	it("should return valid string if there is one attribute with many files", () => {
 		const result = buildTextOfFiles(WITH_ONE_ATTRIBUTE)
 
-		expect(result).toBe(`MCC\n` + `\t• file1 (100)\n` + `\t• file2 (84)\n` + `\t• file3 (122)\n`)
+		expect(result).toBe(`MCC\n` + `\t• root/app/file1 (100)\n` + `\t• root/app/file2 (84)\n` + `\t• root/app/file3 (122)\n`)
 	})
 })
 const WITH_ONE_ATTRIBUTE = new Map<string, FileToValue[]>([
 	[
 		"mcc",
 		[
-			{ name: "file1", value: 100 },
-			{ name: "file2", value: 84 },
-			{ name: "file3", value: 122 }
+			{ filePath: "root/app/file1", value: 100 },
+			{ filePath: "root/app/file2", value: 84 },
+			{ filePath: "root/app/file3", value: 122 }
 		]
 	]
 ])
 const WITH_TWO_ATTRIBUTES = new Map<string, FileToValue[]>([
-	["rloc", [{ name: "fileA", value: 12 }]],
-	["comments", [{ name: "fileA", value: 14 }]]
+	["rloc", [{ filePath: "root/app/fileA", value: 12 }]],
+	["comments", [{ filePath: "root/app/fileA", value: 14 }]]
 ])
 const WITH_ONE_FILELESS_ATTRIBUTE = new Map<string, FileToValue[]>([["functions", []]])

--- a/visualization/app/codeCharta/ui/copyToClipboardButton/util/clipboardString.ts
+++ b/visualization/app/codeCharta/ui/copyToClipboardButton/util/clipboardString.ts
@@ -1,7 +1,7 @@
 import { FileToValue } from "./getFilenamesWithHighestMetrics"
 
 function getLineFromItem(item: FileToValue): string {
-	return `\t• ${item.name} (${item.value})` + `\n`
+	return `\t• ${item.filePath} (${item.value})` + `\n`
 }
 
 function getStringHeaderFromAttribute(title: string): string {

--- a/visualization/app/codeCharta/ui/copyToClipboardButton/util/getFilenamesWithHighestMetric.spec.ts
+++ b/visualization/app/codeCharta/ui/copyToClipboardButton/util/getFilenamesWithHighestMetric.spec.ts
@@ -8,16 +8,16 @@ beforeEach(() => {
 		[
 			"mcc",
 			[
-				{ name: "file2", value: 500 },
-				{ name: "file3", value: 400 },
-				{ name: "file1", value: 300 },
-				{ name: "file1", value: 200 },
-				{ name: "file1", value: 100 },
-				{ name: "file1", value: 50 },
-				{ name: "file1", value: 20 },
-				{ name: "file1", value: 15 },
-				{ name: "file1", value: 10 },
-				{ name: "file1", value: 5 }
+				{ filePath: "root/app/file2", value: 500 },
+				{ filePath: "root/app/file3", value: 400 },
+				{ filePath: "root/app/file1", value: 300 },
+				{ filePath: "root/app/file1", value: 200 },
+				{ filePath: "root/app/file1", value: 100 },
+				{ filePath: "root/app/file1", value: 50 },
+				{ filePath: "root/app/file1", value: 20 },
+				{ filePath: "root/app/file1", value: 15 },
+				{ filePath: "root/app/file1", value: 10 },
+				{ filePath: "root/app/file1", value: 5 }
 			]
 		]
 	])
@@ -39,18 +39,18 @@ describe("getFilenamesWithHighestMetrics", () => {
 		const mccResults = resultMap.get("mcc")
 		const rlocResults = resultMap.get("rloc")
 
-		expect(rlocResults).toEqual([{ name: "leaf1", value: 5 }])
+		expect(rlocResults).toEqual([{ filePath: "root/leaf1", value: 5 }])
 		expect(mccResults).toEqual([
-			{ name: "leaf1", value: 10 },
-			{ name: "leaf2", value: 9 },
-			{ name: "leaf3", value: 8 },
-			{ name: "leaf4", value: 7 },
-			{ name: "leaf5", value: 6 },
-			{ name: "leaf6", value: 5 },
-			{ name: "leaf7", value: 4 },
-			{ name: "leaf8", value: 3 },
-			{ name: "leaf9", value: 2 },
-			{ name: "leaf10", value: 1 }
+			{ filePath: "root/leaf1", value: 10 },
+			{ filePath: "root/leaf2", value: 9 },
+			{ filePath: "root/leaf3", value: 8 },
+			{ filePath: "root/leaf4", value: 7 },
+			{ filePath: "root/leaf5", value: 6 },
+			{ filePath: "root/leaf6", value: 5 },
+			{ filePath: "root/leaf7", value: 4 },
+			{ filePath: "root/leaf8", value: 3 },
+			{ filePath: "root/leaf9", value: 2 },
+			{ filePath: "root/leaf10", value: 1 }
 		])
 	})
 
@@ -58,79 +58,85 @@ describe("getFilenamesWithHighestMetrics", () => {
 		const map = getFilenamesWithHighestMetrics(CONTAINS_FOLDER_WITH_ATTRIBUTES)
 
 		expect(map.get("rloc")).toBeUndefined()
-		expect(map.get("mcc")).toEqual([{ name: "file", value: 0 }])
+		expect(map.get("mcc")).toEqual([{ filePath: "root/file", value: 0 }])
 	})
 })
 
 describe("updateAttributeMap", () => {
 	it("should not add item to attribute if value is lower than old values", () => {
-		updateAttributeMap("mcc", 0, "file with low value", MAP)
+		updateAttributeMap("mcc", 0, "app/src/lowValueFile", MAP)
 
-		expect(MAP.get("mcc")).not.toContainEqual({ name: "file with low value", value: 0 })
+		expect(MAP.get("mcc")).not.toContainEqual({ filePath: "app/src/lowValueFile", value: 0 })
 		expect(MAP.get("mcc").length).toBe(10)
 	})
 
 	it("should add item to attribute if value is higher than old values", () => {
-		updateAttributeMap("mcc", 9001, "file with highest value", MAP)
+		updateAttributeMap("mcc", 9001, "app/src/highValueFile", MAP)
 
-		expect(MAP.get("mcc")).toContainEqual({ name: "file with highest value", value: 9001 })
+		expect(MAP.get("mcc")).toContainEqual({ filePath: "app/src/highValueFile", value: 9001 })
 		expect(MAP.get("mcc").length).toBe(10)
 	})
 
 	it("should add attribute and attribute gets item if map is empty", () => {
 		const EMPTY_MAP = new Map<string, FileToValue[]>()
 
-		updateAttributeMap("mcc", 0, "first file", EMPTY_MAP)
+		updateAttributeMap("mcc", 0, "root/app/firstFile", EMPTY_MAP)
 
-		expect(EMPTY_MAP.get("mcc")).toContainEqual({ name: "first file", value: 0 })
+		expect(EMPTY_MAP.get("mcc")).toContainEqual({ filePath: "root/app/firstFile", value: 0 })
 		expect(EMPTY_MAP.get("mcc").length).toBe(1)
 	})
 
 	it("should add item to attribute if attribute has only one item", () => {
-		const TINY_MAP = new Map<string, FileToValue[]>([["mcc", [{ name: "first file", value: 424_242 }]]])
+		const TINY_MAP = new Map<string, FileToValue[]>([["mcc", [{ filePath: "root/app/firstFile", value: 424_242 }]]])
 
-		updateAttributeMap("mcc", 0, "second file", TINY_MAP)
+		updateAttributeMap("mcc", 0, "root/secondFile", TINY_MAP)
 
-		expect(TINY_MAP.get("mcc")).toContainEqual({ name: "second file", value: 0 })
+		expect(TINY_MAP.get("mcc")).toEqual([
+			{ filePath: "root/app/firstFile", value: 424_242 },
+			{ filePath: "root/secondFile", value: 0 }
+		])
 		expect(TINY_MAP.get("mcc").length).toBe(2)
 	})
 
-	it("should add attribute and attribute gets item if attribute is new", () => {
-		updateAttributeMap("rloc", 0, "first rloc file", MAP)
+	it("should add new attribute and new attribute gets item and old attribute does not change", () => {
+		const oldMcc = MAP.get("mcc")
 
-		expect(MAP.get("rloc")).toEqual([{ name: "first rloc file", value: 0 }])
-		expect(MAP.get("mcc").length).toBe(10)
+		updateAttributeMap("rloc", 0, "app/rlocFile", MAP)
+		const newMcc = MAP.get("mcc")
+
+		expect(MAP.get("rloc")).toEqual([{ filePath: "app/rlocFile", value: 0 }])
+		expect(oldMcc).toBe(newMcc)
 		expect(MAP.size).toBe(2)
 	})
 })
 
 const BIG_NODE_WITH_TWO_ATTRIBUTES = {
-	name: "root",
+	path: "root/",
 	type: NodeType.FOLDER,
 	children: [
 		{
-			name: "folder",
+			path: "folder",
 			type: NodeType.FOLDER,
 			children: [
-				{ name: "leaf2", attributes: { ["mcc"]: 9 }, type: NodeType.FILE },
-				{ name: "leaf3", attributes: { ["mcc"]: 8 }, type: NodeType.FILE },
-				{ name: "leaf4", attributes: { ["mcc"]: 7 }, type: NodeType.FILE },
-				{ name: "leaf5", attributes: { ["mcc"]: 6 }, type: NodeType.FILE },
-				{ name: "leaf6", attributes: { ["mcc"]: 5 }, type: NodeType.FILE },
-				{ name: "leaf7", attributes: { ["mcc"]: 4 }, type: NodeType.FILE },
-				{ name: "leaf8", attributes: { ["mcc"]: 3 }, type: NodeType.FILE },
-				{ name: "leaf9", attributes: { ["mcc"]: 2 }, type: NodeType.FILE },
-				{ name: "leaf10", attributes: { ["mcc"]: 1 }, type: NodeType.FILE },
-				{ name: "leaf11", attributes: { ["mcc"]: 0 }, type: NodeType.FILE }
+				{ path: "root/leaf2", attributes: { ["mcc"]: 9 }, type: NodeType.FILE },
+				{ path: "root/leaf3", attributes: { ["mcc"]: 8 }, type: NodeType.FILE },
+				{ path: "root/leaf4", attributes: { ["mcc"]: 7 }, type: NodeType.FILE },
+				{ path: "root/leaf5", attributes: { ["mcc"]: 6 }, type: NodeType.FILE },
+				{ path: "root/leaf6", attributes: { ["mcc"]: 5 }, type: NodeType.FILE },
+				{ path: "root/leaf7", attributes: { ["mcc"]: 4 }, type: NodeType.FILE },
+				{ path: "root/leaf8", attributes: { ["mcc"]: 3 }, type: NodeType.FILE },
+				{ path: "root/leaf9", attributes: { ["mcc"]: 2 }, type: NodeType.FILE },
+				{ path: "root/leaf10", attributes: { ["mcc"]: 1 }, type: NodeType.FILE },
+				{ path: "root/leaf11", attributes: { ["mcc"]: 0 }, type: NodeType.FILE }
 			]
 		},
-		{ name: "leaf1", attributes: { ["mcc"]: 10, ["rloc"]: 5 }, type: NodeType.FILE }
+		{ path: "root/leaf1", attributes: { ["mcc"]: 10, ["rloc"]: 5 }, type: NodeType.FILE }
 	]
 }
 
 const CONTAINS_FOLDER_WITH_ATTRIBUTES = {
-	name: "root_folder",
+	path: "root/",
 	type: NodeType.FOLDER,
 	attributes: { mcc: 111, rloc: 15 },
-	children: [{ name: "file", type: NodeType.FILE, attributes: { mcc: 0 } }]
+	children: [{ path: "root/file", type: NodeType.FILE, attributes: { mcc: 0 }, children: [] }]
 }

--- a/visualization/app/codeCharta/ui/copyToClipboardButton/util/getFilenamesWithHighestMetrics.ts
+++ b/visualization/app/codeCharta/ui/copyToClipboardButton/util/getFilenamesWithHighestMetrics.ts
@@ -1,24 +1,26 @@
 import { hierarchy } from "d3-hierarchy"
 import { CodeMapNode, NodeType } from "../../../codeCharta.model"
 
-export type FileToValue = { name: string; value: number }
+export type FileToValue = { filePath: string; value: number }
 
 const MAX_ENTRIES = 10
 
-export function getFilenamesWithHighestMetrics(node: Pick<CodeMapNode, "children" | "type" | "attributes" | "name">) {
+type ReducedCodeMapNode = Pick<CodeMapNode, "type" | "attributes" | "path"> & { children?: ReducedCodeMapNode[] }
+
+export function getFilenamesWithHighestMetrics(node: ReducedCodeMapNode) {
 	const fileToValueByAttributes = new Map<string, FileToValue[]>()
 	for (const { data } of hierarchy(node)) {
 		if (data.type === NodeType.FILE && data.attributes) {
 			for (const [key, value] of Object.entries(data.attributes)) {
-				updateAttributeMap(key, value, data.name, fileToValueByAttributes)
+				updateAttributeMap(key, value, data.path, fileToValueByAttributes)
 			}
 		}
 	}
 	return fileToValueByAttributes
 }
 
-export function updateAttributeMap(key: string, value: number, fileName: string, map: Map<string, FileToValue[]>) {
-	const newPair = { name: fileName, value }
+export function updateAttributeMap(key: string, value: number, filePath: string, map: Map<string, FileToValue[]>) {
+	const newPair = { filePath, value }
 
 	const keyIsNew = !map.has(key)
 	if (keyIsNew) {


### PR DESCRIPTION
# Display file path instead of file name in clipboard text


Issue: #2992 

## Description

For the audits, Ruben prefers the complete path name in the clipboard text instead of the file name. (See comment in Zenhub.)