### PR TITLE
Refactor/2318/migrate view cube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Fix exit code handling and update integrationTest's golden_test.sh to cover all modules [#2988](https://github.com/MaibornWolff/codecharta/pull/2988)
 -   Fix missing color pickers within edge metric options [#2993](https://github.com/MaibornWolff/codecharta/pull/2993)
 
+### Chore 👨‍💻 👩‍💻
+
+-   Migrate view cube component and its service to Angular [#2998](https://github.com/MaibornWolff/codecharta/pull/2998)
+
 ## [1.103.6] - 2022-08-17
 
 ### Fixed 🐞

--- a/visualization/app/app.module.ts
+++ b/visualization/app/app.module.ts
@@ -42,7 +42,6 @@ import { HeightSettingsPanelModule } from "./codeCharta/ui/ribbonBar/heightSetti
 import { FilePanelModule } from "./codeCharta/ui/filePanel/filePanel.module"
 import { CustomConfigsModule } from "./codeCharta/ui/customConfigs/customConfigs.module"
 import { ResetColorRangeEffect } from "./codeCharta/state/store/dynamicSettings/colorRange/resetColorRange.effect"
-import { CenterMapButtonModule } from "./codeCharta/ui/viewCube/centerMapButton/centerMapButton.module"
 import { GlobalConfigurationButtonModule } from "./codeCharta/ui/toolBar/globalConfigurationButton/globalConfigurationButton.module"
 import { FileExtensionBarModule } from "./codeCharta/ui/fileExtensionBar/fileExtensionBar.module"
 import { AreaSettingsPanelModule } from "./codeCharta/ui/ribbonBar/areaSettingsPanel/areaSettingsPanel.module"
@@ -60,6 +59,7 @@ import { ScreenshotButtonModule } from "./codeCharta/ui/screenshotButton/screens
 import { SplitStateActionsEffect } from "./codeCharta/state/effects/splitStateActionsEffect/splitStateActions.effect"
 import { CopyToClipboardButtonModule } from "./codeCharta/ui/copyToClipboardButton/copyToClipboardButton.module"
 import { DownloadButtonModule } from "./codeCharta/ui/toolBar/downloadButton/downloadButton.module"
+import { ViewCubeModule } from "./codeCharta/ui/viewCube/viewCube.module"
 
 @NgModule({
 	imports: [
@@ -91,7 +91,7 @@ import { DownloadButtonModule } from "./codeCharta/ui/toolBar/downloadButton/dow
 		CustomConfigsModule,
 		FilePanelModule,
 		HeightSettingsPanelModule,
-		CenterMapButtonModule,
+		ViewCubeModule,
 		GlobalConfigurationButtonModule,
 		FileExtensionBarModule,
 		AreaSettingsPanelModule,

--- a/visualization/app/codeCharta/codeCharta.component.scss
+++ b/visualization/app/codeCharta/codeCharta.component.scss
@@ -55,7 +55,7 @@ code-charta-component {
 	cc-attribute-side-bar .side-bar-container,
 	cc-legend-panel .block-wrapper,
 	cc-legend-panel .panel-button,
-	view-cube-component,
+	cc-view-cube,
 	unfocus-button-component {
 		transition: right 0.3s ease;
 	}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
@@ -1,4 +1,4 @@
 <div id="codeMap" ng-hide="$ctrl._viewModel.isLoadingFile">
-	<view-cube-component ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></view-cube-component>
+	<cc-view-cube ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></cc-view-cube>
 	<cc-attribute-side-bar></cc-attribute-side-bar>
 </div>

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -1,5 +1,5 @@
 code-map-component {
-	view-cube-component {
+	cc-view-cube {
 		position: absolute;
 		z-index: 11;
 		right: 0px;

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.spec.ts
@@ -17,22 +17,21 @@ import {
 } from "three"
 import { ThreeCameraService } from "./threeViewer/threeCameraService"
 import { ThreeSceneService } from "./threeViewer/threeSceneService"
-import { IRootScopeService } from "angular"
 import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
-import { withMockedEventMethods } from "../../util/dataMocks"
 import { StoreService } from "../../state/store.service"
 import { setScaling } from "../../state/store/appSettings/scaling/scaling.actions"
 import { setAmountOfTopLabels } from "../../state/store/appSettings/amountOfTopLabels/amountOfTopLabels.actions"
 import { setHeightMetric } from "../../state/store/dynamicSettings/heightMetric/heightMetric.actions"
 import { setShowMetricLabelNameValue } from "../../state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.actions"
 import { setShowMetricLabelNodeName } from "../../state/store/appSettings/showMetricLabelNodeName/showMetricLabelNodeName.actions"
+import { ThreeOrbitControlsService } from "./threeViewer/threeOrbitControlsService"
 
 describe("CodeMapLabelService", () => {
-	let $rootScope: IRootScopeService
 	let storeService: StoreService
 	let threeCameraService: ThreeCameraService
 	let threeSceneService: ThreeSceneService
 	let codeMapLabelService: CodeMapLabelService
+	let threeOrbitControlsService: ThreeOrbitControlsService
 	let createElementOrigin
 	let sampleLeaf: Node
 	let otherSampleLeaf: Node
@@ -42,7 +41,6 @@ describe("CodeMapLabelService", () => {
 	beforeEach(() => {
 		restartSystem()
 		rebuild()
-		withMockedEventMethods($rootScope)
 		withMockedThreeCameraService()
 		withMockedThreeSceneService()
 		setCanvasRenderSettings()
@@ -51,14 +49,14 @@ describe("CodeMapLabelService", () => {
 	function restartSystem() {
 		instantiateModule("app.codeCharta.ui.codeMap")
 
-		$rootScope = getService<IRootScopeService>("$rootScope")
 		storeService = getService<StoreService>("storeService")
 		threeCameraService = getService<ThreeCameraService>("threeCameraService")
 		threeSceneService = getService<ThreeSceneService>("threeSceneService")
+		threeOrbitControlsService = getService<ThreeOrbitControlsService>("threeOrbitControlsService")
 	}
 
 	function rebuild() {
-		codeMapLabelService = new CodeMapLabelService($rootScope, storeService, threeCameraService, threeSceneService)
+		codeMapLabelService = new CodeMapLabelService(storeService, threeCameraService, threeSceneService, threeOrbitControlsService)
 	}
 
 	function withMockedThreeCameraService() {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -1,9 +1,8 @@
 import { Sprite, Vector3, Box3, Sphere, LineBasicMaterial, Line, BufferGeometry, LinearFilter, Texture, SpriteMaterial, Color } from "three"
 import { LayoutAlgorithm, Node } from "../../codeCharta.model"
-import { CameraChangeSubscriber, ThreeOrbitControlsService } from "./threeViewer/threeOrbitControlsService"
+import { ThreeOrbitControlsService } from "./threeViewer/threeOrbitControlsService"
 import { ThreeCameraService } from "./threeViewer/threeCameraService"
 import { ThreeSceneService } from "./threeViewer/threeSceneService"
-import { IRootScopeService } from "angular"
 import { StoreService } from "../../state/store.service"
 import { ColorConverter } from "../../util/color/colorConverter"
 
@@ -15,7 +14,7 @@ interface InternalLabel {
 	node: Node
 }
 
-export class CodeMapLabelService implements CameraChangeSubscriber {
+export class CodeMapLabelService {
 	private labels: InternalLabel[]
 	private mapLabelColors = this.storeService.getState().appSettings.mapColors.labelColorAndAlpha
 	private LABEL_COLOR_RGB = ColorConverter.convertHexToRgba(this.mapLabelColors.rgb)
@@ -31,14 +30,14 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 	private nodeHeight = 0
 
 	constructor(
-		private $rootScope: IRootScopeService,
 		private storeService: StoreService,
 		private threeCameraService: ThreeCameraService,
-		private threeSceneService: ThreeSceneService
+		private threeSceneService: ThreeSceneService,
+		private threeOrbitControlsService: ThreeOrbitControlsService
 	) {
 		"ngInject"
 		this.labels = new Array<InternalLabel>()
-		ThreeOrbitControlsService.subscribe(this.$rootScope, this)
+		this.threeOrbitControlsService.subscribe("onCameraChanged", this.onCameraChanged)
 	}
 
 	// Labels need to be scaled according to map or it will clip + looks bad
@@ -194,7 +193,7 @@ export class CodeMapLabelService implements CameraChangeSubscriber {
 		this.previousScaling.copy(scaling)
 	}
 
-	onCameraChanged() {
+	onCameraChanged = () => {
 		for (const label of this.labels) {
 			this.setLabelSize(label.sprite, label, label.sprite.material.map.image.width)
 		}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.label.service.ts
@@ -37,7 +37,7 @@ export class CodeMapLabelService {
 	) {
 		"ngInject"
 		this.labels = new Array<InternalLabel>()
-		this.threeOrbitControlsService.subscribe("onCameraChanged", this.onCameraChanged)
+		this.threeOrbitControlsService.subscribe("onCameraChanged", () => this.onCameraChanged())
 	}
 
 	// Labels need to be scaled according to map or it will clip + looks bad
@@ -193,7 +193,7 @@ export class CodeMapLabelService {
 		this.previousScaling.copy(scaling)
 	}
 
-	onCameraChanged = () => {
+	onCameraChanged() {
 		for (const label of this.labels) {
 			this.setLabelSize(label.sprite, label, label.sprite.material.map.image.width)
 		}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
@@ -1,6 +1,6 @@
 import angular from "angular"
 import camelCase from "lodash.camelcase"
-import { downgradeComponent } from "@angular/upgrade/static"
+import { downgradeComponent, downgradeInjectable } from "@angular/upgrade/static"
 
 import "./threeViewer/threeViewer.module"
 import "../../state/state.module"
@@ -11,9 +11,12 @@ import { CodeMapLabelService } from "./codeMap.label.service"
 import { CodeMapArrowService } from "./codeMap.arrow.service"
 import { CodeMapPreRenderService } from "./codeMap.preRender.service"
 import { AttributeSideBarComponent } from "../attributeSideBar/attributeSideBar.component"
+import { ViewCubeComponent } from "../viewCube/viewCube.component"
+import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 
 angular
 	.module("app.codeCharta.ui.codeMap", ["app.codeCharta.state", "app.codeCharta", "app.codeCharta.ui.codeMap.threeViewer"])
+	.factory("viewCubeMouseEvents", downgradeInjectable(ViewCubeMouseEventsService))
 	.component(codeMapComponent.selector, codeMapComponent)
 	.directive("ccAttributeSideBar", downgradeComponent({ component: AttributeSideBarComponent }))
 	.service(camelCase(CodeMapRenderService.name), CodeMapRenderService)
@@ -21,3 +24,4 @@ angular
 	.service(camelCase(CodeMapMouseEventService.name), CodeMapMouseEventService)
 	.service(camelCase(CodeMapLabelService.name), CodeMapLabelService)
 	.service(camelCase(CodeMapArrowService.name), CodeMapArrowService)
+	.directive("ccViewCube", downgradeComponent({ component: ViewCubeComponent }))

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -54,7 +54,6 @@ describe("codeMapMouseEventService", () => {
 		withMockedWindow()
 		withMockedThreeUpdateCycleService()
 		withMockedThreeRendererService()
-		withMockedViewCubeMouseEventsService()
 		withMockedThreeCameraService()
 		withMockedThreeSceneService()
 		withMockedEventMethods($rootScope)
@@ -79,7 +78,12 @@ describe("codeMapMouseEventService", () => {
 		threeUpdateCycleService = getService<ThreeUpdateCycleService>("threeUpdateCycleService")
 		storeService = getService<StoreService>("storeService")
 		codeMapLabelService = getService<CodeMapLabelService>("codeMapLabelService")
-		viewCubeMouseEventsService = getService<ViewCubeMouseEventsService>("viewCubeMouseEventsService")
+		viewCubeMouseEventsService = {
+			subscribe: jest.fn(),
+			propagateMovement: jest.fn(),
+			resetIsDragging: jest.fn(),
+			onDocumentDoubleClick: jest.fn()
+		} as unknown as ViewCubeMouseEventsService
 		threeViewerService = getService<ThreeViewerService>("threeViewerService")
 		idToBuildingService = getService<IdToBuildingService>("idToBuilding")
 
@@ -130,10 +134,6 @@ describe("codeMapMouseEventService", () => {
 				getPixelRatio: jest.fn().mockReturnValue(2)
 			}
 		})()
-	}
-
-	function withMockedViewCubeMouseEventsService() {
-		ViewCubeMouseEventsService.subscribeToEventPropagation = jest.fn()
 	}
 
 	function withMockedThreeCameraService() {
@@ -210,14 +210,6 @@ describe("codeMapMouseEventService", () => {
 			expect(addEventListenerMock.mock.calls[6][0]).toEqual("wheel")
 			expect(addEventListenerMock).toHaveBeenCalledTimes(7)
 		})
-
-		it("should subscribe to event propagation", () => {
-			ViewCubeMouseEventsService.subscribeToEventPropagation = jest.fn()
-
-			codeMapMouseEventService.start()
-
-			expect(ViewCubeMouseEventsService.subscribeToEventPropagation).toHaveBeenCalledWith($rootScope, codeMapMouseEventService)
-		})
 	})
 
 	describe("onViewCubeEventPropagation", () => {
@@ -229,28 +221,28 @@ describe("codeMapMouseEventService", () => {
 		})
 
 		it("should call onDocumentMouseMove", () => {
-			codeMapMouseEventService.onViewCubeEventPropagation("mousemove", null)
-
-			expect(codeMapMouseEventService.onDocumentMouseMove).toHaveBeenCalledWith(null)
+			const data = { type: "mousemove", event: new MouseEvent("mousemove") }
+			codeMapMouseEventService.onViewCubeEventPropagation(data)
+			expect(codeMapMouseEventService.onDocumentMouseMove).toHaveBeenCalledWith(data.event)
 		})
 
 		it("should call onDocumentMouseDown", () => {
-			codeMapMouseEventService.onViewCubeEventPropagation("mousedown", null)
-
-			expect(codeMapMouseEventService.onDocumentMouseDown).toHaveBeenCalledWith(null)
+			const data = { type: "mousedown", event: new MouseEvent("mousedown") }
+			codeMapMouseEventService.onViewCubeEventPropagation(data)
+			expect(codeMapMouseEventService.onDocumentMouseDown).toHaveBeenCalledWith(data.event)
 			expect(codeMapMouseEventService.onDocumentDoubleClick).not.toHaveBeenCalled()
 		})
 
 		it("should call onDocumentMouseUp", () => {
-			codeMapMouseEventService.onViewCubeEventPropagation("mouseup", null)
-
-			expect(codeMapMouseEventService.onDocumentMouseUp).toHaveBeenCalled()
+			const data = { type: "mouseup", event: new MouseEvent("mouseup") }
+			codeMapMouseEventService.onViewCubeEventPropagation(data)
+			expect(codeMapMouseEventService.onDocumentMouseUp).toHaveBeenCalledWith(data.event)
 		})
 
 		it("should call onDocumentDoubleClick", () => {
-			codeMapMouseEventService.onViewCubeEventPropagation("dblclick", null)
-
-			expect(codeMapMouseEventService.onDocumentDoubleClick).toHaveBeenCalled()
+			const data = { type: "dblclick", event: new MouseEvent("dblclick") }
+			codeMapMouseEventService.onViewCubeEventPropagation(data)
+			expect(codeMapMouseEventService.onDocumentDoubleClick).toHaveBeenCalledWith()
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -72,7 +72,7 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 		private threeUpdateCycleService: ThreeUpdateCycleService,
 		private storeService: StoreService,
 		private codeMapLabelService: CodeMapLabelService,
-		private viewCubeMouseEventsService: ViewCubeMouseEventsService,
+		private viewCubeMouseEvents: ViewCubeMouseEventsService,
 		private threeViewerService: ThreeViewerService,
 		private idToBuilding: IdToBuildingService
 	) {
@@ -129,7 +129,7 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 			"wheel",
 			debounce(() => this.threeRendererService.render(), 60)
 		)
-		this.viewCubeMouseEventsService.subscribe("viewCubeEventPropagation", this.onViewCubeEventPropagation)
+		this.viewCubeMouseEvents.subscribe("viewCubeEventPropagation", this.onViewCubeEventPropagation)
 	}
 
 	hoverNode(id: number) {
@@ -274,7 +274,7 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 
 	private EnableOrbitalsRotation(isRotation: boolean) {
 		this.threeViewerService.enableRotation(isRotation)
-		this.viewCubeMouseEventsService.enableRotation(isRotation)
+		this.viewCubeMouseEvents.enableRotation(isRotation)
 	}
 
 	onDocumentMouseEnter() {
@@ -291,7 +291,7 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 		this.mouse.x = event.clientX
 		this.mouse.y = event.clientY
 		this.updateHovering()
-		this.viewCubeMouseEventsService.propagateMovement()
+		this.viewCubeMouseEvents.propagateMovement()
 	}
 
 	onDocumentDoubleClick() {
@@ -326,7 +326,7 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 	}
 
 	onDocumentMouseUp(event: MouseEvent) {
-		this.viewCubeMouseEventsService.resetIsDragging()
+		this.viewCubeMouseEvents.resetIsDragging()
 		if (event.button === ClickType.LeftClick) {
 			this.onLeftClick()
 		} else {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -1,7 +1,7 @@
 import { ThreeCameraService } from "./threeViewer/threeCameraService"
 import { IRootScopeService, IWindowService } from "angular"
 import { CodeMapBuilding } from "./rendering/codeMapBuilding"
-import { ViewCubeEventPropagationSubscriber, ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
+import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 import { BlacklistItem } from "../../codeCharta.model"
 import { ThreeSceneService } from "./threeViewer/threeSceneService"
 import { ThreeUpdateCycleService } from "./threeViewer/threeUpdateCycleService"
@@ -46,7 +46,7 @@ export enum CursorType {
 	Moving = "move"
 }
 
-export class CodeMapMouseEventService implements ViewCubeEventPropagationSubscriber, FilesSelectionSubscriber, BlacklistSubscriber {
+export class CodeMapMouseEventService implements FilesSelectionSubscriber, BlacklistSubscriber {
 	private static readonly BUILDING_HOVERED_EVENT = "building-hovered"
 	private static readonly BUILDING_UNHOVERED_EVENT = "building-unhovered"
 	private readonly THRESHOLD_FOR_MOUSE_MOVEMENT_TRACKING = 3
@@ -129,7 +129,7 @@ export class CodeMapMouseEventService implements ViewCubeEventPropagationSubscri
 			"wheel",
 			debounce(() => this.threeRendererService.render(), 60)
 		)
-		ViewCubeMouseEventsService.subscribeToEventPropagation(this.$rootScope, this)
+		this.viewCubeMouseEventsService.subscribe("viewCubeEventPropagation", this.onViewCubeEventPropagation)
 	}
 
 	hoverNode(id: number) {
@@ -153,16 +153,16 @@ export class CodeMapMouseEventService implements ViewCubeEventPropagationSubscri
 		this.threeUpdateCycleService.update()
 	}
 
-	onViewCubeEventPropagation(eventType: string, event: MouseEvent) {
-		switch (eventType) {
+	onViewCubeEventPropagation = (data: { type: string; event: MouseEvent }) => {
+		switch (data.type) {
 			case "mousemove":
-				this.onDocumentMouseMove(event)
+				this.onDocumentMouseMove(data.event)
 				break
 			case "mouseup":
-				this.onDocumentMouseUp(event)
+				this.onDocumentMouseUp(data.event)
 				break
 			case "mousedown":
-				this.onDocumentMouseDown(event)
+				this.onDocumentMouseDown(data.event)
 				break
 			case "dblclick":
 				this.onDocumentDoubleClick()

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
@@ -27,7 +27,7 @@ export class ThreeOrbitControlsService
 {
 	controls: OrbitControls
 	defaultCameraPosition: Vector3 = new Vector3(0, 0, 0)
-	eventEmitter = new EventEmitter<CameraChangeEvents>()
+	private eventEmitter = new EventEmitter<CameraChangeEvents>()
 
 	constructor(
 		private $rootScope: IRootScopeService,

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
@@ -11,7 +11,6 @@ import {
 } from "../../../state/store/dynamicSettings/focusedNodePath/focusedNodePath.service"
 import { FilesService, FilesSelectionSubscriber } from "../../../state/store/files/files.service"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
-
 // TODO remove this old orbital control and use the jsm examples oneW
 // eslint-disable-next-line no-duplicate-imports
 import * as Three from "three"

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeOrbitControlsService.ts
@@ -1,5 +1,5 @@
 import { ThreeCameraService } from "./threeCameraService"
-import { IRootScopeService, IAngularEvent, ITimeoutService } from "angular"
+import { IRootScopeService, ITimeoutService } from "angular"
 import { Box3, Mesh, MeshNormalMaterial, PerspectiveCamera, Vector3, Sphere, BoxGeometry } from "three"
 import { ThreeSceneService } from "./threeSceneService"
 import { StoreService } from "../../../state/store.service"
@@ -17,18 +17,18 @@ import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
 import * as Three from "three"
 import oc from "three-orbit-controls"
 import { ThreeUpdateCycleService } from "./threeUpdateCycleService"
+import { EventEmitter } from "tsee"
 
-export interface CameraChangeSubscriber {
-	onCameraChanged(camera: PerspectiveCamera)
+type CameraChangeEvents = {
+	onCameraChanged: (data: { camera: PerspectiveCamera }) => void
 }
 
 export class ThreeOrbitControlsService
 	implements FocusNodeSubscriber, UnfocusNodeSubscriber, FilesSelectionSubscriber, LayoutAlgorithmSubscriber
 {
-	static CAMERA_CHANGED_EVENT_NAME = "camera-changed"
-
 	controls: OrbitControls
 	defaultCameraPosition: Vector3 = new Vector3(0, 0, 0)
+	eventEmitter = new EventEmitter<CameraChangeEvents>()
 
 	constructor(
 		private $rootScope: IRootScopeService,
@@ -162,12 +162,12 @@ export class ThreeOrbitControlsService
 
 	onInput(camera: PerspectiveCamera) {
 		this.setControlTarget(this.controls.target)
-		this.$rootScope.$broadcast(ThreeOrbitControlsService.CAMERA_CHANGED_EVENT_NAME, camera)
+		this.eventEmitter.emit("onCameraChanged", { camera })
 	}
 
-	static subscribe($rootScope: IRootScopeService, subscriber: CameraChangeSubscriber) {
-		$rootScope.$on(ThreeOrbitControlsService.CAMERA_CHANGED_EVENT_NAME, (_event: IAngularEvent, camera: PerspectiveCamera) => {
-			subscriber.onCameraChanged(camera)
+	subscribe<Key extends keyof CameraChangeEvents>(key: Key, callback: CameraChangeEvents[Key]) {
+		this.eventEmitter.on(key, data => {
+			callback(data)
 		})
 	}
 }

--- a/visualization/app/codeCharta/ui/ui.ts
+++ b/visualization/app/codeCharta/ui/ui.ts
@@ -22,8 +22,7 @@ angular
 		"app.codeCharta.ui.dialog",
 		"app.codeCharta.ui.resetSettingsButton",
 		"app.codeCharta.ui.ribbonBar",
-		"app.codeCharta.ui.toolBar",
-		"app.codeCharta.ui.viewCube"
+		"app.codeCharta.ui.toolBar"
 	])
 	.directive("ccExportThreedMapButton", downgradeComponent({ component: Export3DMapButtonComponent }))
 	.directive("ccLegendPanel", downgradeComponent({ component: LegendPanelComponent }))

--- a/visualization/app/codeCharta/ui/viewCube/centerMapButton/centerMapButton.module.ts
+++ b/visualization/app/codeCharta/ui/viewCube/centerMapButton/centerMapButton.module.ts
@@ -1,9 +1,0 @@
-import { NgModule } from "@angular/core"
-import { CenterMapButtonComponent } from "./centerMapButton.component"
-
-@NgModule({
-	declarations: [CenterMapButtonComponent],
-	exports: [CenterMapButtonComponent],
-	entryComponents: [CenterMapButtonComponent]
-})
-export class CenterMapButtonModule {}

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.component.spec.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.component.spec.ts
@@ -1,72 +1,33 @@
 import "./viewCube.module"
-import { IRootScopeService } from "angular"
-import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
 import { ThreeOrbitControlsService } from "../codeMap/threeViewer/threeOrbitControlsService"
-import { ViewCubeController } from "./viewCube.component"
 import { ViewCubeMouseEventsService } from "./viewCube.mouseEvents.service"
 import { PerspectiveCamera } from "three/src/cameras/PerspectiveCamera"
 import { ThreeCameraService } from "../codeMap/threeViewer/threeCameraService"
 import { Color, Mesh, Vector3, WebGLRenderer } from "three"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
+import { ViewCubeComponent } from "./viewCube.component"
 
-describe("ViewCubeController", () => {
-	let viewCubeController: ViewCubeController
-	let $rootScope: IRootScopeService
+describe("ViewCubeComponent", () => {
+	let viewCubeComponent: ViewCubeComponent
 	let threeOrbitControlsService: ThreeOrbitControlsService
 	let viewCubeMouseEventsService: ViewCubeMouseEventsService
-	let $element: Element
 
 	beforeEach(() => {
-		restartSystem()
-		rebuildController()
-		mockElement()
-	})
-
-	function restartSystem() {
-		instantiateModule("app.codeCharta.ui.viewCube")
-
-		$rootScope = getService<IRootScopeService>("$rootScope")
-		threeOrbitControlsService = getService<ThreeOrbitControlsService>("storeService")
-		viewCubeMouseEventsService = getService<ViewCubeMouseEventsService>("storeService")
-		viewCubeMouseEventsService.init = jest.fn()
+		threeOrbitControlsService = {} as ThreeOrbitControlsService
+		viewCubeMouseEventsService = { init: jest.fn() } as unknown as ViewCubeMouseEventsService
 		threeOrbitControlsService.controls = {
 			target: new Vector3(1, 2, 3)
 		} as OrbitControls
-	}
-
-	function rebuildController() {
-		ViewCubeController.prototype["initRenderer"] = jest.fn()
-		ViewCubeController.prototype["onAnimationFrame"] = jest.fn()
-
-		viewCubeController = new ViewCubeController($element, $rootScope, threeOrbitControlsService, viewCubeMouseEventsService)
-	}
-
-	function mockElement() {
-		$element = [] as unknown as Element
-	}
-
-	describe("constructor", () => {
-		it("should subscribe to ThreeOrbitControlsService", () => {
-			ThreeOrbitControlsService.subscribe = jest.fn()
-
-			rebuildController()
-
-			expect(ThreeOrbitControlsService.subscribe).toHaveBeenCalledWith($rootScope, viewCubeController)
-		})
-
-		it("should subscribe to ViewCubeMouseEventsService", () => {
-			ViewCubeMouseEventsService.subscribeToViewCubeMouseEvents = jest.fn()
-
-			rebuildController()
-
-			expect(ViewCubeMouseEventsService.subscribeToViewCubeMouseEvents).toHaveBeenCalledWith($rootScope, viewCubeController)
-		})
+		ViewCubeComponent.prototype["initRenderer"] = jest.fn()
+		ViewCubeComponent.prototype["onAnimationFrame"] = jest.fn()
+		const elementReference = { nativeElement: {} as HTMLElement }
+		viewCubeComponent = new ViewCubeComponent(elementReference, threeOrbitControlsService, viewCubeMouseEventsService)
 	})
 
 	describe("onCameraChanged", () => {
 		it("should call setCameraPosition", () => {
-			viewCubeController["setCameraPosition"] = jest.fn()
-			viewCubeController["renderer"] = {
+			viewCubeComponent["setCameraPosition"] = jest.fn()
+			viewCubeComponent["renderer"] = {
 				render: jest.fn()
 			} as unknown as WebGLRenderer
 			const perspectiveCamera = new PerspectiveCamera(
@@ -76,9 +37,9 @@ describe("ViewCubeController", () => {
 				ThreeCameraService.FAR
 			)
 
-			viewCubeController.onCameraChanged(perspectiveCamera)
+			viewCubeComponent.onCameraChanged({ camera: perspectiveCamera })
 
-			expect(viewCubeController["setCameraPosition"]).toHaveBeenCalledWith({
+			expect(viewCubeComponent["setCameraPosition"]).toHaveBeenCalledWith({
 				x: -0.801_783_725_737_273_2,
 				y: -1.603_567_451_474_546_4,
 				z: -2.405_351_177_211_819_5
@@ -88,28 +49,28 @@ describe("ViewCubeController", () => {
 
 	describe("onCubeHovered", () => {
 		it("should set hover info cube emmisive color to white", () => {
-			viewCubeController["renderer"] = {
+			viewCubeComponent["renderer"] = {
 				render: jest.fn()
 			} as unknown as WebGLRenderer
-			viewCubeController.onCubeHovered(new Mesh())
+			viewCubeComponent.onCubeHovered({ cube: new Mesh() })
 
-			expect(viewCubeController["hoverInfo"].cube.material.emissive).toStrictEqual(new Color(0xff_ff_ff))
+			expect(viewCubeComponent["hoverInfo"].cube.material.emissive).toStrictEqual(new Color(0xff_ff_ff))
 		})
 	})
 
 	describe("onCubeUnHovered", () => {
 		it("should set cube to null", () => {
-			viewCubeController["hoverInfo"].cube = {
+			viewCubeComponent["hoverInfo"].cube = {
 				material: {
 					emissive: new Color(0xff_ff_ff)
 				}
 			}
-			viewCubeController["renderer"] = {
+			viewCubeComponent["renderer"] = {
 				render: jest.fn()
 			} as unknown as WebGLRenderer
-			viewCubeController.onCubeUnhovered()
+			viewCubeComponent.onCubeUnhovered()
 
-			expect(viewCubeController["hoverInfo"].cube).toBe(null)
+			expect(viewCubeComponent["hoverInfo"].cube).toBe(null)
 		})
 	})
 
@@ -317,12 +278,12 @@ describe("ViewCubeController", () => {
 
 		beforeEach(() => {
 			threeOrbitControlsService.rotateCameraInVectorDirection = jest.fn()
-			viewCubeController["cubeDefinition"] = cubeDefinition
+			viewCubeComponent["cubeDefinition"] = cubeDefinition
 		})
 
 		for (const test of loopTests) {
 			it(`should rotateCameraInVectorDirection with ${test.expectedString} when mesh is ${test.whenObject}`, () => {
-				viewCubeController.onCubeClicked(test.eventValue)
+				viewCubeComponent.onCubeClicked({ cube: test.eventValue })
 
 				const expected = test.expected
 				expect(threeOrbitControlsService.rotateCameraInVectorDirection).toHaveBeenCalledWith(expected.x, expected.y, expected.z)

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
@@ -11,12 +11,11 @@ import {
 	Vector3,
 	WebGLRenderer
 } from "three"
-import { IRootScopeService } from "angular"
 import { ViewCubemeshGenerator } from "./viewCube.meshGenerator"
-import { CameraChangeSubscriber, ThreeOrbitControlsService } from "../codeMap/threeViewer/threeOrbitControlsService"
+import { ThreeOrbitControlsService } from "../codeMap/threeViewer/threeOrbitControlsService"
 import { ViewCubeMouseEventsService } from "./viewCube.mouseEvents.service"
 
-export class ViewCubeController implements CameraChangeSubscriber {
+export class ViewCubeController {
 	private lights: Group
 	private cubeGroup: Group
 	private camera: PerspectiveCamera
@@ -36,7 +35,6 @@ export class ViewCubeController implements CameraChangeSubscriber {
 
 	constructor(
 		private $element,
-		private $rootScope: IRootScopeService,
 		private threeOrbitControlsService: ThreeOrbitControlsService,
 		private viewCubeMouseEventsService: ViewCubeMouseEventsService
 	) {
@@ -49,7 +47,7 @@ export class ViewCubeController implements CameraChangeSubscriber {
 		this.initCamera()
 		this.viewCubeMouseEventsService.init(this.cubeGroup, this.camera, this.renderer)
 
-		ThreeOrbitControlsService.subscribe(this.$rootScope, this)
+		this.threeOrbitControlsService.subscribe("onCameraChanged", this.onCameraChanged)
 		this.viewCubeMouseEventsService.subscribe("viewCubeHoveredEvent", this.onCubeHovered)
 		this.viewCubeMouseEventsService.subscribe("viewCubeHoveredEvent", this.onCubeUnhovered)
 		this.viewCubeMouseEventsService.subscribe("viewCubeClicked", this.onCubeClicked)
@@ -79,8 +77,8 @@ export class ViewCubeController implements CameraChangeSubscriber {
 		this.scene.add(cubeBoundingBox)
 	}
 
-	onCameraChanged(camera: PerspectiveCamera) {
-		const newCameraPosition = this.calculateCameraPosition(camera)
+	onCameraChanged = (data: { camera: PerspectiveCamera }) => {
+		const newCameraPosition = this.calculateCameraPosition(data.camera)
 		this.setCameraPosition(newCameraPosition)
 		this.updateRenderFrame()
 	}

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
@@ -14,9 +14,9 @@ import {
 import { IRootScopeService } from "angular"
 import { ViewCubemeshGenerator } from "./viewCube.meshGenerator"
 import { CameraChangeSubscriber, ThreeOrbitControlsService } from "../codeMap/threeViewer/threeOrbitControlsService"
-import { ViewCubeEventSubscriber, ViewCubeMouseEventsService } from "./viewCube.mouseEvents.service"
+import { ViewCubeMouseEventsService } from "./viewCube.mouseEvents.service"
 
-export class ViewCubeController implements CameraChangeSubscriber, ViewCubeEventSubscriber {
+export class ViewCubeController implements CameraChangeSubscriber {
 	private lights: Group
 	private cubeGroup: Group
 	private camera: PerspectiveCamera
@@ -50,7 +50,9 @@ export class ViewCubeController implements CameraChangeSubscriber, ViewCubeEvent
 		this.viewCubeMouseEventsService.init(this.cubeGroup, this.camera, this.renderer)
 
 		ThreeOrbitControlsService.subscribe(this.$rootScope, this)
-		ViewCubeMouseEventsService.subscribeToViewCubeMouseEvents(this.$rootScope, this)
+		this.viewCubeMouseEventsService.subscribe("viewCubeHoveredEvent", this.onCubeHovered)
+		this.viewCubeMouseEventsService.subscribe("viewCubeHoveredEvent", this.onCubeUnhovered)
+		this.viewCubeMouseEventsService.subscribe("viewCubeClicked", this.onCubeClicked)
 	}
 
 	private initAxesHelper() {
@@ -118,23 +120,23 @@ export class ViewCubeController implements CameraChangeSubscriber, ViewCubeEvent
 		this.camera.position.z = 4
 	}
 
-	onCubeHovered(cube: Mesh) {
+	onCubeHovered = (data: { cube: Mesh }) => {
 		this.hoverInfo = {
-			cube,
-			originalMaterial: cube.material
+			cube: data.cube,
+			originalMaterial: data.cube.material
 		}
 		this.hoverInfo.cube.material.emissive = new Color(0xff_ff_ff)
 		this.updateRenderFrame()
 	}
 
-	onCubeUnhovered() {
+	onCubeUnhovered = () => {
 		this.hoverInfo.cube.material.emissive = new Color(0x00_00_00) //? NOTE why is this needed
 		this.hoverInfo.cube = null
 		this.updateRenderFrame()
 	}
 
-	onCubeClicked(cube: Mesh) {
-		switch (cube) {
+	onCubeClicked = (data: { cube: Mesh }) => {
+		switch (data.cube) {
 			case this.cubeDefinition.front.top.middle:
 				this.threeOrbitControlsService.rotateCameraInVectorDirection(0, -1, -1)
 				break

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
@@ -42,7 +42,7 @@ export class ViewCubeComponent implements OnInit {
 	constructor(
 		@Inject(ElementRef) private elementReference: ElementRef,
 		@Inject(ThreeOrbitControlsServiceToken) private threeOrbitControlsService: ThreeOrbitControlsService,
-		@Inject(ViewCubeMouseEventsService) private viewCubeMouseEventsService: ViewCubeMouseEventsService
+		@Inject(ViewCubeMouseEventsService) private viewCubeMouseEvents: ViewCubeMouseEventsService
 	) {}
 
 	ngOnInit() {
@@ -52,12 +52,12 @@ export class ViewCubeComponent implements OnInit {
 		this.initCube()
 		this.initAxesHelper()
 		this.initCamera()
-		this.viewCubeMouseEventsService.init(this.cubeGroup, this.camera, this.renderer)
+		this.viewCubeMouseEvents.init(this.cubeGroup, this.camera, this.renderer)
 
 		this.threeOrbitControlsService.subscribe("onCameraChanged", this.onCameraChanged)
-		this.viewCubeMouseEventsService.subscribe("viewCubeHoveredEvent", this.onCubeHovered)
-		this.viewCubeMouseEventsService.subscribe("viewCubeUnHoveredEvent", this.onCubeUnhovered)
-		this.viewCubeMouseEventsService.subscribe("viewCubeClicked", this.onCubeClicked)
+		this.viewCubeMouseEvents.subscribe("viewCubeHoveredEvent", this.onCubeHovered)
+		this.viewCubeMouseEvents.subscribe("viewCubeUnHoveredEvent", this.onCubeUnhovered)
+		this.viewCubeMouseEvents.subscribe("viewCubeClicked", this.onCubeClicked)
 	}
 
 	private initAxesHelper() {

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.component.ts
@@ -109,7 +109,7 @@ export class ViewCubeController implements CameraChangeSubscriber, ViewCubeEvent
 			antialias: true
 		})
 		this.renderer.setSize(this.WIDTH, this.HEIGHT)
-		this.renderer.setPixelRatio(window.devicePixelRatio) // geometry is low poly, no noticeble performance hit even with higher device pixel ratio
+		this.renderer.setPixelRatio(window.devicePixelRatio) // geometry is low poly, no noticeable performance hit even with higher device pixel ratio
 		$element[0].appendChild(this.renderer.domElement)
 	}
 

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.module.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.module.ts
@@ -1,13 +1,12 @@
-import angular from "angular"
-import "../codeMap/threeViewer/threeViewer.module"
-import { viewCubeComponent } from "./viewCube.component"
-import { ViewCubeMouseEventsService } from "./viewCube.mouseEvents.service"
-import camelCase from "lodash.camelcase"
-import { downgradeComponent } from "@angular/upgrade/static"
+import { ViewCubeComponent } from "./viewCube.component"
 import { CenterMapButtonComponent } from "./centerMapButton/centerMapButton.component"
+import { NgModule } from "@angular/core"
+import { CommonModule } from "@angular/common"
 
-angular
-	.module("app.codeCharta.ui.viewCube", ["app.codeCharta.ui.codeMap.threeViewer"])
-	.component(viewCubeComponent.selector, viewCubeComponent)
-	.service(camelCase(ViewCubeMouseEventsService.name), ViewCubeMouseEventsService)
-	.directive("ccCenterMapButton", downgradeComponent({ component: CenterMapButtonComponent }))
+@NgModule({
+	imports: [CommonModule],
+	declarations: [ViewCubeComponent, CenterMapButtonComponent],
+	exports: [ViewCubeComponent],
+	entryComponents: [ViewCubeComponent]
+})
+export class ViewCubeModule {}

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.mouseEvents.service.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.mouseEvents.service.ts
@@ -8,6 +8,8 @@ import oc from "three-orbit-controls"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
 import { ThreeOrbitControlsService } from "../codeMap/threeViewer/threeOrbitControlsService"
 import { EventEmitter } from "tsee"
+import { Inject, Injectable } from "@angular/core"
+import { ThreeOrbitControlsServiceToken } from "../../services/ajs-upgraded-providers"
 
 type ViewCubeEvents = {
 	viewCubeEventPropagation: (data: { event: MouseEvent; type: string }) => void
@@ -16,6 +18,7 @@ type ViewCubeEvents = {
 	viewCubeClicked: (data: { cube: Mesh }) => void
 }
 
+@Injectable({ providedIn: "root" })
 export class ViewCubeMouseEventsService {
 	private eventEmitter = new EventEmitter<ViewCubeEvents>()
 
@@ -26,9 +29,7 @@ export class ViewCubeMouseEventsService {
 	private controls: OrbitControls
 	private isDragging = false
 
-	constructor(private threeOrbitControlsService: ThreeOrbitControlsService) {
-		"ngInject"
-	}
+	constructor(@Inject(ThreeOrbitControlsServiceToken) private threeOrbitControlsService: ThreeOrbitControlsService) {}
 
 	init(cubeGroup: Group, camera: PerspectiveCamera, renderer: WebGLRenderer) {
 		this.cubeGroup = cubeGroup

--- a/visualization/mocks/ng.mockhelper.ts
+++ b/visualization/mocks/ng.mockhelper.ts
@@ -3,7 +3,6 @@ import { IdToBuildingService } from "../app/codeCharta/services/idToBuilding/idT
 import { Store } from "../app/codeCharta/state/store/store"
 
 export const NGMock: IAngularStatic = angular
-export const NG = angular
 
 export function instantiateModule(id: string) {
 	NGMock.mock.module(id)
@@ -11,12 +10,20 @@ export function instantiateModule(id: string) {
 	angular.mock.module(($provide: ng.auto.IProvideService) => {
 		$provide.value("idToBuilding", idToBuildingService)
 	})
+	angular.mock.module(($provide: ng.auto.IProvideService) => {
+		$provide.value("viewCubeMouseEvents", {})
+	})
 }
 
 export function getService<T>(id: string): T {
 	// eslint-disable-next-line prefer-const
 	let service: T = null
 	eval(`NGMock.mock.inject(function(_${id}_) { service = _${id}_; });`)
-	if (id === "storeService") Store["initialize"]() // reset shared store
+	if (id === "storeService") {
+		// reset shared store
+		Store["initialize"]()
+	}
 	return service
 }
+
+export { default as NG } from "angular"

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -107,6 +107,7 @@
 				"terser-webpack-plugin": "^5.3.1",
 				"ts-jest": "^26.5.5",
 				"ts-loader": "^9.0.0",
+				"tsee": "^1.3.2",
 				"typescript": "4.5.5",
 				"webpack": "^5.33.2",
 				"webpack-cli": "^4.7.2",
@@ -23374,6 +23375,21 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/tsee": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/tsee/-/tsee-1.3.2.tgz",
+			"integrity": "sha512-+oKU7u1d5J+AEwbA4S7+aF3jdPS1RLcf5fzB6z6CMwJE1U2DCPD0AcaPmAisVEBQx6+ssUyThAEzSNZ59UmvXA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "^12.7.2"
+			}
+		},
+		"node_modules/tsee/node_modules/@types/node": {
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"dev": true
+		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -43145,6 +43161,23 @@
 					"version": "8.2.0",
 					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+				}
+			}
+		},
+		"tsee": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/tsee/-/tsee-1.3.2.tgz",
+			"integrity": "sha512-+oKU7u1d5J+AEwbA4S7+aF3jdPS1RLcf5fzB6z6CMwJE1U2DCPD0AcaPmAisVEBQx6+ssUyThAEzSNZ59UmvXA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^12.7.2"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.20.55",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+					"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+					"dev": true
 				}
 			}
 		},

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -162,6 +162,7 @@
 		"terser-webpack-plugin": "^5.3.1",
 		"ts-jest": "^26.5.5",
 		"ts-loader": "^9.0.0",
+		"tsee": "^1.3.2",
 		"typescript": "4.5.5",
 		"webpack": "^5.33.2",
 		"webpack-cli": "^4.7.2",


### PR DESCRIPTION
this PR migrates viewCube.component, viewCube.mouseEvents.service and replaces some AngularJS' `$rootScope` through an event emitter.

TODO:
- [x] add changelog
