### PR TITLE
Fix/3008/Adjust links to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix broken links to new document pages about how using SonarQube [#3009](https://github.com/MaibornWolff/codecharta/pull/3009)
+
 ## [1.104.0] - 2022-08-31
 
 ### Added 🚀

--- a/gh-pages/_docs/05-05-analyze-with-sonarqube.md
+++ b/gh-pages/_docs/05-05-analyze-with-sonarqube.md
@@ -1,9 +1,5 @@
 ---
-categories:
-    - How-To-SonarQube
-tags:
-    - sonarimport
-    - analysis
+permalink: /docs/analyze-with-sonarqube/
 title: "Analyze a project with SonarQube"
 ---
 
@@ -71,4 +67,4 @@ To visualize your project metrics created by Sonar use CodeCharta's [sonar impor
 
 ## Beginner's Guide for using SonarQube
 
-If you are totally new to SonarQube, you are welcome to read more detailed instructions [here]({{site.baseurl}}{% link _post/how-to/2022-08-12-detailed-instruction-how-to-use-sonarqube.md %}).
+If you are totally new to SonarQube, you are welcome to read more detailed instructions [here]({{site.baseurl}}{% link _posts/how-to/2022-08-12-detailed-instruction-how-to-use-sonarqube.md %}).

--- a/gh-pages/_posts/how-to/2018-09-19-jenkins_sonarqube.md
+++ b/gh-pages/_posts/how-to/2018-09-19-jenkins_sonarqube.md
@@ -4,7 +4,7 @@ categories:
 tags:
     - jenkins
     - sonarimport
-title: Integrating CodeCharte into a Jenkins 2 and Sonarqube pipeline
+title: Integrating CodeCharta into a Jenkins 2 and Sonarqube pipeline
 ---
 
 This writeup documents a way to use CC in a Jenkins 2 Pipeline. CC will take your project analysis and publish the CodeCharta web-application as an artifact.

--- a/gh-pages/_posts/how-to/2022-08-12-detailed-instruction-how-to-use-sonarqube.md
+++ b/gh-pages/_posts/how-to/2022-08-12-detailed-instruction-how-to-use-sonarqube.md
@@ -4,7 +4,7 @@ categories:
 tags:
     - sonarimport
     - analysis
-title: "Detailed instruction of how to use SonarQube 9.4"
+title: Detailed instruction of how to use SonarQube 9.4
 ---
 
 ## Analyze CodeCharta (Visualization Part) using SonarQube from zip file on Windows


### PR DESCRIPTION
# Adjust links to docs

closes: #3008

## Description
- links to new doc pages about sonarqube were broken and and have been fixed now
