### PR TITLE
Fix/Re-align close icon, move node name to same alignment start as path

### DIFF
--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBarHeaderSection/attributeSideBarHeaderSection.component.scss
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBarHeaderSection/attributeSideBarHeaderSection.component.scss
@@ -1,5 +1,6 @@
 cc-attribute-side-bar-header-section {
-	display: block;
+	display: flex;
+	flex-direction: column;
 
 	.close-icon,
 	.node-link {
@@ -15,9 +16,8 @@ cc-attribute-side-bar-header-section {
 	}
 
 	.close-icon {
-		position: absolute;
-		top: 5px;
-		right: 5px;
+		align-self: flex-end;
+		font-size: 20px;
 	}
 
 	.node-name {
@@ -37,6 +37,7 @@ cc-attribute-side-bar-header-section {
 	.node-origin,
 	.cc-node-path {
 		color: grey;
+		margin: 5px 0;
 
 		.file-path {
 			word-wrap: break-word;
@@ -65,7 +66,6 @@ cc-attribute-side-bar-header-section {
 	.node-name,
 	.node-origin,
 	.node-path {
-		margin: 10px;
 		word-break: break-all;
 		-webkit-user-select: text;
 		-moz-user-select: text;


### PR DESCRIPTION
# Re-align close icon to simplify closing the attribute sidebar

Closes: #3013 

## Description

- increase the size of the close button  to simplify closing the attribute sidebar
- move node name to the same alignment as the path

## Screenshots or gifs
Before:
![image](https://user-images.githubusercontent.com/72517530/187703955-6fef4d2f-f4e2-4b7d-ad9d-7c88a4cd54eb.png)

After:
![image](https://user-images.githubusercontent.com/72517530/187703825-2b395219-cd81-4d0c-bc08-8b760e861b96.png)

