### PR TITLE
Fix/2619/metricgardener not running under windows

### DIFF
--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -15,6 +15,7 @@ import java.io.IOException
 import java.io.PrintStream
 import java.nio.charset.Charset
 import java.nio.file.Paths
+import java.util.Locale
 import java.util.concurrent.Callable
 
 @CommandLine.Command(
@@ -60,8 +61,10 @@ class MetricGardenerImporter(
         if (!isJsonFile) {
             val tempMgOutput = File.createTempFile("MGOutput", ".json")
             tempMgOutput.deleteOnExit()
+
+            val npm = if (isWindows()) "npm.cmd" else "npm"
             shellRun(
-                command = "npm",
+                command = npm,
                 arguments = listOf(
                     "exec", "-y", "metric-gardener", "--", "parse",
                     inputFile.absolutePath, "--output-path", tempMgOutput.absolutePath
@@ -92,6 +95,10 @@ class MetricGardenerImporter(
         fun main(args: Array<String>) {
             CommandLine.call(MetricGardenerImporter(), System.out, *args)
         }
+    }
+
+    private fun isWindows(): Boolean {
+        return System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
     }
 
     override fun getDialog(): ParserDialogInterface = ParserDialog

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -15,7 +15,6 @@ import java.io.IOException
 import java.io.PrintStream
 import java.nio.charset.Charset
 import java.nio.file.Paths
-import java.util.Locale
 import java.util.concurrent.Callable
 
 @CommandLine.Command(
@@ -98,7 +97,7 @@ class MetricGardenerImporter(
     }
 
     private fun isWindows(): Boolean {
-        return System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
+        return System.getProperty("os.name").contains("win", ignoreCase = true)
     }
 
     override fun getDialog(): ParserDialogInterface = ParserDialog

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
@@ -16,8 +16,9 @@ class ParserDialog {
                 )
 
             val inputFile = KInquirer.promptInput(
-                message = "What Project do you want to parse?",
-                hint = "path/to/my/project"
+                message = if (isJsonFile) "Which MetricGardener json-File do you want to import?"
+                          else "What Project do you want to parse?",
+                hint = if (isJsonFile) "path/to/metricgardener/file.json" else "path/to/my/project"
             )
 
             val outputFileName: String = KInquirer.promptInput(

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
@@ -9,10 +9,10 @@ class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            val mgJsonAvailable: Boolean =
+            val isJsonFile: Boolean =
                 KInquirer.promptConfirm(
                     message = "Do you already have a MetricGardener json-File?",
-                    default = true
+                    default = false
                 )
 
             val inputFile = KInquirer.promptInput(
@@ -32,7 +32,7 @@ class ParserDialog {
                 inputFile,
                 "--output-file=$outputFileName",
                 if (isCompressed) null else "--not-compressed",
-                if (mgJsonAvailable) null else "--with-mg-run"
+                if (isJsonFile) "--is-json-file" else null
             )
         }
     }

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
@@ -9,7 +9,6 @@ import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -24,12 +23,11 @@ class ParserDialogTest {
     }
 
     @Test
-    @Disabled // TODO: Enable (and fix) after implementation of MG run
     fun `should output correct arguments non compressed`() {
         val fileName = "metricGardenIn.json"
         val outputFileName = "out.cc.json"
         val isCompressed = false
-        val mgJsonAvailable = true
+        val isJsonFile = true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -38,7 +36,7 @@ class ParserDialogTest {
         mockkStatic("com.github.kinquirer.components.ConfirmKt")
         every {
             KInquirer.promptConfirm(any(), any())
-        } returns isCompressed
+        } returns isJsonFile andThen isCompressed
 
         val parserArguments = ParserDialog.collectParserArgs()
 
@@ -47,7 +45,7 @@ class ParserDialogTest {
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
-        assertNull(parseResult.matchedOption("--with-MG-run"))
+        Assertions.assertThat(parseResult.matchedOption("is-json-file").getValue<Boolean>()).isEqualTo(isJsonFile)
     }
 
     @Test
@@ -55,6 +53,7 @@ class ParserDialogTest {
         val fileName = "metricGardenIn.json"
         val outputFileName = "out.cc.json"
         val isCompressed = true
+        val isJsonFile = false
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -63,7 +62,7 @@ class ParserDialogTest {
         mockkStatic("com.github.kinquirer.components.ConfirmKt")
         every {
             KInquirer.promptConfirm(any(), any())
-        } returns isCompressed
+        } returns isJsonFile andThen isCompressed
 
         val parserArguments = ParserDialog.collectParserArgs()
 
@@ -72,5 +71,6 @@ class ParserDialogTest {
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         assertNull(parseResult.matchedOption("not-compressed"))
+        assertNull(parseResult.matchedOption("is-json-file"))
     }
 }

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
@@ -7,6 +7,8 @@ import picocli.CommandLine
 
 class ParserService {
     companion object {
+        private const val EXIT_CODE_PARSER_NOT_SUPPORTED = 42
+
         fun selectParser(commandLine: CommandLine): String {
             val selectedParser: String = KInquirer.promptList(
                 message = "Which parser do you want to execute?",
@@ -28,7 +30,7 @@ class ParserService {
                 return subCommandLine.execute(*collectedArgs.toTypedArray())
             } else {
                 printNotSupported(selectedParser)
-                return 42
+                return EXIT_CODE_PARSER_NOT_SUPPORTED
             }
         }
 
@@ -49,8 +51,10 @@ class ParserService {
         }
 
         private fun printNotSupported(parserName: String) {
-            println("The interactive usage of $parserName is not supported yet.\n" +
-                    "Please specify the full command to run the parser.")
+            println(
+                "The interactive usage of $parserName is not supported yet.\n" +
+                        "Please specify the full command to run the parser."
+            )
         }
     }
 }

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -8,6 +8,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -66,6 +67,7 @@ class CcshTest {
     }
 
     @Test
+    @Disabled
     fun `should execute interactive parser when passed parser is unknown`() {
         mockkObject(ParserService)
         every {

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -8,7 +8,6 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -47,7 +46,8 @@ class CcshTest {
         val exitCode = ccshCLI.execute("-h")
 
         Assertions.assertThat(exitCode).isEqualTo(0)
-        Assertions.assertThat(contentOutput.toString()).contains("Usage: ccsh [-hv] [COMMAND]", "Command Line Interface for CodeCharta analysis")
+        Assertions.assertThat(contentOutput.toString())
+            .contains("Usage: ccsh [-hv] [COMMAND]", "Command Line Interface for CodeCharta analysis")
         verify(exactly = 0) { ParserService.executeSelectedParser(any(), any()) }
     }
 
@@ -61,13 +61,13 @@ class CcshTest {
             ParserService.executeSelectedParser(any(), any())
         } returns 0
 
-        Ccsh.main(emptyArray())
+        val exitCode = Ccsh.executeCommandLine(emptyArray())
+        Assertions.assertThat(exitCode).isZero
 
         verify { ParserService.executeSelectedParser(any(), any()) }
     }
 
     @Test
-    @Disabled
     fun `should execute interactive parser when passed parser is unknown`() {
         mockkObject(ParserService)
         every {
@@ -77,7 +77,8 @@ class CcshTest {
             ParserService.executeSelectedParser(any(), any())
         } returns 0
 
-        Ccsh.main(arrayOf("unknownparser"))
+        val exitCode = Ccsh.executeCommandLine(arrayOf("unknownparser"))
+        Assertions.assertThat(exitCode).isZero
 
         verify { ParserService.executeSelectedParser(any(), any()) }
     }


### PR DESCRIPTION
# Fix MetricGardenerImporter not running on Windows due to a wrong npm command

This PR also fixes failing tests that were missed during PR #3015

Closes #2619
