### PR TITLE
Documentation: Change commands for GitLog-Parser to be the same as in its Readme

### DIFF
--- a/analysis/import/GitLogParser/README.md
+++ b/analysis/import/GitLogParser/README.md
@@ -2,13 +2,12 @@
 
 Generates visualisation data from git repository logs and repository file list.
 
-This parser specializes in tracking file changes across different file-renaming on different feature-branches and then merged main.
-Furthermore, special care is taken to avoid showing un-existing files that might show up in standard histories due to renaming actions on feature branches.
+This parser specializes in tracking file changes across different file-versions on different feature-branches and then the merged main.
+Furthermore, special care is taken not to display non-existent files that might show up in normal-Git histories due to renaming actions on feature branches.
 
 Things to note:
 
 -   File deletions that get reverted later on are ignored by this parser.
--   This parser is experimental, some features might not work correctly. If you encounter a bug, please report it over at https://github.com/MaibornWolff/codecharta/issues.
 
 It supports the following metrics per file:
 
@@ -44,6 +43,8 @@ You can also use the bash script anongit which generates an anonymous git log wi
 ### Creating the git files list of the repository for metric generation
 
 > `git ls-files > file-name-list.txt`
+
+Please make sure to execute this command in the root folder of your repository.
 
 ### Executing the GitLogParser
 

--- a/analysis/import/GitLogParser/README.md
+++ b/analysis/import/GitLogParser/README.md
@@ -1,6 +1,16 @@
 # GitLogParser - Status: stable
 
-Generates visualisation data from git repository logs and repository file list. It supports the following metrics per file:
+Generates visualisation data from git repository logs and repository file list.
+
+This parser specializes in tracking file changes across different file-renaming on different feature-branches and then merged main.
+Furthermore, special care is taken to avoid showing un-existing files that might show up in standard histories due to renaming actions on feature branches.
+
+Things to note:
+
+-   File deletions that get reverted later on are ignored by this parser.
+-   This parser is experimental, some features might not work correctly. If you encounter a bug, please report it over at https://github.com/MaibornWolff/codecharta/issues.
+
+It supports the following metrics per file:
 
 | Metric                 | Description                                                                           |
 | ---------------------- | ------------------------------------------------------------------------------------- |

--- a/gh-pages/_docs/04-12-gitlogparser.md
+++ b/gh-pages/_docs/04-12-gitlogparser.md
@@ -48,7 +48,7 @@ You can also use the bash script anongit which generates an anonymous git log wi
 
 ### Creating the git files list of the repository for metric generation
 
-> `git ls-files > file-name-list.tmp`
+> `git ls-files > file-name-list.txt`
 
 ### Executing the GitLogParser
 
@@ -64,7 +64,7 @@ The resulting project has the project name specified for the GitLogParser.
 ### Example using Git
 
 -   `cd <my_git_project>`
--   `git log --numstat --raw --topo-order --reverse -m > gitlog.tmp` (or `anongit --reverse > gitlog.tmp`)
--   `git ls-files > file-name-list.tmp`
--   `./ccsh gitlogparser gitlog.tmp -o output.cc.json -n file-name-list.tmp`
+-   `git log --numstat --raw --topo-order --reverse -m > git.log` (or `anongit > git.log`)
+-   `git ls-files > file-name-list.txt`
+-   `./ccsh gitlogparser git.log -o output.cc.json -n file-name-list.tmp`
 -   load `output.cc.json` in visualization

--- a/gh-pages/_docs/04-12-gitlogparser.md
+++ b/gh-pages/_docs/04-12-gitlogparser.md
@@ -7,13 +7,12 @@ title: "Git Log Parser"
 
 Generates visualisation data from git repository logs and repository file list.
 
-This parser specializes in tracking file changes across different file-renaming on different feature-branches and then merged main.
-Furthermore, special care is taken to avoid showing un-existing files that might show up in standard histories due to renaming actions on feature branches.
+This parser specializes in tracking file changes across different file-versions on different feature-branches and then the merged main.
+Furthermore, special care is taken not to display non-existent files that might show up in normal-Git histories due to renaming actions on feature branches.
 
 Things to note:
 
 -   File deletions that get reverted later on are ignored by this parser.
--   This parser is experimental, some features might not work correctly. If you encounter a bug, please report it over at https://github.com/MaibornWolff/codecharta/issues.
 
 It supports the following metrics per file:
 
@@ -50,6 +49,8 @@ You can also use the bash script anongit which generates an anonymous git log wi
 
 > `git ls-files > file-name-list.txt`
 
+Please make sure to execute this command in the root folder of your repository.
+
 ### Executing the GitLogParser
 
 See `ccsh -h` for help. Standard usage:
@@ -66,5 +67,5 @@ The resulting project has the project name specified for the GitLogParser.
 -   `cd <my_git_project>`
 -   `git log --numstat --raw --topo-order --reverse -m > git.log` (or `anongit > git.log`)
 -   `git ls-files > file-name-list.txt`
--   `./ccsh gitlogparser git.log -o output.cc.json -n file-name-list.tmp`
+-   `./ccsh gitlogparser git.log -o output.cc.json -n file-name-list.txt`
 -   load `output.cc.json` in visualization


### PR DESCRIPTION
# Update GitLogParser Documentation in Quick Start Guide

Closes: #2950 

## Description

- Change Documentation in Quick Start Guide to feature the same commands for GitLogParser as in its own readme
- Add a paragraph in the readme about the GitLogParser
