### PR TITLE
refactor anongit-script to avoid unintended side-effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Stop asking the user to compress a file when printing to stdOut [#3024](https://github.com/MaibornWolff/codecharta/pull/3024)
 
+### Fixed 🐞
+
+-   Fix anongit script using the wrong whitespace, causing gitlogparser to fail [#3030](https://github.com/MaibornWolff/codecharta/pull/3030)
+
 ## [1.105.0] - 2022-09-06
 
 ### Added 🚀

--- a/analysis/import/GitLogParser/src/main/dist/anongit
+++ b/analysis/import/GitLogParser/src/main/dist/anongit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $1=="-h" ]]; then
+if [[ $1 == "-h" ]]; then
   echo "Generates anonymous log for CodeCharta"
   echo "  inherits all options from git log --numstat --raw --topo-order --reverse -m"
   exit 0
@@ -8,11 +8,10 @@ fi
 
 # init hashmap of authors
 HASHMAP_FILE=hashmap.authors
-rm -f ${HASHMAP_FILE}
 COUNTER=1
 
 # main functionality
-gitlog=`git log --numstat --raw --topo-order --reverse -m "$@"`
+gitlog=$(git log --numstat --raw --topo-order --reverse -m "$@")
 
 while read -r line; do
   if [[ "$line" =~ ^Author.*\<.*\>$ ]]; then
@@ -22,9 +21,9 @@ while read -r line; do
       echo -e "$line\n$aliasLine" >> ${HASHMAP_FILE}
       ((COUNTER++))
     fi
-    echo ${aliasLine}
+    echo "${aliasLine}"
   else
-    echo ${line}
+    echo "${line}"
   fi
 done <<< "$gitlog"
 

--- a/analysis/import/GitLogParser/src/main/dist/anongit
+++ b/analysis/import/GitLogParser/src/main/dist/anongit
@@ -7,6 +7,7 @@ if [[ $1 == "-h" ]]; then
 fi
 
 # init hashmap of authors
+touch hashmap.authors
 HASHMAP_FILE=hashmap.authors
 COUNTER=1
 


### PR DESCRIPTION
# GitLog-Parser does not work, due to a possible error in the anongit-script

Issue: #2749

## Description

When crating a git.log file with our anongit script, the wrong type of whitespace (space instead of tabs) seem to be used

## Screenshots or gifs

<img width="1620" alt="log-problem" src="https://user-images.githubusercontent.com/65733509/188843160-1d8db132-d760-4dbb-b7dd-f98ae8ce06a6.png">

