### PR TITLE
Fix/3047/Uncheck-Checkbox-Invert-Height-Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
--   Uncheck the box when 'reset invert height' icon is
-    clicked [#3048](https://github.com/MaibornWolff/codecharta/pull/3048)
+-   Uncheck the box when 'reset invert height' icon is clicked [#3048](https://github.com/MaibornWolff/codecharta/pull/3048)
 -   Update ReadMe and GitHub pages for MetricGardener [#3045](https://github.com/MaibornWolff/codecharta/pull/3045)
 
 ## [1.106.1] - 2022-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Uncheck the box when 'reset invert height' icon is
+    clicked [#3048](https://github.com/MaibornWolff/codecharta/pull/3048)
 -   Update ReadMe and GitHub pages for MetricGardener [#3045](https://github.com/MaibornWolff/codecharta/pull/3045)
 
 ## [1.106.1] - 2022-09-20

--- a/visualization/app/codeCharta/ui/ribbonBar/heightSettingsPanel/heightSettingsPanel.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/heightSettingsPanel/heightSettingsPanel.component.html
@@ -37,7 +37,9 @@
 ></cc-slider>
 
 <div class="cc-height-settings-panel-row cc-height-settings-panel-reset-row">
-	<mat-checkbox *ngIf="!(isDeltaState$ | async)" [checked]="invertHeight" (change)="setInvertHeight($event)">Invert Height</mat-checkbox>
+	<mat-checkbox (change)="setInvertHeight($event)" *ngIf="!(isDeltaState$ | async)" [checked]="invertHeight$ | async">
+		Invert Height
+	</mat-checkbox>
 	<cc-reset-settings-button
 		[settingsKeys]="['appSettings.amountOfTopLabels', 'appSettings.scaling.y', 'appSettings.invertHeight']"
 		tooltip="Reset height metric settings to their defaults"


### PR DESCRIPTION
# Uncheck the box when the 'Invert height' option is clicked

Closes: #3047 

## Description

- fix binding of observable that is responsible for checking and unchecking the box for 'invert height' option

