### PR TITLE
Refactor/2318/migrate code map component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Uncheck the box when 'reset invert height' icon is clicked [#3048](https://github.com/MaibornWolff/codecharta/pull/3048)
 -   Update ReadMe and GitHub pages for MetricGardener [#3045](https://github.com/MaibornWolff/codecharta/pull/3045)
 
+### Chore 👨‍💻 👩‍💻
+
+-   Migrate codeMap.component to Angular with minor internal improvements [#3049](https://github.com/MaibornWolff/codecharta/pull/3049)
+
 ## [1.106.1] - 2022-09-20
 
 ### Fixed 🐞

--- a/visualization/app/app.module.ts
+++ b/visualization/app/app.module.ts
@@ -8,7 +8,6 @@ import { UpgradeModule } from "@angular/upgrade/static"
 import { FormsModule, ReactiveFormsModule } from "@angular/forms"
 import { MaterialModule } from "./material/material.module"
 import { AttributeSideBarModule } from "./codeCharta/ui/attributeSideBar/attributeSideBar.module"
-import { AttributeSideBarComponent } from "./codeCharta/ui/attributeSideBar/attributeSideBar.component"
 import { LegendPanelComponent } from "./codeCharta/ui/legendPanel/legendPanel.component"
 import { LegendPanelModule } from "./codeCharta/ui/legendPanel/legendPanel.module"
 import { ColorPickerForMapColorModule } from "./codeCharta/ui/colorPickerForMapColor/colorPickerForMapColor.module"
@@ -18,10 +17,12 @@ import { AddBlacklistItemsIfNotResultsInEmptyMapEffect } from "./codeCharta/stat
 import { dialogs } from "./codeCharta/ui/dialogs/dialogs"
 import {
 	codeChartaServiceProvider,
+	CodeMapMouseEventServiceTokenProvider,
 	threeCameraServiceProvider,
 	threeOrbitControlsServiceProvider,
 	threeRendererServiceProvider,
-	threeSceneServiceProvider
+	threeSceneServiceProvider,
+	threeViewerServiceTokenProvider
 } from "./codeCharta/services/ajs-upgraded-providers"
 import { NodeContextMenuCardModule } from "./codeCharta/state/effects/nodeContextMenu/nodeContextMenuCard/nodeContextMenuCard.module"
 import { OpenNodeContextMenuEffect } from "./codeCharta/state/effects/nodeContextMenu/openNodeContextMenu.effect"
@@ -42,10 +43,10 @@ import { ChangelogDialogModule } from "./codeCharta/ui/dialogs/changelogDialog/c
 import { VersionService } from "./codeCharta/services/version/version.service"
 import { ActionIconModule } from "./codeCharta/ui/actionIcon/actionIcon.module"
 import { SplitStateActionsEffect } from "./codeCharta/state/effects/splitStateActionsEffect/splitStateActions.effect"
-import { ViewCubeModule } from "./codeCharta/ui/viewCube/viewCube.module"
 import { ToolBarModule } from "./codeCharta/ui/toolBar/toolBar.module"
 import { RenderCodeMapEffect } from "./codeCharta/state/effects/renderCodeMapEffect/renderCodeMap.effect"
 import { AutoFitCodeMapOnFileSelectionChangeEffect } from "./codeCharta/state/effects/autoFitCodeMapOnFileSelectionChange/autoFitCodeMapOnFileSelectionChange.effect"
+import { CodeChartaModule } from "./codeCharta/codeCharta.module"
 
 @NgModule({
 	imports: [
@@ -73,14 +74,14 @@ import { AutoFitCodeMapOnFileSelectionChangeEffect } from "./codeCharta/state/ef
 		NodeContextMenuCardModule,
 		ReactiveFormsModule,
 		LoadingFileProgressSpinnerModule,
-		ViewCubeModule,
 		FileExtensionBarModule,
 		MetricChooserModule,
 		RibbonBarModule,
 		ChangelogDialogModule,
 		ActionIconModule,
 		ToolBarModule,
-		RibbonBarModule
+		RibbonBarModule,
+		CodeChartaModule
 	],
 	providers: [
 		threeSceneServiceProvider,
@@ -89,6 +90,8 @@ import { AutoFitCodeMapOnFileSelectionChangeEffect } from "./codeCharta/state/ef
 		threeCameraServiceProvider,
 		threeOrbitControlsServiceProvider,
 		threeRendererServiceProvider,
+		threeViewerServiceTokenProvider,
+		CodeMapMouseEventServiceTokenProvider,
 		VersionService,
 		{
 			provide: APP_INITIALIZER,
@@ -98,13 +101,7 @@ import { AutoFitCodeMapOnFileSelectionChangeEffect } from "./codeCharta/state/ef
 		}
 	],
 	declarations: [...dialogs],
-	entryComponents: [
-		AttributeSideBarComponent,
-		LegendPanelComponent,
-		FocusButtonsComponent,
-		LoadingFileProgressSpinnerComponent,
-		...dialogs
-	]
+	entryComponents: [LegendPanelComponent, FocusButtonsComponent, LoadingFileProgressSpinnerComponent, ...dialogs]
 })
 export class AppModule {
 	constructor(@Inject(UpgradeModule) private upgrade: UpgradeModule) {}

--- a/visualization/app/codeCharta/codeCharta.component.html
+++ b/visualization/app/codeCharta/codeCharta.component.html
@@ -4,7 +4,7 @@
 	<cc-file-extension-bar></cc-file-extension-bar>
 	<cc-ribbon-bar></cc-ribbon-bar>
 
-	<code-map-component></code-map-component>
+	<cc-code-map></cc-code-map>
 
 	<cc-legend-panel></cc-legend-panel>
 

--- a/visualization/app/codeCharta/codeCharta.module.ts
+++ b/visualization/app/codeCharta/codeCharta.module.ts
@@ -13,6 +13,10 @@ import { LoadingFileProgressSpinnerComponent } from "./ui/loadingFileProgressSpi
 import { FileExtensionBarComponent } from "./ui/fileExtensionBar/fileExtensionBar.component"
 import { ToolBarComponent } from "./ui/toolBar/toolBar.component"
 import { RibbonBarComponent } from "./ui/ribbonBar/ribbonBar.component"
+import { NgModule } from "@angular/core"
+import { CommonModule } from "@angular/common"
+import { CodeMapComponent } from "./ui/codeMap/codeMap.component"
+import { CodeMapModule } from "./ui/codeMap/codeMap.module"
 
 angular.module("app.codeCharta", ["app.codeCharta.state", "app.codeCharta.ui"])
 
@@ -24,3 +28,10 @@ angular
 	.directive("ccFileExtensionBar", downgradeComponent({ component: FileExtensionBarComponent }))
 	.directive("ccToolBar", downgradeComponent({ component: ToolBarComponent }))
 	.directive("ccRibbonBar", downgradeComponent({ component: RibbonBarComponent }))
+	.directive("ccCodeMap", downgradeComponent({ component: CodeMapComponent }))
+
+@NgModule({
+	imports: [CommonModule, CodeMapModule],
+	entryComponents: [CodeMapComponent]
+})
+export class CodeChartaModule {}

--- a/visualization/app/codeCharta/services/ajs-upgraded-providers.ts
+++ b/visualization/app/codeCharta/services/ajs-upgraded-providers.ts
@@ -44,3 +44,21 @@ export const threeRendererServiceProvider = {
 	},
 	deps: ["$injector"]
 }
+
+export const ThreeViewerServiceToken = new InjectionToken("ThreeViewerService")
+export const threeViewerServiceTokenProvider = {
+	provide: ThreeViewerServiceToken,
+	useFactory: function ThreeViewerServiceTokenFactory(injector: Injector) {
+		return injector.get("threeViewerService")
+	},
+	deps: ["$injector"]
+}
+
+export const CodeMapMouseEventServiceToken = new InjectionToken("CodeMapMouseEventService")
+export const CodeMapMouseEventServiceTokenProvider = {
+	provide: CodeMapMouseEventServiceToken,
+	useFactory: function CodeMapMouseEventServiceTokenFactory(injector: Injector) {
+		return injector.get("codeMapMouseEventService")
+	},
+	deps: ["$injector"]
+}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.html
@@ -1,4 +1,4 @@
-<div id="codeMap" ng-hide="$ctrl._viewModel.isLoadingFile">
-	<cc-view-cube ng-class="{ sideBarVisible: $ctrl._viewModel.isSideBarVisible }"></cc-view-cube>
+<div id="codeMap" [class.hidden]="isLoadingFile$ | async">
+	<cc-view-cube [class.sideBarVisible]="isAttributeSidebarVisible$ | async"></cc-view-cube>
 	<cc-attribute-side-bar></cc-attribute-side-bar>
 </div>

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -1,4 +1,8 @@
 cc-code-map {
+	.hidden {
+		display: none;
+	}
+
 	cc-view-cube {
 		position: absolute;
 		z-index: 11;

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.scss
@@ -1,4 +1,4 @@
-code-map-component {
+cc-code-map {
 	cc-view-cube {
 		position: absolute;
 		z-index: 11;

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.spec.ts
@@ -1,105 +1,54 @@
-import "./codeMap.module"
-import "../../codeCharta.module"
-import { IRootScopeService } from "angular"
-import { getService, instantiateModule } from "../../../../mocks/ng.mockhelper"
-import { CodeMapController } from "./codeMap.component"
-import { ThreeViewerService } from "./threeViewer/threeViewerService"
+import { ElementRef } from "@angular/core"
+import { Subject } from "rxjs"
+import { Store } from "../../state/angular-redux/store"
+import { sharpnessModeSelector } from "../../state/store/appSettings/sharpnessMode/sharpnessMode.selector"
+import { CodeMapComponent } from "./codeMap.component"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
-import { IsLoadingFileService } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.service"
+import { ThreeViewerService } from "./threeViewer/threeViewerService"
 
-describe("ColorSettingsPanelController", () => {
-	let codeMapController: CodeMapController
-	let $rootScope: IRootScopeService
-	let $element: Element
-	let threeViewerService: ThreeViewerService
-	let codeMapMouseEventService: CodeMapMouseEventService
+describe("CodeMapComponent", () => {
+	let mockedThreeViewService: ThreeViewerService
+	let mockedCodeMapMouseEventService: CodeMapMouseEventService
+	let mockedElementReference: ElementRef
+	let mockedSharpnessModeSelector$: Subject<string>
+	const mockedStore = {
+		select: (selector: unknown) => {
+			switch (selector) {
+				case sharpnessModeSelector:
+					return mockedSharpnessModeSelector$
+				default:
+					return jest.fn()
+			}
+		}
+	} as unknown as Store
 
 	beforeEach(() => {
-		restartSystem()
-		rebuildController()
-		mockElement()
-		withMockedThreeViewerService()
+		mockedThreeViewService = { init: jest.fn(), restart: jest.fn() } as unknown as ThreeViewerService
+		mockedCodeMapMouseEventService = { start: jest.fn() } as unknown as CodeMapMouseEventService
+		mockedElementReference = { nativeElement: { querySelector: jest.fn() } }
+		mockedSharpnessModeSelector$ = new Subject()
 	})
 
-	function restartSystem() {
-		instantiateModule("app.codeCharta.ui.codeMap")
-
-		$rootScope = getService<IRootScopeService>("$rootScope")
-		threeViewerService = getService<ThreeViewerService>("threeViewerService")
-		codeMapMouseEventService = getService<CodeMapMouseEventService>("codeMapMouseEventService")
-	}
-
-	function mockElement() {
-		// @ts-ignore we only care about few properties for the tests.
-		$element = [{ children: [{ clientWidth: 50, clientHeight: 100 }] }]
-	}
-
-	function withMockedThreeViewerService() {
-		threeViewerService = codeMapController["threeViewerService"] = jest.fn().mockReturnValue({
-			destroy: jest.fn(),
-			animate: jest.fn(),
-			stopAnimate: jest.fn(),
-			autoFitTo: jest.fn(),
-			animateStats: jest.fn(),
-			dispose: jest.fn()
-		})()
-	}
-
-	function rebuildController() {
-		codeMapController = new CodeMapController($rootScope, $element, threeViewerService, codeMapMouseEventService)
-		codeMapController.$postLink = jest.fn()
-	}
-
-	describe("constructor", () => {
-		it("should subscribe to IsLoadingFileService", () => {
-			IsLoadingFileService.subscribe = jest.fn()
-
-			rebuildController()
-
-			expect(IsLoadingFileService.subscribe).toHaveBeenCalledWith($rootScope, codeMapController)
-		})
-
-		it("should set attribute isLoadingFile to true", () => {
-			rebuildController()
-
-			expect(codeMapController["_viewModel"].isLoadingFile).toBeTruthy()
-		})
+	it("should init threeViewerService and start codeMapMouseService after view init", () => {
+		const codeMapComponent = new CodeMapComponent(
+			mockedStore,
+			mockedThreeViewService,
+			mockedCodeMapMouseEventService,
+			mockedElementReference
+		)
+		codeMapComponent.ngAfterViewInit()
+		expect(mockedThreeViewService.init).toHaveBeenCalled()
+		expect(mockedCodeMapMouseEventService.start).toHaveBeenCalled()
 	})
 
-	describe("onIsLoadingFileChanged", () => {
-		it("should set isLoadingFile in viewModel to true", () => {
-			codeMapController.onIsLoadingFileChanged(true)
+	it("should restart on sharpnessModeChanges but not on first one as it will get started then", () => {
+		new CodeMapComponent(mockedStore, mockedThreeViewService, mockedCodeMapMouseEventService, mockedElementReference)
+		mockedSharpnessModeSelector$.next("High")
+		expect(mockedThreeViewService.restart).not.toHaveBeenCalled()
+		expect(mockedCodeMapMouseEventService.start).not.toHaveBeenCalled()
 
-			expect(codeMapController["_viewModel"].isLoadingFile).toBe(true)
-		})
-
-		it("should set isLoadingFile in viewModel to false", () => {
-			codeMapController.onIsLoadingFileChanged(false)
-
-			expect(codeMapController["_viewModel"].isLoadingFile).toBe(false)
-		})
-	})
-
-	describe("onSharpnessModeChanged", () => {
-		const sharpnessTests = [
-			{ func: "stopAnimate" },
-			{ func: "destroy" },
-			{ func: "autoFitTo" },
-			{ func: "animate" },
-			{ func: "animateStats" }
-		]
-		beforeEach(() => {
-			codeMapController.onSharpnessModeChanged()
-		})
-
-		for (const test of sharpnessTests) {
-			it(`should call threeViewerService ${test.func}`, () => {
-				expect(threeViewerService[`${test.func}`]).toHaveBeenCalled()
-			})
-		}
-
-		it("should call CodeMapController $postLink", () => {
-			expect(codeMapController.$postLink).toHaveBeenCalled()
-		})
+		mockedSharpnessModeSelector$.next("Low")
+		expect(mockedThreeViewService.restart).toHaveBeenCalled()
+		expect(mockedCodeMapMouseEventService.start).toHaveBeenCalled()
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
@@ -5,9 +5,9 @@ import { isLoadingFileSelector } from "../../state/store/appSettings/isLoadingFi
 import { isAttributeSideBarVisibleSelector } from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.selector"
 import { ThreeViewerService } from "./threeViewer/threeViewerService"
 import { CodeMapMouseEventServiceToken, ThreeViewerServiceToken } from "../../services/ajs-upgraded-providers"
-import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 import { onStoreChanged } from "../../state/angular-redux/onStoreChanged/onStoreChanged"
 import { sharpnessModeSelector } from "../../state/store/appSettings/sharpnessMode/sharpnessMode.selector"
+import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 
 @Component({
 	selector: "cc-code-map",
@@ -25,23 +25,14 @@ export class CodeMapComponent implements AfterViewInit {
 	) {}
 
 	ngAfterViewInit(): void {
-		this.initMap()
-		onStoreChanged(sharpnessModeSelector, oldValue => {
-			if (!oldValue) {
-				// skip initial change as this is already handled within ngAfterViewInit
-				return
-			}
-			this.threeViewerService.stopAnimate()
-			this.threeViewerService.destroy()
-			this.initMap()
-			this.threeViewerService.autoFitTo()
-			this.threeViewerService.animate()
-			this.threeViewerService.animateStats()
-		})
-	}
-
-	private initMap() {
 		this.threeViewerService.init(this.elementReference.nativeElement.querySelector("#codeMap"))
 		this.codeMapMouseEventService.start()
+
+		onStoreChanged(sharpnessModeSelector, oldValue => {
+			if (oldValue) {
+				this.threeViewerService.restart(this.elementReference.nativeElement.querySelector("#codeMap"))
+				this.codeMapMouseEventService.start()
+			}
+		})
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
@@ -1,21 +1,31 @@
 import "./codeMap.component.scss"
-import { Component, Inject, AfterViewInit, ElementRef } from "@angular/core"
+import { Component, Inject, AfterViewInit, ElementRef, OnDestroy } from "@angular/core"
 import { Store } from "../../state/angular-redux/store"
 import { isLoadingFileSelector } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.selector"
 import { isAttributeSideBarVisibleSelector } from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.selector"
 import { ThreeViewerService } from "./threeViewer/threeViewerService"
 import { CodeMapMouseEventServiceToken, ThreeViewerServiceToken } from "../../services/ajs-upgraded-providers"
-import { onStoreChanged } from "../../state/angular-redux/onStoreChanged/onStoreChanged"
 import { sharpnessModeSelector } from "../../state/store/appSettings/sharpnessMode/sharpnessMode.selector"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
+import { skip, tap } from "rxjs"
 
 @Component({
 	selector: "cc-code-map",
 	template: require("./codeMap.component.html")
 })
-export class CodeMapComponent implements AfterViewInit {
+export class CodeMapComponent implements AfterViewInit, OnDestroy {
 	isLoadingFile$ = this.store.select(isLoadingFileSelector)
 	isAttributeSidebarVisible$ = this.store.select(isAttributeSideBarVisibleSelector)
+	restartOnSharpnessModeChangesSubscription = this.store
+		.select(sharpnessModeSelector)
+		.pipe(
+			skip(1),
+			tap(() => {
+				this.threeViewerService.restart(this.elementReference.nativeElement.querySelector("#codeMap"))
+				this.codeMapMouseEventService.start()
+			})
+		)
+		.subscribe()
 
 	constructor(
 		@Inject(Store) private store: Store,
@@ -27,12 +37,9 @@ export class CodeMapComponent implements AfterViewInit {
 	ngAfterViewInit(): void {
 		this.threeViewerService.init(this.elementReference.nativeElement.querySelector("#codeMap"))
 		this.codeMapMouseEventService.start()
+	}
 
-		onStoreChanged(sharpnessModeSelector, oldValue => {
-			if (oldValue) {
-				this.threeViewerService.restart(this.elementReference.nativeElement.querySelector("#codeMap"))
-				this.codeMapMouseEventService.start()
-			}
-		})
+	ngOnDestroy(): void {
+		this.restartOnSharpnessModeChangesSubscription.unsubscribe()
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.component.ts
@@ -1,74 +1,47 @@
 import "./codeMap.component.scss"
+import { Component, Inject, AfterViewInit, ElementRef } from "@angular/core"
+import { Store } from "../../state/angular-redux/store"
+import { isLoadingFileSelector } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.selector"
+import { isAttributeSideBarVisibleSelector } from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.selector"
 import { ThreeViewerService } from "./threeViewer/threeViewerService"
+import { CodeMapMouseEventServiceToken, ThreeViewerServiceToken } from "../../services/ajs-upgraded-providers"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
-import { IRootScopeService } from "angular"
-import { IsLoadingFileService, IsLoadingFileSubscriber } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.service"
-import {
-	IsAttributeSideBarVisibleService,
-	IsAttributeSideBarVisibleSubscriber
-} from "../../state/store/appSettings/isAttributeSideBarVisible/isAttributeSideBarVisible.service"
-import { SharpnessModeService, SharpnessModeSubscriber } from "../../state/store/appSettings/sharpnessMode/sharpnessMode.service"
-export class CodeMapController implements IsAttributeSideBarVisibleSubscriber, IsLoadingFileSubscriber, SharpnessModeSubscriber {
-	private _viewModel: {
-		isLoadingFile: boolean
-		isSideBarVisible: boolean
-	} = {
-		isLoadingFile: true,
-		isSideBarVisible: null
-	}
+import { onStoreChanged } from "../../state/angular-redux/onStoreChanged/onStoreChanged"
+import { sharpnessModeSelector } from "../../state/store/appSettings/sharpnessMode/sharpnessMode.selector"
+
+@Component({
+	selector: "cc-code-map",
+	template: require("./codeMap.component.html")
+})
+export class CodeMapComponent implements AfterViewInit {
+	isLoadingFile$ = this.store.select(isLoadingFileSelector)
+	isAttributeSidebarVisible$ = this.store.select(isAttributeSideBarVisibleSelector)
 
 	constructor(
-		private $rootScope: IRootScopeService,
-		private $element: Element,
-		private threeViewerService: ThreeViewerService,
-		private codeMapMouseEventService: CodeMapMouseEventService
-	) {
-		"ngInject"
-		IsAttributeSideBarVisibleService.subscribe(this.$rootScope, this)
-		IsLoadingFileService.subscribe(this.$rootScope, this)
-		SharpnessModeService.subscribe(this.$rootScope, this)
+		@Inject(Store) private store: Store,
+		@Inject(ThreeViewerServiceToken) private threeViewerService: ThreeViewerService,
+		@Inject(CodeMapMouseEventServiceToken) private codeMapMouseEventService: CodeMapMouseEventService,
+		@Inject(ElementRef) private elementReference: ElementRef
+	) {}
+
+	ngAfterViewInit(): void {
+		this.initMap()
+		onStoreChanged(sharpnessModeSelector, oldValue => {
+			if (!oldValue) {
+				// skip initial change as this is already handled within ngAfterViewInit
+				return
+			}
+			this.threeViewerService.stopAnimate()
+			this.threeViewerService.destroy()
+			this.initMap()
+			this.threeViewerService.autoFitTo()
+			this.threeViewerService.animate()
+			this.threeViewerService.animateStats()
+		})
 	}
 
-	$postLink() {
-		this.threeViewerService.init(this.$element[0].children[0])
+	private initMap() {
+		this.threeViewerService.init(this.elementReference.nativeElement.querySelector("#codeMap"))
 		this.codeMapMouseEventService.start()
 	}
-
-	onIsAttributeSideBarVisibleChanged(isAttributeSideBarVisible: boolean) {
-		this._viewModel.isSideBarVisible = isAttributeSideBarVisible
-	}
-
-	onIsLoadingFileChanged(isLoadingFile: boolean) {
-		this.threeViewerService?.dispose()
-		this._viewModel.isLoadingFile = isLoadingFile
-	}
-
-	// TODO not used right now, but added for catching the gl context loss, needs to be further implemented and tested
-	catchContextLoss() {
-		const canvas = this.threeViewerService.getRenderCanvas()
-		const extention = this.threeViewerService.getRenderLoseExtention()
-		canvas.addEventListener(
-			"webglcontextlost",
-			() => {
-				extention.restoreContext()
-			},
-			false
-		)
-		canvas.addEventListener("webglcontextrestored", () => {})
-	}
-
-	onSharpnessModeChanged() {
-		this.threeViewerService.stopAnimate()
-		this.threeViewerService.destroy()
-		this.$postLink()
-		this.threeViewerService.autoFitTo()
-		this.threeViewerService.animate()
-		this.threeViewerService.animateStats()
-	}
-}
-
-export const codeMapComponent = {
-	selector: "codeMapComponent",
-	template: require("./codeMap.component.html"),
-	controller: CodeMapController
 }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
@@ -4,7 +4,6 @@ import { downgradeComponent, downgradeInjectable } from "@angular/upgrade/static
 
 import "./threeViewer/threeViewer.module"
 import "../../state/state.module"
-import { codeMapComponent } from "./codeMap.component"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 import { CodeMapRenderService } from "./codeMap.render.service"
 import { CodeMapLabelService } from "./codeMap.label.service"
@@ -12,14 +11,25 @@ import { CodeMapArrowService } from "./codeMap.arrow.service"
 import { AttributeSideBarComponent } from "../attributeSideBar/attributeSideBar.component"
 import { ViewCubeComponent } from "../viewCube/viewCube.component"
 import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
+import { NgModule } from "@angular/core"
+import { CommonModule } from "@angular/common"
+import { ViewCubeModule } from "../viewCube/viewCube.module"
+import { AttributeSideBarModule } from "../attributeSideBar/attributeSideBar.module"
+import { CodeMapComponent } from "./codeMap.component"
 
 angular
 	.module("app.codeCharta.ui.codeMap", ["app.codeCharta.state", "app.codeCharta", "app.codeCharta.ui.codeMap.threeViewer"])
 	.factory("viewCubeMouseEvents", downgradeInjectable(ViewCubeMouseEventsService))
-	.component(codeMapComponent.selector, codeMapComponent)
 	.directive("ccAttributeSideBar", downgradeComponent({ component: AttributeSideBarComponent }))
 	.service(camelCase(CodeMapRenderService.name), CodeMapRenderService)
 	.service(camelCase(CodeMapMouseEventService.name), CodeMapMouseEventService)
 	.service(camelCase(CodeMapLabelService.name), CodeMapLabelService)
 	.service(camelCase(CodeMapArrowService.name), CodeMapArrowService)
 	.directive("ccViewCube", downgradeComponent({ component: ViewCubeComponent }))
+
+@NgModule({
+	imports: [CommonModule, ViewCubeModule, AttributeSideBarModule],
+	declarations: [CodeMapComponent],
+	exports: [CodeMapComponent]
+})
+export class CodeMapModule {}

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.module.ts
@@ -1,6 +1,6 @@
 import angular from "angular"
 import camelCase from "lodash.camelcase"
-import { downgradeComponent, downgradeInjectable } from "@angular/upgrade/static"
+import { downgradeInjectable } from "@angular/upgrade/static"
 
 import "./threeViewer/threeViewer.module"
 import "../../state/state.module"
@@ -8,8 +8,6 @@ import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 import { CodeMapRenderService } from "./codeMap.render.service"
 import { CodeMapLabelService } from "./codeMap.label.service"
 import { CodeMapArrowService } from "./codeMap.arrow.service"
-import { AttributeSideBarComponent } from "../attributeSideBar/attributeSideBar.component"
-import { ViewCubeComponent } from "../viewCube/viewCube.component"
 import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 import { NgModule } from "@angular/core"
 import { CommonModule } from "@angular/common"
@@ -20,12 +18,10 @@ import { CodeMapComponent } from "./codeMap.component"
 angular
 	.module("app.codeCharta.ui.codeMap", ["app.codeCharta.state", "app.codeCharta", "app.codeCharta.ui.codeMap.threeViewer"])
 	.factory("viewCubeMouseEvents", downgradeInjectable(ViewCubeMouseEventsService))
-	.directive("ccAttributeSideBar", downgradeComponent({ component: AttributeSideBarComponent }))
 	.service(camelCase(CodeMapRenderService.name), CodeMapRenderService)
 	.service(camelCase(CodeMapMouseEventService.name), CodeMapMouseEventService)
 	.service(camelCase(CodeMapLabelService.name), CodeMapLabelService)
 	.service(camelCase(CodeMapArrowService.name), CodeMapArrowService)
-	.directive("ccViewCube", downgradeComponent({ component: ViewCubeComponent }))
 
 @NgModule({
 	imports: [CommonModule, ViewCubeModule, AttributeSideBarModule],

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -115,7 +115,6 @@ export class CodeMapMouseEventService implements FilesSelectionSubscriber, Black
 	}
 
 	start() {
-		// TODO: Check if these event listeners should ever be removed again.
 		this.threeRendererService.renderer.domElement.addEventListener(
 			"mousemove",
 			debounce(event => this.onDocumentMouseMove(event), 60)

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.spec.ts
@@ -94,7 +94,7 @@ describe("ThreeViewerService", () => {
 	}
 
 	function withMockedThreeStatsService() {
-		threeStatsService = threeViewerService["threeStatsService"] = jest.fn().mockReturnValue({ init: jest.fn() })()
+		threeStatsService = threeViewerService["threeStatsService"] = jest.fn().mockReturnValue({ init: jest.fn(), destroy: jest.fn() })()
 	}
 
 	describe("init", () => {
@@ -263,6 +263,25 @@ describe("ThreeViewerService", () => {
 			threeViewerService.autoFitTo()
 
 			expect(threeOrbitControlsService.autoFitTo).toHaveBeenCalled()
+		})
+	})
+
+	describe("restart", () => {
+		it("should restart the system", () => {
+			threeViewerService.stopAnimate = jest.fn()
+			threeViewerService.destroy = jest.fn()
+			threeViewerService.init = jest.fn()
+			threeViewerService.autoFitTo = jest.fn()
+			threeViewerService.animate = jest.fn()
+			threeViewerService.animateStats = jest.fn()
+
+			threeViewerService.restart(element)
+			expect(threeViewerService.stopAnimate).toHaveBeenCalled()
+			expect(threeViewerService.destroy).toHaveBeenCalled()
+			expect(threeViewerService.init).toHaveBeenCalled()
+			expect(threeViewerService.autoFitTo).toHaveBeenCalled()
+			expect(threeViewerService.animate).toHaveBeenCalled()
+			expect(threeViewerService.animateStats).toHaveBeenCalled()
 		})
 	})
 

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
@@ -1,5 +1,3 @@
-"use strict"
-
 import { ThreeSceneService } from "./threeSceneService"
 import { ThreeCameraService } from "./threeCameraService"
 import { ThreeOrbitControlsService } from "./threeOrbitControlsService"
@@ -28,7 +26,10 @@ export class ThreeViewerService {
 			threeCameraService: { camera },
 			threeRendererService,
 			threeStatsService,
-			threeOrbitControlsService
+			threeOrbitControlsService,
+			onWindowResize,
+			onFocusIn,
+			onFocusOut
 		} = this
 		camera.lookAt(scene.position)
 		scene.add(camera)
@@ -38,13 +39,12 @@ export class ThreeViewerService {
 
 		canvasElement.append(threeRendererService.renderer.domElement)
 
-		// TODO do we need to remove these listeners ?
-		window.addEventListener("resize", () => this.onWindowResize())
-		window.addEventListener("focusin", event => this.onFocusIn(event))
-		window.addEventListener("focusout", event => this.onFocusOut(event))
+		window.addEventListener("resize", onWindowResize)
+		window.addEventListener("focusin", onFocusIn)
+		window.addEventListener("focusout", onFocusOut)
 	}
 
-	onWindowResize() {
+	onWindowResize = () => {
 		this.threeSceneService.scene.updateMatrixWorld(false)
 		this.threeRendererService.renderer.setSize(window.innerWidth, window.innerHeight)
 		this.threeCameraService.camera.aspect = window.innerWidth / window.innerHeight
@@ -56,13 +56,13 @@ export class ThreeViewerService {
 		this.threeOrbitControlsService.controls.enableRotate = value
 	}
 
-	onFocusIn(event) {
+	onFocusIn = event => {
 		if (event.target.nodeName === "INPUT") {
 			this.threeOrbitControlsService.controls.enableKeys = false
 		}
 	}
 
-	onFocusOut(event) {
+	onFocusOut = event => {
 		if (event.target.nodeName === "INPUT") {
 			this.threeOrbitControlsService.controls.enableKeys = true
 		}
@@ -101,6 +101,10 @@ export class ThreeViewerService {
 	}
 
 	destroy() {
+		window.removeEventListener("resize", this.onWindowResize)
+		window.removeEventListener("focusin", this.onFocusIn)
+		window.removeEventListener("focusout", this.onFocusOut)
+		this.dispose()
 		this.threeStatsService.destroy()
 		this.getRenderCanvas().remove()
 		this.dispose()

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
@@ -35,6 +35,9 @@ export class ThreeViewerService {
 		window.addEventListener("resize", this.onWindowResize)
 		window.addEventListener("focusin", this.onFocusIn)
 		window.addEventListener("focusout", this.onFocusOut)
+
+		this.animate()
+		this.animateStats()
 	}
 
 	restart(target: Element) {

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeViewerService.ts
@@ -3,8 +3,8 @@ import { ThreeCameraService } from "./threeCameraService"
 import { ThreeOrbitControlsService } from "./threeOrbitControlsService"
 import { ThreeRendererService } from "./threeRendererService"
 import { ThreeUpdateCycleService } from "./threeUpdateCycleService"
-
 import { ThreeStatsService } from "./threeStatsService"
+
 export class ThreeViewerService {
 	private animationFrameId: number
 
@@ -19,29 +19,31 @@ export class ThreeViewerService {
 		"ngInject"
 	}
 
-	init(canvasElement: Element) {
+	init(target: Element) {
 		this.threeCameraService.init(window.innerWidth, window.innerHeight)
-		const {
-			threeSceneService: { scene },
-			threeCameraService: { camera },
-			threeRendererService,
-			threeStatsService,
-			threeOrbitControlsService,
-			onWindowResize,
-			onFocusIn,
-			onFocusOut
-		} = this
+
+		const camera = this.threeCameraService.camera
+		const scene = this.threeSceneService.scene
 		camera.lookAt(scene.position)
 		scene.add(camera)
-		threeRendererService.init(window.innerWidth, window.innerHeight, scene, camera)
-		threeStatsService.init(canvasElement)
-		threeOrbitControlsService.init(threeRendererService.renderer.domElement)
+		this.threeRendererService.init(window.innerWidth, window.innerHeight, scene, camera)
+		this.threeStatsService.init(target)
+		this.threeOrbitControlsService.init(this.threeRendererService.renderer.domElement)
 
-		canvasElement.append(threeRendererService.renderer.domElement)
+		target.append(this.threeRendererService.renderer.domElement)
 
-		window.addEventListener("resize", onWindowResize)
-		window.addEventListener("focusin", onFocusIn)
-		window.addEventListener("focusout", onFocusOut)
+		window.addEventListener("resize", this.onWindowResize)
+		window.addEventListener("focusin", this.onFocusIn)
+		window.addEventListener("focusout", this.onFocusOut)
+	}
+
+	restart(target: Element) {
+		this.stopAnimate()
+		this.destroy()
+		this.init(target)
+		this.autoFitTo()
+		this.animate()
+		this.animateStats()
 	}
 
 	onWindowResize = () => {

--- a/visualization/app/codeCharta/ui/viewCube/viewCube.module.ts
+++ b/visualization/app/codeCharta/ui/viewCube/viewCube.module.ts
@@ -6,7 +6,6 @@ import { CommonModule } from "@angular/common"
 @NgModule({
 	imports: [CommonModule],
 	declarations: [ViewCubeComponent, CenterMapButtonComponent],
-	exports: [ViewCubeComponent],
-	entryComponents: [ViewCubeComponent]
+	exports: [ViewCubeComponent]
 })
 export class ViewCubeModule {}


### PR DESCRIPTION
- migrate codeMap.component to Angular
- init map initially only once and not twice as before
- remove window event listener on threeViewerService.destroy, so that they don't stack up on sharpness mode changes