### PR TITLE
Fix formatting in GitHub release pipeline

### DIFF
--- a/.github/workflows/release_gh_pages.yml
+++ b/.github/workflows/release_gh_pages.yml
@@ -102,7 +102,7 @@ jobs:
           name: codecharta/codecharta-visualization
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: ${{env.RELEASE_VERSION}, "latest"}
+          tags: "latest,${{ env.RELEASE_VERSION }}"
           workdir: ./visualization
 
       - name: Publish Docker Analysis Image
@@ -112,7 +112,7 @@ jobs:
           name: codecharta/codecharta-analysis
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: ${{env.RELEASE_VERSION}, "latest"}
+          tags: "latest,${{ env.RELEASE_VERSION }}"
           workdir: ./analysis
 
       - name: Deploy


### PR DESCRIPTION
# Fix formatting in GitHub release pipeline

Issue: #2946
## Description 
The formatting for tagging Docker containers now adheres to https://github.com/elgohr/Publish-Docker-Github-Action/tree/v4#tags
