### PR TITLE
Refactor/Clean up custom config builder

### DIFF
--- a/visualization/app/codeCharta/util/customConfigBuilder.ts
+++ b/visualization/app/codeCharta/util/customConfigBuilder.ts
@@ -18,126 +18,14 @@ export function buildCustomConfigFromState(configName: string, state: State, cam
 		mapChecksum: customConfigFileStateConnector.getChecksumOfAssignedMaps(),
 		customConfigVersion: CUSTOM_CONFIG_API_VERSION,
 		stateSettings: {
-			appSettings: undefined,
-			dynamicSettings: undefined,
-			fileSettings: undefined,
-			treeMap: undefined
+			appSettings: { ...state.appSettings },
+			dynamicSettings: { ...state.dynamicSettings },
+			fileSettings: { ...state.fileSettings },
+			treeMap: { ...state.treeMap }
 		},
 		camera
 	}
 
-	// Initialize all necessary state settings with default values right here
-	// Any changes to the state properties must also be adapted here
-	// You must handle breaking changes of the CustomConfig API
-	initializeAppSettings(customConfig)
-	initializeDynamicSettings(customConfig)
-	initializeFileSettings(customConfig)
-	initializeTreeMapSettings(customConfig)
-
-	// Override the default state settings with the stored CustomConfig values
-	deepMapOneToOther(state, customConfig.stateSettings)
-
 	customConfig.id = md5(JSON.stringify(customConfig, stateObjectReplacer))
 	return customConfig
-}
-
-function initializeAppSettings(target: CustomConfig) {
-	target.stateSettings.appSettings = {
-		showMetricLabelNameValue: false,
-		showMetricLabelNodeName: false,
-		colorLabels: {
-			positive: false,
-			negative: false,
-			neutral: false
-		},
-		amountOfEdgePreviews: 0,
-		amountOfTopLabels: 0,
-		dynamicMargin: false,
-		edgeHeight: 0,
-		hideFlatBuildings: false,
-		invertHeight: false,
-		invertArea: false,
-		isAttributeSideBarVisible: false,
-		isLoadingFile: false,
-		isLoadingMap: false,
-		isPresentationMode: false,
-		isWhiteBackground: false,
-		resetCameraIfNewFileIsLoaded: false,
-		scaling: undefined,
-		showOnlyBuildingsWithEdges: false,
-		isEdgeMetricVisible: true,
-		sortingOrderAscending: false,
-		experimentalFeaturesEnabled: false,
-		screenshotToClipboardEnabled: false,
-		layoutAlgorithm: undefined,
-		maxTreeMapFiles: 0,
-		sharpnessMode: undefined,
-		mapColors: {
-			labelColorAndAlpha: { alpha: 0, rgb: "" },
-			base: "",
-			flat: "",
-			incomingEdge: "",
-			markingColors: [],
-			negative: "",
-			negativeDelta: "",
-			neutral: "",
-			outgoingEdge: "",
-			positive: "",
-			positiveDelta: "",
-			selected: ""
-		}
-	}
-}
-
-function initializeDynamicSettings(target: CustomConfig) {
-	target.stateSettings.dynamicSettings = {
-		areaMetric: "",
-		colorMetric: "",
-		distributionMetric: "",
-		edgeMetric: "",
-		focusedNodePath: [],
-		heightMetric: "",
-		margin: 0,
-		searchPattern: "",
-		sortingOption: undefined,
-		colorRange: {
-			from: 0,
-			to: 0
-		},
-		colorMode: undefined
-	}
-}
-
-function initializeFileSettings(target: CustomConfig) {
-	target.stateSettings.fileSettings = {
-		attributeTypes: undefined,
-		blacklist: undefined,
-		edges: [],
-		markedPackages: []
-	}
-}
-
-function initializeTreeMapSettings(target: CustomConfig) {
-	target.stateSettings.treeMap = {
-		mapSize: 0
-	}
-}
-
-function deepMapOneToOther<T>(source: State, target: T) {
-	for (const [key, value] of Object.entries(source)) {
-		// if a property of source is missing, we don't want to copy it into target.
-		if (!Object.prototype.hasOwnProperty.call(target, key)) {
-			continue
-		}
-
-		if (typeof value !== "object" || Array.isArray(value) || value === null || target[key] === undefined) {
-			// Assign primitive values to target
-			target[key] = value
-		} else {
-			// We have to map an object with nested properties here.
-			// source and target have the same properties specified for the nested object.
-			// Thus, map properties of the next deeper level.
-			deepMapOneToOther(value, target[key])
-		}
-	}
 }


### PR DESCRIPTION
# Clean up custom config builder

## Description

I have often been annoyed with the Custom Config Builder, especially when implementing a new state property for CodeCharta. This meant that you had to add the new property manually each time. But it is much easier if you directly map the state to the custom config. This saves duplications and is less error-prone. 
And I do not see any case where state values should not be complete. Besides, I didn't have to change a single test!
Also, we can still load old configs into CodeCharta.


