### PR TITLE
Give all containers a name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
     sonar:
         image: sonarqube:community
+        container_name: sonar
         ports:
             - "9000:9000"
         volumes:
@@ -9,6 +10,7 @@ services:
 
     visualization:
         image: codecharta/codecharta-visualization
+        container_name: visualization
         ports:
             - "9001:80"
         volumes:
@@ -16,6 +18,7 @@ services:
 
     analysis:
         image: codecharta/codecharta-analysis
+        container_name: analysis
         volumes:
             - shared-volume:/mnt/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
     visualization:
         image: codecharta/codecharta-visualization
-        container_name: visualization
+        container_name: codecharta-visualization
         ports:
             - "9001:80"
         volumes:
@@ -18,7 +18,7 @@ services:
 
     analysis:
         image: codecharta/codecharta-analysis
-        container_name: analysis
+        container_name: codecharta-analysis
         volumes:
             - shared-volume:/mnt/data
 

--- a/gh-pages/_docs/01-01-quick-start-guide.md
+++ b/gh-pages/_docs/01-01-quick-start-guide.md
@@ -125,14 +125,14 @@ Now that all containers are running, we can connect to the analysis container.
 
 ```bash
 # You can see the name of all running containers with 'docker ps'
-docker exec -it analysis bash
+docker exec -it codecharta-analysis bash
 ```
 
 You are now connected into the container, and are able to run ccsh by simply typing `ccsh`. You can try any of the other quickstart guides to create a .cc.json file.
 Once you have a .cc.json file, we can copy it to our hard drive.
 
 ```bash
-docker cp analysis:path/to/ccjson/ docker-sample.cc.json
+docker cp codecharta-analysis:path/to/ccjson/ docker-sample.cc.json
 ```
 
 > You can also [check the docs of the docker cp command to learn more.](https://docs.docker.com/engine/reference/commandline/cp/)

--- a/gh-pages/_docs/01-01-quick-start-guide.md
+++ b/gh-pages/_docs/01-01-quick-start-guide.md
@@ -125,15 +125,14 @@ Now that all containers are running, we can connect to the analysis container.
 
 ```bash
 # You can see the name of all running containers with 'docker ps'
-docker exec -it codecharta-analysis-1 bash
+docker exec -it analysis bash
 ```
 
 You are now connected into the container, and are able to run ccsh by simply typing `ccsh`. You can try any of the other quickstart guides to create a .cc.json file.
 Once you have a .cc.json file, we can copy it to our hard drive.
 
 ```bash
-# You can see the name of all running containers with 'docker ps'
-docker cp codecharta-analysis-1:path/to/ccjson/ docker-sample.cc.json
+docker cp analysis:path/to/ccjson/ docker-sample.cc.json
 ```
 
 > You can also [check the docs of the docker cp command to learn more.](https://docs.docker.com/engine/reference/commandline/cp/)

--- a/gh-pages/_docs/05-06-docker-containers.md
+++ b/gh-pages/_docs/05-06-docker-containers.md
@@ -9,18 +9,18 @@ docker-compose.yml
 
 ## The Container Landscape
 
-| Container-Name           | Description                             | How to use                                                      |
-| ------------------------ | --------------------------------------- | --------------------------------------------------------------- |
-| codecharta-sonar         | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux       |
-| codecharta-visualization | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive                 |
-| codecharta-analysis      | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it codecharta-analysis bash` |
+| Container-Name | Description                             | How to use                                                |
+| -------------- | --------------------------------------- | --------------------------------------------------------- |
+| sonar          | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux |
+| visualization  | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive           |
+| analysis       | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it analysis bash`      |
 
 > To see the actual names of the containers on your system, run `docker ps`
 
 All containers share a volume for the quick transfer of files. You can find it under /mnt/data in each container.
 Please note that you will need to copy finished cc.json files to **your** hard-drive to open them in Visualization.
 
-### codecharta-sonar
+### Sonar
 
 See also [SonarQube Docs](https://docs.sonarqube.org/latest/setup/get-started-2-minutes/)
 
@@ -33,14 +33,14 @@ Simply follow the steps for a manual, local project under Linux. You can also [c
 {{site.baseurl}}{% link _docs/analyze-with-sonarqube.md %})
 The sonar-scanner is already pre-installed in our analysis container.
 
-### codecharta-visualization
+### Visualization
 
 See also [CodeCharta Visualization]({{site.baseurl}}{% link _docs/visualization.md %})
 
 Open `localhost:9001` in your browser and open any file you want from your hard drive.
 To open files you have created in the analysis container, copy them over using `docker cp`
 
-### codecharta-analysis
+### Analysis
 
 See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/analysis.md %})
 
@@ -58,7 +58,7 @@ Once you have your .cc.json file ready, you can copy it to your machine.
 This is how the command could look like if I want to copy a file from the container to my current working directory:
 
 ```bash
-docker cp codecharta-analysis-1:/root/junit4.cc.json.gz junit4.cc.json.gz
+docker cp analysis:/root/junit4.cc.json.gz junit4.cc.json.gz
 ```
 
 To check the name of the container, you can simply type `docker ps`.

--- a/gh-pages/_docs/05-06-docker-containers.md
+++ b/gh-pages/_docs/05-06-docker-containers.md
@@ -9,11 +9,11 @@ docker-compose.yml
 
 ## The Container Landscape
 
-| Container-Name | Description                             | How to use                                                |
-| -------------- | --------------------------------------- | --------------------------------------------------------- |
-| sonar          | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux |
-| visualization  | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive           |
-| analysis       | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it analysis bash`      |
+| Container-Name           | Description                             | How to use                                                |
+| ------------------------ | --------------------------------------- | --------------------------------------------------------- |
+| sonar                    | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux |
+| codecharta-visualization | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive           |
+| codecharta-analysis      | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it analysis bash`      |
 
 > To see the actual names of the containers on your system, run `docker ps`
 
@@ -33,14 +33,14 @@ Simply follow the steps for a manual, local project under Linux. You can also [c
 {{site.baseurl}}{% link _docs/analyze-with-sonarqube.md %})
 The sonar-scanner is already pre-installed in our analysis container.
 
-### Visualization
+### codecharta-visualization
 
 See also [CodeCharta Visualization]({{site.baseurl}}{% link _docs/visualization.md %})
 
 Open `localhost:9001` in your browser and open any file you want from your hard drive.
 To open files you have created in the analysis container, copy them over using `docker cp`
 
-### Analysis
+### codecharta-analysis
 
 See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/analysis.md %})
 
@@ -58,7 +58,7 @@ Once you have your .cc.json file ready, you can copy it to your machine.
 This is how the command could look like if I want to copy a file from the container to my current working directory:
 
 ```bash
-docker cp analysis:/root/junit4.cc.json.gz junit4.cc.json.gz
+docker cp codecharta-analysis:/root/junit4.cc.json.gz junit4.cc.json.gz
 ```
 
 To check the name of the container, you can simply type `docker ps`.

--- a/gh-pages/_docs/05-06-docker-containers.md
+++ b/gh-pages/_docs/05-06-docker-containers.md
@@ -9,11 +9,11 @@ docker-compose.yml
 
 ## The Container Landscape
 
-| Container-Name           | Description                             | How to use                                                |
-| ------------------------ | --------------------------------------- | --------------------------------------------------------- |
-| sonar                    | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux |
-| codecharta-visualization | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive           |
-| codecharta-analysis      | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it analysis bash`      |
+| Container-Name           | Description                             | How to use                                                      |
+| ------------------------ | --------------------------------------- | --------------------------------------------------------------- |
+| sonar                    | Hosts an instance of SonarQube          | localhost:9000 in the browser, follow the steps for Linux       |
+| codecharta-visualization | Runs the visualisation part o CodeChara | localhost:9001, load files from your hard-drive                 |
+| codecharta-analysis      | Contains all tools the ccsh can import  | Connect via terminal `docker exec -it codecharta-analysis bash` |
 
 > To see the actual names of the containers on your system, run `docker ps`
 


### PR DESCRIPTION
# Give all containers a name

Closes: #2946

## Description

Containers created by docker compose are named automatically in the moment, resulting in some less than pretty names and suffixes. Now the containers have an explicit name. The documentation has been updated as well.

## Screenshots or gifs
