### PR TITLE
Fix/3074/Remove await when using jest 'toMatch' function

### DIFF
--- a/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/attributeSideBar/attributeSideBar.component.spec.ts
@@ -61,14 +61,14 @@ describe("AttributeSideBarComponent", () => {
 		expect(isSideBarOpen).toBe(true)
 
 		const name = container.querySelector("a[class=node-link]").textContent
-		await expect(name).toMatch("root/big leaf.ts")
+		expect(name).toMatch("root/big leaf.ts")
 
 		const pathName = container.querySelector("cc-node-path").textContent
-		await expect(pathName).toMatch("/root/big leaf")
+		expect(pathName).toMatch("/root/big leaf")
 
 		const firstPrimaryMetricEntry = container.querySelector("cc-attribute-side-bar-primary-metric").textContent
 		const expectedPrimaryMetricTextContent = "20 a"
-		await expect(firstPrimaryMetricEntry).toMatch(expectedPrimaryMetricTextContent)
+		expect(firstPrimaryMetricEntry).toMatch(expectedPrimaryMetricTextContent)
 
 		const expectedSecondaryMetricTextContent = "15b"
 		const isSecondaryMetricInPrimaryMetricSection = container
@@ -76,7 +76,7 @@ describe("AttributeSideBarComponent", () => {
 			.textContent.includes(expectedSecondaryMetricTextContent)
 		expect(isSecondaryMetricInPrimaryMetricSection).toBe(false)
 		const firstSecondaryMetricEntry = container.querySelector("cc-attribute-side-bar-secondary-metrics .metric-row").textContent
-		await expect(firstSecondaryMetricEntry).toMatch(expectedSecondaryMetricTextContent)
+		expect(firstSecondaryMetricEntry).toMatch(expectedSecondaryMetricTextContent)
 
 		expect(isAttributeTypeSelectorShown(container)).toBe(false)
 	})
@@ -87,11 +87,11 @@ describe("AttributeSideBarComponent", () => {
 
 		const firstPrimaryMetricEntry = container.querySelector("cc-attribute-side-bar-primary-metric").textContent
 		const expectedPrimaryMetricTextContent = /20\s+Δ1.0\s+a/
-		await expect(firstPrimaryMetricEntry).toMatch(expectedPrimaryMetricTextContent)
+		expect(firstPrimaryMetricEntry).toMatch(expectedPrimaryMetricTextContent)
 
 		const expectedSecondaryMetricTextContent = /15\s+Δ2.0\s+b/
 		const firstSecondaryMetricEntry = container.querySelector("cc-attribute-side-bar-secondary-metrics .metric-row").textContent
-		await expect(firstSecondaryMetricEntry).toMatch(expectedSecondaryMetricTextContent)
+		expect(firstSecondaryMetricEntry).toMatch(expectedSecondaryMetricTextContent)
 	})
 
 	it("should display attribute type selectors for folders", async () => {

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
@@ -33,9 +33,9 @@ describe("metricChooserComponent", () => {
 
 		await userEvent.click(await screen.findByText("aMetric (1)"))
 		const options = screen.queryAllByRole("option")
-		await expect(options[0].textContent).toMatch("aMetric (1)")
-		await expect(options[1].textContent).toMatch("bMetric (2)")
-		await expect(options[2].textContent).toMatch("cMetric (3)")
+		expect(options[0].textContent).toMatch("aMetric (1)")
+		expect(options[1].textContent).toMatch("bMetric (2)")
+		expect(options[2].textContent).toMatch("cMetric (3)")
 
 		await userEvent.click(options[1])
 		expect(screen.queryByText("aMetric (1)")).toBe(null)
@@ -60,7 +60,7 @@ describe("metricChooserComponent", () => {
 		await userEvent.type(getSearchBox(), "b")
 		const options = screen.queryAllByRole("option")
 		expect(options.length).toBe(1)
-		await expect(options[0].textContent).toMatch("bMetric (2)")
+		expect(options[0].textContent).toMatch("bMetric (2)")
 
 		await userEvent.click(options[0])
 		expect(screen.queryByRole("listbox")).toBeNull()


### PR DESCRIPTION
# Remove asynchronous function call when using jest `toMatch()`

Closes: #3074

## Description

Switch asynchronous to synchronous function calls when using jest `toMatch()`. IntelliJ get confused because of jest/expect-puppeteer `toMatch()` function (that is not used in our case).
