### PR TITLE
Fix/2507/hide link metrics button in delta mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add a new button that links the height metric to the color metric so that the colour metric is automatically set to
-    the selected height metric [#3058](https://github.com/MaibornWolff/codecharta/pull/3058) </br>
-    ![image](https://user-images.githubusercontent.com/72517530/193291144-fdc73a15-2087-47e2-845b-05c666aec71d.png) </br>
+    the selected height metric [#3058](https://github.com/MaibornWolff/codecharta/pull/3058)
+    , [#3086](https://github.com/MaibornWolff/codecharta/pull/3086) <br/>
+    ![image](https://user-images.githubusercontent.com/72517530/193291144-fdc73a15-2087-47e2-845b-05c666aec71d.png) <br/>
     ![image](https://user-images.githubusercontent.com/72517530/194300920-60ce9fcd-0dd5-46ef-a90b-01d9a29205e6.png)
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/ui/ribbonBar/linkColorMetricToHeightMetricButton/linkColorMetricToHeightMetricButton.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/linkColorMetricToHeightMetricButton/linkColorMetricToHeightMetricButton.component.html
@@ -3,5 +3,5 @@
 	class="link-metrics-button"
 	(click)="toggleIsColorMetricLinkedToHeightMetric()"
 >
-	<i [ngClass]="(isColorMetricLinkedToHeightMetric$ | async) ? 'fa fa-link' : 'fa fa-chain-broken'"></i>
+	<i [ngClass]="(isColorMetricLinkedToHeightMetric$ | async) ? 'fa fa-chain-broken' : 'fa fa-link'"></i>
 </button>

--- a/visualization/app/codeCharta/ui/ribbonBar/linkColorMetricToHeightMetricButton/linkColorMetricToHeightMetricButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/linkColorMetricToHeightMetricButton/linkColorMetricToHeightMetricButton.component.spec.ts
@@ -16,14 +16,14 @@ describe("linkHeightAndColorMetricComponent", () => {
 	it("should toggle height and color metric link on click and show associated icon", async () => {
 		const { container } = await render(LinkColorMetricToHeightMetricButtonComponent)
 
-		expect(container.querySelector(".fa.fa-chain-broken")).not.toBe(null)
-		expect(container.querySelector(".fa.fa-link")).toBe(null)
+		expect(container.querySelector(".fa.fa-link")).not.toBe(null)
+		expect(container.querySelector(".fa.fa-chain-broken")).toBe(null)
 		expect(screen.queryByText("Unlink Height And Color Metric")).toBe(null)
 
 		await userEvent.click(screen.getByTitle("Link Height And Color Metric"))
 
-		expect(container.querySelector(".fa.fa-link")).not.toBe(null)
-		expect(container.querySelector(".fa.fa-chain-broken")).toBe(null)
+		expect(container.querySelector(".fa.fa-chain-broken")).not.toBe(null)
+		expect(container.querySelector(".fa.fa-link")).toBe(null)
 		expect(screen.getByTitle("Unlink Height And Color Metric")).not.toBe(null)
 		expect(screen.queryByText("Link Height And Color Metric")).toBe(null)
 	})

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
@@ -53,7 +53,7 @@
 	></cc-height-settings-panel>
 </mat-card>
 
-<mat-card class="link-color-metric-to-height-metric-card">
+<mat-card *ngIf="!(isDeltaState$ | async)" class="link-color-metric-to-height-metric-card">
 	<cc-link-color-metric-to-height-metric-button></cc-link-color-metric-to-height-metric-button>
 </mat-card>
 

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.spec.ts
@@ -19,12 +19,12 @@ const mockedIsDeltaStateSelector = mocked(isDeltaStateSelector)
 jest.mock("../../state/selectors/accumulatedData/metricData/edgeMetricData.selector", () => ({
 	edgeMetricDataSelector: jest.fn(() => [])
 }))
-const mockEdedgeMetricDataSelector = mocked(edgeMetricDataSelector)
+const mockEdgeMetricDataSelector = mocked(edgeMetricDataSelector)
 
 describe("RibbonBarComponent", () => {
 	beforeEach(() => {
 		mockedIsDeltaStateSelector.mockImplementation(() => false)
-		mockEdedgeMetricDataSelector.mockImplementation(() => [])
+		mockEdgeMetricDataSelector.mockImplementation(() => [])
 		TestBed.configureTestingModule({
 			imports: [RibbonBarModule],
 			providers: [
@@ -83,28 +83,30 @@ describe("RibbonBarComponent", () => {
 	})
 
 	describe("delta state", () => {
-		it("should not show cc-color-metric-chooser when in delta mode", async () => {
+		it("should not show cc-color-metric-chooser and cc-link-color-metric-to-height-metric-button when in delta mode", async () => {
 			mockedIsDeltaStateSelector.mockImplementation(() => true)
 			const { container } = await render(RibbonBarComponent, { excludeComponentDeclaration: true })
 			expect(container.querySelector("cc-color-metric-chooser")).toBe(null)
+			expect(container.querySelector("cc-link-color-metric-to-height-metric-button")).toBe(null)
 		})
 
-		it("should show cc-color-metric-chooser when not in delta mode", async () => {
+		it("should show cc-color-metric-chooser and cc-link-color-metric-to-height-metric-button when not in delta mode", async () => {
 			mockedIsDeltaStateSelector.mockImplementation(() => false)
 			const { container } = await render(RibbonBarComponent, { excludeComponentDeclaration: true })
 			expect(container.querySelector("cc-color-metric-chooser")).not.toBe(null)
+			expect(container.querySelector("cc-link-color-metric-to-height-metric-button")).not.toBe(null)
 		})
 	})
 
 	describe("edge metric chooser", () => {
 		it("should show edge metrics when there are some available", async () => {
-			mockEdedgeMetricDataSelector.mockImplementation(() => [{} as EdgeMetricData])
+			mockEdgeMetricDataSelector.mockImplementation(() => [{} as EdgeMetricData])
 			await render(RibbonBarComponent, { excludeComponentDeclaration: true })
 			expect(screen.getByText("Edge Metric Options")).toBeTruthy()
 		})
 
 		it("should hide edge metrics when there aren't any available", async () => {
-			mockEdedgeMetricDataSelector.mockImplementation(() => [])
+			mockEdgeMetricDataSelector.mockImplementation(() => [])
 			await render(RibbonBarComponent, { excludeComponentDeclaration: true })
 			expect(screen.queryByText("Edge Metric Options")).toBe(null)
 		})


### PR DESCRIPTION
# Hide link metrics button in delta mode

Closes: #2507 

## Description

- hide link metrics button when delta mode is enabled
- Replace icons for link metric button

