### PR TITLE
Fix/Adjust changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add a new button that links the height metric to the color metric so that the colour metric is automatically set to
-    the selected height metric [#3058](https://github.com/MaibornWolff/codecharta/pull/3058)
-    , [#3086](https://github.com/MaibornWolff/codecharta/pull/3086) <br/>
+    the selected height metric [#3058](https://github.com/MaibornWolff/codecharta/pull/3058) <br/>
     ![image](https://user-images.githubusercontent.com/72517530/193291144-fdc73a15-2087-47e2-845b-05c666aec71d.png) <br/>
     ![image](https://user-images.githubusercontent.com/72517530/194300920-60ce9fcd-0dd5-46ef-a90b-01d9a29205e6.png)
 


### PR DESCRIPTION
# Adjust changelog entry for feature 'Link Color to Height Metric'

## Description

Remove additional PR link (#3086) from the changelog entry. It might be confusing for the user why there is a fix for a feature that has not yet been released.

