### PR TITLE
Fix links to GitHub pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix broken links on new GitHub Page 'Docker Containers' [#3089](https://github.com/MaibornWolff/codecharta/pull/3089)
+
 ## [1.109.0] - 2022-10-12
 
 ### Added 🚀

--- a/gh-pages/_docs/05-06-docker-containers.md
+++ b/gh-pages/_docs/05-06-docker-containers.md
@@ -30,19 +30,19 @@ Open `localhost:9000` in your browser and log in with
 -   password: admin
 
 Simply follow the steps for a manual, local project under Linux. You can also [check our tutorial for SonarQube](
-{{site.baseurl}}{% link _docs/analyze-with-sonarqube.md %})
+{{site.baseurl}}{% link _docs/05-05-analyze-with-sonarqube.md %})
 The sonar-scanner is already pre-installed in our analysis container.
 
 ### codecharta-visualization
 
-See also [CodeCharta Visualization]({{site.baseurl}}{% link _docs/visualization.md %})
+See also [CodeCharta Visualization]({{site.baseurl}}{% link _docs/06-01-visualization.md %})
 
-Open `localhost:9001` in your browser and open any file you want from your hard drive.
-To open files you have created in the analysis container, copy them over using `docker cp`
+Open `localhost:9001` in your browser and open any file you want from your hard drive. To open files you have created in
+the analysis container, copy them over using `docker cp`
 
 ### codecharta-analysis
 
-See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/analysis.md %})
+See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/05-01-analysis.md %})
 
 Almost all tools the ccsh can import data from are included in the container, so you can get started immediately.
 Installed are:


### PR DESCRIPTION
# Fix broken GitHub Links

## Description

Some links on the new GitHub page 'Docker Containers' were not set correctly. This PR fixes that.



