### PR TITLE
Add font-family to global style sheet

### DIFF
--- a/visualization/app/app.scss
+++ b/visualization/app/app.scss
@@ -18,6 +18,7 @@ html,
 body {
 	overflow-y: hidden;
 	overflow-x: hidden;
+	font-family: Roboto, "Helvetica Neue", sans-serif;
 
 	@include prefix(
 		(


### PR DESCRIPTION
# Add font family to global style sheet

## Description

- Due to the final migration we have lost our font family
- Now the font family `Roboto, "Helvetica Neue", sans-serif` is set in the global style sheet
