### PR TITLE
Bug/3122/focusing on building with size zero crashes the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix crashing on focusing or hovering un-rendered buildings [#3123](https://github.com/MaibornWolff/codecharta/pull/3123)
+
 ## [1.110.0] - 2022-11-04
 
 ### Changed

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
@@ -127,13 +127,24 @@ describe("CodeMapArrowService", () => {
 			codeMapArrowService.addEdgePreview = jest.fn()
 			threeSceneService.clearHighlight = jest.fn()
 			codeMapArrowService["buildPairingEdges"] = jest.fn()
+			codeMapArrowService.scale = jest.fn()
 		})
+
 		it("should call clearArrows and showEdgesOfBuildings through BuildingSelected", () => {
 			codeMapArrowService.onBuildingSelected({ building: CODE_MAP_BUILDING })
 
 			expect(codeMapArrowService.clearArrows).toHaveBeenCalled()
 			expect(codeMapArrowService["showEdgesOfBuildings"]).toHaveBeenCalled()
 			expect(codeMapArrowService.addEdgePreview).toHaveBeenCalledTimes(0)
+		})
+
+		it("should not call sub-methods through BuildingSelected if building is undefined", () => {
+			codeMapArrowService.onBuildingSelected({ building: undefined })
+
+			expect(codeMapArrowService.clearArrows).not.toHaveBeenCalled()
+			expect(codeMapArrowService["showEdgesOfBuildings"]).not.toHaveBeenCalled()
+			expect(codeMapArrowService.addEdgePreview).not.toHaveBeenCalled()
+			expect(codeMapArrowService.scale).toHaveBeenCalled()
 		})
 
 		it("should call clearArrows and showEdgesOfBuildings through BuildingHovered", async () => {

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
@@ -131,7 +131,7 @@ export class CodeMapArrowService {
 	}
 
 	private isEdgeApplicableForBuilding(codeMapBuilding: CodeMapBuilding) {
-		return this.state.getValue().appSettings.isEdgeMetricVisible && !codeMapBuilding.node.flat
+		return this.state.getValue().appSettings.isEdgeMetricVisible && codeMapBuilding && !codeMapBuilding.node.flat
 	}
 
 	private showEdgesOfBuildings(hoveredbuilding?: CodeMapBuilding) {

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
@@ -119,7 +119,7 @@ export class CodeMapMesh {
 	}
 
 	private initDeltaColorsOnMesh(state: State) {
-		if (this.mapGeomDesc.buildings[0].node.deltas) {
+		if (this.mapGeomDesc.buildings[0]?.node.deltas) {
 			for (const building of this.mapGeomDesc.buildings) {
 				this.setNewDeltaColor(building, state)
 				this.setVertexColor(building.id, building.getColorVector(), building.getDeltaColorVector())


### PR DESCRIPTION
# Focusing or hovering an un-rendered building results in a crash

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #3122 

## Description

**Descriptive pull request text**, answering:

Currently focusing an un-rendered building, e.g. one that has an area metric of 0 or is missing due to margins crashes the app and prevents further input.

I decided to ignore the input in such cases to keep it consistent with the behavior for flatten, highlight, and exclude.
In the future all those options should be disabled by default, see feature #3113 

Furthermore after the latest change hovering any building with area 0 leads to console error as we attempt to draw an edge, this was also addressed in this PR.
