### PR TITLE
Fix/Adjust regex pattern for changelog dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix crashing on focusing or hovering un-rendered buildings [#3123](https://github.com/MaibornWolff/codecharta/pull/3123)
+-   Fix showing changelog entries in the dialog when a new version is available [#3123](https://github.com/MaibornWolff/codecharta/pull/3129)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/dialogs/changelogDialog/changelogDialog.component.ts
+++ b/visualization/app/codeCharta/ui/dialogs/changelogDialog/changelogDialog.component.ts
@@ -13,7 +13,6 @@ export class ChangelogDialogComponent {
 		let changelogLines = markdownFile.split("\n")
 		const currentVersionFirstLine = this.findVersionLine(changelogLines, this.data.currentVersion)
 		const lastOpenedVersionFirstLine = this.findVersionLine(changelogLines, this.data.previousVersion)
-
 		//Add 1 to keep the version line so that it detects the end of the last set of changes
 		changelogLines = changelogLines.slice(currentVersionFirstLine, lastOpenedVersionFirstLine + 1)
 		const titles = ["Added 🚀", "Fixed 🐞", "Changed", "Removed 🗑", "Chore 👨‍💻 👩‍💻"]
@@ -47,7 +46,7 @@ export class ChangelogDialogComponent {
 	}
 
 	private findVersionLine(lines: string[], version: string): number {
-		const versionPattern = new RegExp(version.replace(".", "\\."))
+		const versionPattern = new RegExp(`\\[${version}]`)
 		return lines.findIndex(element => versionPattern.test(element))
 	}
 


### PR DESCRIPTION
# Fix showing changelog entries when new version is available


## Description

- The previous regex pattern was not properly formulated, it also found version entries that did not initiate a new release update
- now the version is found only if it is enclosed in square brackets, e.g. `[1.110.0]`

