### PR TITLE
Bug/3124/Map Tree View Node Context Can Be Opened Multiple Times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix Node Context-Menu in Map Tree View opening multiple times [#3135](https://github.com/MaibornWolff/codecharta/pull/3135)
+
 ## [1.111.0] - 2022-11-11
 
 ### Added 🚀

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -72,7 +72,26 @@ describe("nodeContextMenuService", () => {
 		document.addEventListener("contextmenu", event => {
 			wasDefaultContextMenuPrevented = event.defaultPrevented
 		})
-		fireEvent.contextMenu(nodeContextMenu["overlayReference"].overlayElement)
+		fireEvent.contextMenu(nodeContextMenu["Reference"].Element)
 		expect(wasDefaultContextMenuPrevented).toBe(true)
+	})
+
+	it("should not dispose with only one opened panel", () => {
+		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
+		nodeContextMenu.open(10, 10)
+
+		const disposeSpy = jest.spyOn(nodeContextMenu["overlayReference"], "dispose")
+
+		expect(disposeSpy).not.toHaveBeenCalled()
+	})
+
+	it("should not open multiple times when open is clicked twice, disposing previous reference", () => {
+		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
+		nodeContextMenu.open(10, 10)
+		nodeContextMenu.open(10, 11)
+
+		const disposeSpy = jest.spyOn(nodeContextMenu["overlayReference"], "dispose")
+
+		expect(disposeSpy).toHaveBeenCalled()
 	})
 })

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -80,7 +80,7 @@ describe("nodeContextMenuService", () => {
 		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
 		nodeContextMenu.open(10, 10)
 
-		const resetSpy = jest.spyOn(nodeContextMenu as any, "resetOverlay")
+		const resetSpy = jest.spyOn(nodeContextMenu, "resetOverlay")
 
 		expect(resetSpy).not.toHaveBeenCalled()
 	})
@@ -88,9 +88,12 @@ describe("nodeContextMenuService", () => {
 	it("should not open multiple times when open is clicked twice, disposing previous reference", () => {
 		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
 		nodeContextMenu.open(10, 10)
+
+		expect(nodeContextMenu["overlayReference"]).not.toBe(null)
+
 		nodeContextMenu.open(10, 11)
 
-		const resetSpy = jest.spyOn(nodeContextMenu as any, "resetOverlay")
+		const resetSpy = jest.spyOn(nodeContextMenu, "resetOverlay")
 
 		expect(resetSpy).toHaveBeenCalled()
 	})

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -1,3 +1,4 @@
+import { OverlayRef } from "@angular/cdk/overlay"
 import { ApplicationInitStatus } from "@angular/core"
 import { TestBed } from "@angular/core/testing"
 import { fireEvent } from "@testing-library/angular"
@@ -16,7 +17,7 @@ describe("nodeContextMenuService", () => {
 		jest.spyOn(document, "getElementById").mockImplementation(() => mockedWheelTargetElement)
 
 		TestBed.configureTestingModule({
-			imports: [MaterialModule, EffectsModule.forRoot([OpenNodeContextMenuEffect]), NodeContextMenuCardModule],
+			imports: [MaterialModule, EffectsModule.forRoot([OpenNodeContextMenuEffect]), NodeContextMenuCardModule, OverlayRef],
 			providers: [NodeContextMenuService]
 		})
 		await TestBed.inject(ApplicationInitStatus).donePromise
@@ -72,7 +73,7 @@ describe("nodeContextMenuService", () => {
 		document.addEventListener("contextmenu", event => {
 			wasDefaultContextMenuPrevented = event.defaultPrevented
 		})
-		fireEvent.contextMenu(nodeContextMenu["Reference"].Element)
+		fireEvent.contextMenu(nodeContextMenu["overlayReference"].overlayElement)
 		expect(wasDefaultContextMenuPrevented).toBe(true)
 	})
 

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -78,9 +78,9 @@ describe("nodeContextMenuService", () => {
 
 	it("should not dispose with only one opened panel", () => {
 		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
-		nodeContextMenu.open(10, 10)
-
 		const resetSpy = jest.spyOn(nodeContextMenu, "resetOverlay")
+
+		nodeContextMenu.open(10, 10)
 
 		expect(resetSpy).not.toHaveBeenCalled()
 	})

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -91,9 +91,9 @@ describe("nodeContextMenuService", () => {
 
 		expect(nodeContextMenu["overlayReference"]).not.toBe(null)
 
-		nodeContextMenu.open(10, 11)
-
 		const resetSpy = jest.spyOn(nodeContextMenu, "resetOverlay")
+
+		nodeContextMenu.open(10, 11)
 
 		expect(resetSpy).toHaveBeenCalled()
 	})

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.spec.ts
@@ -1,4 +1,3 @@
-import { OverlayRef } from "@angular/cdk/overlay"
 import { ApplicationInitStatus } from "@angular/core"
 import { TestBed } from "@angular/core/testing"
 import { fireEvent } from "@testing-library/angular"
@@ -17,7 +16,7 @@ describe("nodeContextMenuService", () => {
 		jest.spyOn(document, "getElementById").mockImplementation(() => mockedWheelTargetElement)
 
 		TestBed.configureTestingModule({
-			imports: [MaterialModule, EffectsModule.forRoot([OpenNodeContextMenuEffect]), NodeContextMenuCardModule, OverlayRef],
+			imports: [MaterialModule, EffectsModule.forRoot([OpenNodeContextMenuEffect]), NodeContextMenuCardModule],
 			providers: [NodeContextMenuService]
 		})
 		await TestBed.inject(ApplicationInitStatus).donePromise
@@ -81,9 +80,9 @@ describe("nodeContextMenuService", () => {
 		const nodeContextMenu = TestBed.inject(NodeContextMenuService)
 		nodeContextMenu.open(10, 10)
 
-		const disposeSpy = jest.spyOn(nodeContextMenu["overlayReference"], "dispose")
+		const resetSpy = jest.spyOn(nodeContextMenu as any, "resetOverlay")
 
-		expect(disposeSpy).not.toHaveBeenCalled()
+		expect(resetSpy).not.toHaveBeenCalled()
 	})
 
 	it("should not open multiple times when open is clicked twice, disposing previous reference", () => {
@@ -91,8 +90,8 @@ describe("nodeContextMenuService", () => {
 		nodeContextMenu.open(10, 10)
 		nodeContextMenu.open(10, 11)
 
-		const disposeSpy = jest.spyOn(nodeContextMenu["overlayReference"], "dispose")
+		const resetSpy = jest.spyOn(nodeContextMenu as any, "resetOverlay")
 
-		expect(disposeSpy).toHaveBeenCalled()
+		expect(resetSpy).toHaveBeenCalled()
 	})
 })

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
@@ -72,7 +72,7 @@ export class NodeContextMenuService {
 		this.close()
 	}
 
-	private resetOverlay() {
+	resetOverlay() {
 		this.overlayReference.dispose()
 		this.overlayReference = null
 	}

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
@@ -12,6 +12,11 @@ export class NodeContextMenuService {
 	constructor(@Inject(Overlay) private overlay: Overlay, @Inject(Store) private store: Store) {}
 
 	open(x: number, y: number) {
+		if (this.overlayReference) {
+			this.overlayReference.dispose()
+			this.overlayReference = null
+		}
+
 		const positionStrategy = this.overlay
 			.position()
 			.flexibleConnectedTo({ x, y })

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/nodeContextMenu.service.ts
@@ -13,8 +13,7 @@ export class NodeContextMenuService {
 
 	open(x: number, y: number) {
 		if (this.overlayReference) {
-			this.overlayReference.dispose()
-			this.overlayReference = null
+			this.resetOverlay()
 		}
 
 		const positionStrategy = this.overlay
@@ -53,8 +52,7 @@ export class NodeContextMenuService {
 		this.store.dispatch(setRightClickedNodeData(null))
 
 		if (this.overlayReference) {
-			this.overlayReference.dispose()
-			this.overlayReference = null
+			this.resetOverlay()
 		}
 	}
 
@@ -72,6 +70,11 @@ export class NodeContextMenuService {
 		}
 		// Close on right click down, to close before the map gets potential moved by right clicked
 		this.close()
+	}
+
+	private resetOverlay() {
+		this.overlayReference.dispose()
+		this.overlayReference = null
 	}
 
 	private isEventFromColorPicker(mouseEvent: MouseEvent) {


### PR DESCRIPTION
# Fixes multiple instance of tree view node context when pressing the button without closing

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

closes: #3124 

## Description

Fixes the issue with the node context opening multiple times, and becoming unable to be closed, when the user presses the corresponding button again without closing the menu beforehand.
