### PR TITLE
refactor: remove redundant puppeteer types

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -64,7 +64,6 @@
 				"@types/jest-environment-puppeteer": "^5.0.3",
 				"@types/lodash": "^4.14.168",
 				"@types/node": "^18.0.0",
-				"@types/puppeteer": "^7.0.4",
 				"@types/three": "^0.126.0",
 				"@typescript-eslint/eslint-plugin": "^5.44.0",
 				"@typescript-eslint/parser": "^5.44.0",
@@ -3596,16 +3595,6 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
 			"integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
 			"dev": true
-		},
-		"node_modules/@types/puppeteer": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-7.0.4.tgz",
-			"integrity": "sha512-ja78vquZc8y+GM2al07GZqWDKQskQXygCDiu0e3uO0DMRKqE0MjrFBFmTulfPYzLB6WnL7Kl2tFPy0WXSpPomg==",
-			"deprecated": "This is a stub types definition. puppeteer provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"puppeteer": "*"
-			}
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -27603,15 +27592,6 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
 			"integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
 			"dev": true
-		},
-		"@types/puppeteer": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-7.0.4.tgz",
-			"integrity": "sha512-ja78vquZc8y+GM2al07GZqWDKQskQXygCDiu0e3uO0DMRKqE0MjrFBFmTulfPYzLB6WnL7Kl2tFPy0WXSpPomg==",
-			"dev": true,
-			"requires": {
-				"puppeteer": "*"
-			}
 		},
 		"@types/qs": {
 			"version": "6.9.7",

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -118,7 +118,6 @@
 		"@types/jest": "^26.0.22",
 		"@types/jest-environment-puppeteer": "^5.0.3",
 		"@types/lodash": "^4.14.168",
-		"@types/puppeteer": "^7.0.4",
 		"@types/node": "^18.0.0",
 		"@types/three": "^0.126.0",
 		"@typescript-eslint/eslint-plugin": "^5.44.0",


### PR DESCRIPTION
since puppeteer brings its own types by now

see https://www.npmjs.com/package/puppeteer/v/17.0.0 or `npm ci` installation log
> npm WARN deprecated @types/puppeteer@7.0.4: This is a stub types definition. puppeteer provides its own type definitions, so you do not need this installed.
