### PR TITLE
refactor: use correct brackets

### DIFF
--- a/visualization/app/codeCharta/ui/searchPanel/mapTreeView/mapTreeViewItemName/mapTreeViewItemName.component.html
+++ b/visualization/app/codeCharta/ui/searchPanel/mapTreeView/mapTreeViewItemName/mapTreeViewItemName.component.html
@@ -1,7 +1,7 @@
 <span
 	class="node-name"
 	[class.flattened]="node.isFlattened"
-	[class.noAreaMetric]="!node.attributes[areaMetric$ | async] > 0"
+	[class.noAreaMetric]="!(node.attributes[areaMetric$ | async] > 0)"
 	[class.angular-green]="(searchedNodePaths$ | async).has(node.path)"
 >
 	{{ node.name }}

--- a/visualization/app/codeCharta/ui/searchPanel/mapTreeView/mapTreeViewItemName/mapTreeViewItemName.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/mapTreeView/mapTreeViewItemName/mapTreeViewItemName.component.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from "@angular/core/testing"
+import { render } from "@testing-library/angular"
+import { CodeMapNode } from "../../../../codeCharta.model"
+import { MapTreeViewModule } from "../mapTreeView.module"
+import { MapTreeViewItemNameComponent } from "./mapTreeViewItemName.component"
+
+jest.mock("../../../../state/store/dynamicSettings/areaMetric/areaMetric.selector", () => ({
+	areaMetricSelector: () => "rloc"
+}))
+
+describe("mapTreeViewItemNameComponent", () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [MapTreeViewModule]
+		})
+	})
+
+	it("shouldn't have class 'noAreaMetric' when node's area metric is bigger than 0", async () => {
+		const { container } = await render(MapTreeViewItemNameComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: {
+				node: { attributes: { rloc: 2 } } as unknown as CodeMapNode
+			}
+		})
+
+		const nodeNameWrapper = container.querySelector(".node-name")
+		expect(nodeNameWrapper.classList).not.toContain("noAreaMetric")
+	})
+
+	it("should have class 'noAreaMetric' when node's area metric is 0", async () => {
+		const { container } = await render(MapTreeViewItemNameComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: {
+				node: { attributes: { rloc: 0 } } as unknown as CodeMapNode
+			}
+		})
+
+		const nodeNameWrapper = container.querySelector(".node-name")
+		expect(nodeNameWrapper.classList).toContain("noAreaMetric")
+	})
+
+	it("should have class 'noAreaMetric' when node's area metric doesn't exist", async () => {
+		const { container } = await render(MapTreeViewItemNameComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: {
+				node: { attributes: {} } as unknown as CodeMapNode
+			}
+		})
+
+		const nodeNameWrapper = container.querySelector(".node-name")
+		expect(nodeNameWrapper.classList).toContain("noAreaMetric")
+	})
+})


### PR DESCRIPTION
which surprisingly doesn't change evaluation due to JS type conversion. But strict template checking of angular build tools would complain, as e.g. `false > 0` is not allowed

ref #3116
