### PR TITLE
refactor: use string union instead of enum for blacklist type to impr…

### DIFF
--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -237,10 +237,7 @@ export interface BlacklistItem {
 	nodeType?: NodeType
 }
 
-export enum BlacklistType {
-	flatten = "flatten",
-	exclude = "exclude"
-}
+export type BlacklistType = "flatten" | "exclude"
 
 export interface MarkedPackage {
 	path: string

--- a/visualization/app/codeCharta/services/loadFile/loadFile.service.spec.ts
+++ b/visualization/app/codeCharta/services/loadFile/loadFile.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from "@angular/core/testing"
 import { LoadFileService } from "./loadFile.service"
 import { TEST_FILE_CONTENT } from "../../util/dataMocks"
-import { BlacklistType, CCFile, NodeMetricData, NodeType } from "../../codeCharta.model"
+import { CCFile, NodeMetricData, NodeType } from "../../codeCharta.model"
 import { removeFile, setDeltaReference, setFiles, setStandard } from "../../state/store/files/files.actions"
 import { ExportBlacklistType, ExportCCFile } from "../../codeCharta.api.model"
 import { getCCFiles, isPartialState } from "../../model/files/files.helper"
@@ -314,7 +314,7 @@ describe("loadFileService", () => {
 				}
 			])
 
-			const blacklist = [{ path: "foo", type: BlacklistType.flatten }]
+			const blacklist = [{ path: "foo", type: "flatten" }]
 			expect(getCCFiles(state.getValue().files)[0].settings.fileSettings.blacklist).toEqual(blacklist)
 		})
 

--- a/visualization/app/codeCharta/state/effects/addBlacklistItemsIfNotResultsInEmptyMap/addBlacklistItemsIfNotResultsInEmptyMap.effect.spec.ts
+++ b/visualization/app/codeCharta/state/effects/addBlacklistItemsIfNotResultsInEmptyMap/addBlacklistItemsIfNotResultsInEmptyMap.effect.spec.ts
@@ -3,7 +3,6 @@ import { TestBed } from "@angular/core/testing"
 import { MatDialog } from "@angular/material/dialog"
 import { Action } from "redux"
 import { Subject } from "rxjs"
-import { BlacklistType } from "../../../codeCharta.model"
 import { FILE_STATES_JAVA } from "../../../util/dataMocks"
 
 import { EffectsModule } from "../../angular-redux/effects/effects.module"
@@ -40,21 +39,17 @@ describe("AddBlacklistItemsIfNotResultsInEmptyMapEffect", () => {
 	})
 
 	it("should not blacklist items if it would lead to an empty map but show error dialog", () => {
-		EffectsModule.actions$.next(addBlacklistItemsIfNotResultsInEmptyMap([{ type: BlacklistType.exclude, path: "foo/bar" }]))
-		expect(storeDispatchSpy).not.toHaveBeenCalledWith(addBlacklistItems([{ type: BlacklistType.exclude, path: "foo/bar" }]))
+		EffectsModule.actions$.next(addBlacklistItemsIfNotResultsInEmptyMap([{ type: "exclude", path: "foo/bar" }]))
+		expect(storeDispatchSpy).not.toHaveBeenCalledWith(addBlacklistItems([{ type: "exclude", path: "foo/bar" }]))
 		expect(mockedDialog.open).toHaveBeenCalledTimes(1)
 	})
 
 	it("should blacklist items if it doesn't lead to an empty map", () => {
 		Store.dispatch(setFiles(FILE_STATES_JAVA))
 
-		EffectsModule.actions$.next(
-			addBlacklistItemsIfNotResultsInEmptyMap([{ type: BlacklistType.exclude, path: "/root/src/main/file1.java" }])
-		)
+		EffectsModule.actions$.next(addBlacklistItemsIfNotResultsInEmptyMap([{ type: "exclude", path: "/root/src/main/file1.java" }]))
 
-		expect(storeDispatchSpy).toHaveBeenCalledWith(
-			addBlacklistItems([{ type: BlacklistType.exclude, path: "/root/src/main/file1.java" }])
-		)
+		expect(storeDispatchSpy).toHaveBeenCalledWith(addBlacklistItems([{ type: "exclude", path: "/root/src/main/file1.java" }]))
 		expect(mockedDialog.open).not.toHaveBeenCalled()
 	})
 })

--- a/visualization/app/codeCharta/state/effects/addBlacklistItemsIfNotResultsInEmptyMap/resultsInEmptyMap.ts
+++ b/visualization/app/codeCharta/state/effects/addBlacklistItemsIfNotResultsInEmptyMap/resultsInEmptyMap.ts
@@ -1,5 +1,5 @@
 import { hierarchy, HierarchyNode } from "d3-hierarchy"
-import { BlacklistItem, BlacklistType, CCFile, CodeMapNode } from "../../../codeCharta.model"
+import { BlacklistItem, CCFile, CodeMapNode } from "../../../codeCharta.model"
 import { FileState } from "../../../model/files/files"
 import { isLeaf, isPathBlacklisted } from "../../../util/codeMapHelper"
 
@@ -27,4 +27,4 @@ const resultsInEmptyFile = (file: CCFile, blacklist: BlacklistItem[]) => {
 }
 
 const isNodeIncluded = (node: HierarchyNode<CodeMapNode>, blacklist: Array<BlacklistItem>) =>
-	isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, BlacklistType.exclude)
+	isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, "exclude")

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/excludeButton/excludeButton.component.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/excludeButton/excludeButton.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input } from "@angular/core"
-import { BlacklistType, CodeMapNode } from "../../../../codeCharta.model"
+import { CodeMapNode } from "../../../../codeCharta.model"
 import { Store } from "../../../angular-redux/store"
 import { addBlacklistItemsIfNotResultsInEmptyMap } from "../../../store/fileSettings/blacklist/blacklist.actions"
 
@@ -17,7 +17,7 @@ export class ExcludeButtonComponent {
 			addBlacklistItemsIfNotResultsInEmptyMap([
 				{
 					path: this.codeMapNode.path,
-					type: BlacklistType.exclude,
+					type: "exclude",
 					nodeType: this.codeMapNode.type
 				}
 			])

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/flattenButtons/flattenButtons.component.spec.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/flattenButtons/flattenButtons.component.spec.ts
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/angular"
 import { TestBed } from "@angular/core/testing"
 import { FlattenButtonsComponent } from "./flattenButtons.component"
 import { FlattenButtonsModule } from "./flattenButtons.module"
-import { BlacklistType, NodeType } from "../../../../codeCharta.model"
+import { NodeType } from "../../../../codeCharta.model"
 import userEvent from "@testing-library/user-event"
 import { Store } from "../../../store/store"
 
@@ -27,7 +27,7 @@ describe("flattenButtonsComponent", () => {
 		expect(Store.store.getState().fileSettings.blacklist).toContainEqual({
 			nodeType: NodeType.FILE,
 			path: "/root/foo.ts",
-			type: BlacklistType.flatten
+			type: "flatten"
 		})
 	})
 
@@ -35,7 +35,7 @@ describe("flattenButtonsComponent", () => {
 		Store.store.getState().fileSettings.blacklist.push({
 			nodeType: NodeType.FILE,
 			path: "/root/foo.ts",
-			type: BlacklistType.flatten
+			type: "flatten"
 		})
 		await render(FlattenButtonsComponent, {
 			excludeComponentDeclaration: true,
@@ -49,7 +49,7 @@ describe("flattenButtonsComponent", () => {
 		expect(Store.store.getState().fileSettings.blacklist).not.toContainEqual({
 			nodeType: NodeType.FILE,
 			path: "/root/foo.ts",
-			type: BlacklistType.flatten
+			type: "flatten"
 		})
 	})
 })

--- a/visualization/app/codeCharta/state/effects/nodeContextMenu/flattenButtons/flattenButtons.component.ts
+++ b/visualization/app/codeCharta/state/effects/nodeContextMenu/flattenButtons/flattenButtons.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input } from "@angular/core"
-import { BlacklistType, CodeMapNode } from "../../../../codeCharta.model"
+import { CodeMapNode } from "../../../../codeCharta.model"
 import { Store } from "../../../angular-redux/store"
 import { addBlacklistItem, removeBlacklistItem } from "../../../store/fileSettings/blacklist/blacklist.actions"
 
@@ -16,7 +16,7 @@ export class FlattenButtonsComponent {
 		this.store.dispatch(
 			addBlacklistItem({
 				path: this.codeMapNode.path,
-				type: BlacklistType.flatten,
+				type: "flatten",
 				nodeType: this.codeMapNode.type
 			})
 		)
@@ -26,7 +26,7 @@ export class FlattenButtonsComponent {
 		this.store.dispatch(
 			removeBlacklistItem({
 				path: this.codeMapNode.path,
-				type: BlacklistType.flatten,
+				type: "flatten",
 				nodeType: this.codeMapNode.type
 			})
 		)

--- a/visualization/app/codeCharta/state/effects/updateFileSettings/utils/blacklist.merger.spec.ts
+++ b/visualization/app/codeCharta/state/effects/updateFileSettings/utils/blacklist.merger.spec.ts
@@ -1,6 +1,6 @@
 import { getMergedBlacklist } from "./blacklist.merger"
 import { TEST_FILE_DATA } from "../../../../util/dataMocks"
-import { BlacklistItem, BlacklistType, CCFile } from "../../../../codeCharta.model"
+import { BlacklistItem, CCFile } from "../../../../codeCharta.model"
 import { clone } from "../../../../util/clone"
 
 describe("BlacklistMerger", () => {
@@ -16,11 +16,11 @@ describe("BlacklistMerger", () => {
 	})
 
 	describe("getMergedBlacklist", () => {
-		const blacklistItem1: BlacklistItem = { path: "/root/nodeA", type: BlacklistType.exclude }
-		const blacklistItem2: BlacklistItem = { path: "/another/nodeB", type: BlacklistType.flatten }
-		const blacklistItem3: BlacklistItem = { path: "/another/nodeC", type: BlacklistType.exclude }
-		const blacklistItem4: BlacklistItem = { path: "*prefix/nodeD", type: BlacklistType.flatten }
-		const blacklistItem1Duplicate: BlacklistItem = { path: "/root/nodeA", type: BlacklistType.exclude }
+		const blacklistItem1: BlacklistItem = { path: "/root/nodeA", type: "exclude" }
+		const blacklistItem2: BlacklistItem = { path: "/another/nodeB", type: "flatten" }
+		const blacklistItem3: BlacklistItem = { path: "/another/nodeC", type: "exclude" }
+		const blacklistItem4: BlacklistItem = { path: "*prefix/nodeD", type: "flatten" }
+		const blacklistItem1Duplicate: BlacklistItem = { path: "/root/nodeA", type: "exclude" }
 
 		it("should merge blacklist for different paths", () => {
 			file1.settings.fileSettings.blacklist = [blacklistItem1, blacklistItem2]

--- a/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/edgeMetricData.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/edgeMetricData.selector.ts
@@ -1,5 +1,5 @@
 import { hierarchy } from "d3-hierarchy"
-import { BlacklistItem, BlacklistType, Edge, EdgeMetricCount, EdgeMetricData } from "../../../../codeCharta.model"
+import { BlacklistItem, Edge, EdgeMetricCount, EdgeMetricData } from "../../../../codeCharta.model"
 import { FileState } from "../../../../model/files/files"
 import { isPathBlacklisted } from "../../../../util/codeMapHelper"
 import { createSelector } from "../../../angular-redux/createSelector"
@@ -52,10 +52,7 @@ export function calculateEdgeMetricData(visibleFileStates: FileState[], blacklis
 
 function bothNodesAssociatedAreVisible(edge: Edge, filePaths: Set<string>, blacklist: BlacklistItem[]) {
 	if (filePaths.has(edge.fromNodeName) && filePaths.has(edge.toNodeName)) {
-		return (
-			!isPathBlacklisted(edge.fromNodeName, blacklist, BlacklistType.exclude) &&
-			!isPathBlacklisted(edge.toNodeName, blacklist, BlacklistType.exclude)
-		)
+		return !isPathBlacklisted(edge.fromNodeName, blacklist, "exclude") && !isPathBlacklisted(edge.toNodeName, blacklist, "exclude")
 	}
 	return false
 }

--- a/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/nodeMetricData.selector.spec.ts
+++ b/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/nodeMetricData.selector.spec.ts
@@ -1,6 +1,5 @@
 import { TEST_DELTA_MAP_A, VALID_NODE_WITH_ROOT_UNARY } from "../../../../util/dataMocks"
 import { FileSelectionState, FileState } from "../../../../model/files/files"
-import { BlacklistType } from "../../../../codeCharta.model"
 import { NodeDecorator } from "../../../../util/nodeDecorator"
 import { clone } from "../../../../util/clone"
 import { calculateNodeMetricData, UNARY_METRIC } from "./nodeMetricData.selector"
@@ -38,7 +37,7 @@ describe("nodeMetricDataSelector", () => {
 			{ maxValue: 1, minValue: 1, name: UNARY_METRIC }
 		]
 
-		const result = calculateNodeMetricData([fileState], [{ path: "root/big leaf", type: BlacklistType.exclude }])
+		const result = calculateNodeMetricData([fileState], [{ path: "root/big leaf", type: "exclude" }])
 
 		expect(result).toEqual(expected)
 	})

--- a/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/nodeMetricData.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/accumulatedData/metricData/nodeMetricData.selector.ts
@@ -1,6 +1,6 @@
 import { hierarchy } from "d3-hierarchy"
 
-import { BlacklistItem, BlacklistType, NodeMetricData } from "../../../../codeCharta.model"
+import { BlacklistItem, NodeMetricData } from "../../../../codeCharta.model"
 import { FileState } from "../../../../model/files/files"
 import { isLeaf, isPathBlacklisted } from "../../../../util/codeMapHelper"
 import { createSelector } from "../../../angular-redux/createSelector"
@@ -20,7 +20,7 @@ export const calculateNodeMetricData = (visibleFileStates: FileState[], blacklis
 
 	for (const { file } of visibleFileStates) {
 		for (const node of hierarchy(file.map)) {
-			if (isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, BlacklistType.exclude)) {
+			if (isLeaf(node) && node.data.path && !isPathBlacklisted(node.data.path, blacklist, "exclude")) {
 				for (const metric of Object.keys(node.data.attributes)) {
 					const maxValue = metricMaxValues.get(metric)
 					const minValue = metricMinValues.get(metric)

--- a/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/fileSettings/blacklist/blacklist.reducer.spec.ts
@@ -1,9 +1,9 @@
 import { addBlacklistItem, BlacklistAction, setBlacklist, removeBlacklistItem, addBlacklistItems } from "./blacklist.actions"
 import { blacklist } from "./blacklist.reducer"
-import { BlacklistItem, BlacklistType } from "../../../../codeCharta.model"
+import { BlacklistItem } from "../../../../codeCharta.model"
 
 describe("blacklist", () => {
-	const item: BlacklistItem = { type: BlacklistType.flatten, path: "foo/bar" }
+	const item: BlacklistItem = { type: "flatten", path: "foo/bar" }
 
 	describe("Default State", () => {
 		it("should initialize the default state", () => {
@@ -23,17 +23,13 @@ describe("blacklist", () => {
 
 	describe("Action: ADD_BLACKLIST_ITEMS", () => {
 		it("should add all unique blacklist items to the blacklist", () => {
-			const existingItem: BlacklistItem = { type: BlacklistType.flatten, path: "foo/bar" }
+			const existingItem: BlacklistItem = { type: "flatten", path: "foo/bar" }
 			const result = blacklist(
 				[existingItem],
-				addBlacklistItems([
-					existingItem,
-					{ type: BlacklistType.flatten, path: "foo/bar2" },
-					{ type: BlacklistType.flatten, path: "foo/bar2" }
-				])
+				addBlacklistItems([existingItem, { type: "flatten", path: "foo/bar2" }, { type: "flatten", path: "foo/bar2" }])
 			)
 
-			expect(result).toEqual([existingItem, { type: BlacklistType.flatten, path: "foo/bar2" }])
+			expect(result).toEqual([existingItem, { type: "flatten", path: "foo/bar2" }])
 		})
 	})
 

--- a/visualization/app/codeCharta/state/store/state.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/state.reducer.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from "@angular/core/testing"
-import { AttributeTypeValue, BlacklistType, RecursivePartial, State } from "../../codeCharta.model"
+import { AttributeTypeValue, RecursivePartial, State } from "../../codeCharta.model"
 import rootReducer from "./state.reducer"
 import { defaultState, setState } from "./state.actions"
 import { expect } from "@jest/globals"
@@ -46,7 +46,7 @@ describe("rootReducer", () => {
 				blacklist: [
 					{
 						path: "excludedNode",
-						type: BlacklistType.exclude
+						type: "exclude"
 					}
 				]
 			}
@@ -58,7 +58,7 @@ describe("rootReducer", () => {
 		expect(newState.fileSettings.blacklist).toEqual([
 			{
 				path: "excludedNode",
-				type: BlacklistType.exclude
+				type: "exclude"
 			}
 		])
 	})

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -6,7 +6,7 @@ import { ThreeRendererService } from "./threeViewer/threeRenderer.service"
 import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 import { CodeMapBuilding } from "./rendering/codeMapBuilding"
 import { CODE_MAP_BUILDING, CONSTANT_HIGHLIGHT, TEST_FILE_WITH_PATHS, TEST_NODES } from "../../util/dataMocks"
-import { BlacklistType, CodeMapNode, Node } from "../../codeCharta.model"
+import { BlacklistItem, CodeMapNode, Node } from "../../codeCharta.model"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { klona } from "klona"
 import { CodeMapLabelService } from "./codeMap.label.service"
@@ -231,7 +231,7 @@ describe("codeMapMouseEventService", () => {
 
 	describe("onBlacklistChanged", () => {
 		it("should deselect the building when the selected building is excluded", () => {
-			const blacklist = [{ path: CODE_MAP_BUILDING.node.path, type: BlacklistType.exclude }]
+			const blacklist: BlacklistItem[] = [{ path: CODE_MAP_BUILDING.node.path, type: "exclude" }]
 
 			codeMapMouseEventService.onBlacklistChanged(blacklist)
 
@@ -239,7 +239,7 @@ describe("codeMapMouseEventService", () => {
 		})
 
 		it("should deselect the building when the selected building is hidden", () => {
-			const blacklist = [{ path: CODE_MAP_BUILDING.node.path, type: BlacklistType.flatten }]
+			const blacklist: BlacklistItem[] = [{ path: CODE_MAP_BUILDING.node.path, type: "flatten" }]
 
 			codeMapMouseEventService.onBlacklistChanged(blacklist)
 

--- a/visualization/app/codeCharta/ui/fileExtensionBar/selectors/fileExtensionCalculator.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/selectors/fileExtensionCalculator.spec.ts
@@ -1,5 +1,5 @@
 import { FileExtensionCalculator, MetricDistribution } from "./fileExtensionCalculator"
-import { BlacklistType, CodeMapNode, NodeType } from "../../../codeCharta.model"
+import { CodeMapNode, NodeType } from "../../../codeCharta.model"
 import { VALID_NODE_WITH_PATH_AND_EXTENSION, VALID_NODE_WITHOUT_RLOC_METRIC, setIsBlacklisted } from "../../../util/dataMocks"
 import { clone } from "../../../util/clone"
 
@@ -30,7 +30,7 @@ describe("FileExtensionCalculator", () => {
 		})
 
 		it("should get correct absolute distribution of file-extensions for given metric with hidden node", () => {
-			setIsBlacklisted([map.children[0].path], map, BlacklistType.flatten)
+			setIsBlacklisted([map.children[0].path], map, "flatten")
 
 			const expected: MetricDistribution[] = [
 				{ fileExtension: "java", absoluteMetricValue: 162, relativeMetricValue: 42.970_822_281_167_11, color: "hsl(58, 40%, 50%)" },
@@ -50,7 +50,7 @@ describe("FileExtensionCalculator", () => {
 		})
 
 		it("should get correct absolute distribution of file-extensions for given metric with excluded node", () => {
-			setIsBlacklisted([map.children[0].path], map, BlacklistType.exclude)
+			setIsBlacklisted([map.children[0].path], map, "exclude")
 
 			const expected: MetricDistribution[] = [
 				{ fileExtension: "java", absoluteMetricValue: 162, relativeMetricValue: 58.483_754_512_635_38, color: "hsl(58, 40%, 50%)" },
@@ -70,7 +70,7 @@ describe("FileExtensionCalculator", () => {
 		})
 
 		it("should get correct absolute distribution of file-extensions for given metric with excluded path", () => {
-			setIsBlacklisted(["/root/another big leaf.java", "/root/Parent Leaf/another leaf.java"], map, BlacklistType.exclude)
+			setIsBlacklisted(["/root/another big leaf.java", "/root/Parent Leaf/another leaf.java"], map, "exclude")
 
 			const expected: MetricDistribution[] = [
 				{ fileExtension: "jpg", absoluteMetricValue: 130, relativeMetricValue: 60.465_116_279_069_77, color: "hsl(321, 40%, 50%)" },

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.spec.ts
@@ -1,6 +1,6 @@
 import { calculate } from "./artificialIntelligence.selector"
 import { VALID_NODE_JAVA } from "../../../../util/dataMocks"
-import { BlacklistItem, BlacklistType, NodeType } from "../../../../codeCharta.model"
+import { BlacklistItem, NodeType } from "../../../../codeCharta.model"
 
 describe("ArtificialIntelligenceSelector", () => {
 	it("should return undefined when experimental features are disabled ", () => {
@@ -44,7 +44,7 @@ describe("ArtificialIntelligenceSelector", () => {
 	})
 
 	it("should ignore excluded nodes when experimental features are enabled", () => {
-		const blacklist: BlacklistItem[] = [{ path: "file1.java", type: BlacklistType.exclude }]
+		const blacklist: BlacklistItem[] = [{ path: "file1.java", type: "exclude" }]
 		const blacklistedNode = {
 			name: "file1.java",
 			path: "file1.java",

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.ts
@@ -14,7 +14,7 @@ import {
 	MetricValuesByLanguage
 } from "./util/suspiciousMetricsHelper"
 import { hierarchy } from "d3-hierarchy"
-import { BlacklistItem, BlacklistType, CodeMapNode, NodeType } from "../../../../codeCharta.model"
+import { BlacklistItem, CodeMapNode, NodeType } from "../../../../codeCharta.model"
 import { getMostFrequentLanguage } from "./util/mainProgrammingLanguageHelper"
 import { isPathBlacklisted } from "../../../../util/codeMapHelper"
 import { createSelector } from "../../../../state/angular-redux/createSelector"
@@ -55,7 +55,7 @@ export const calculate = (
 
 	for (const { data } of hierarchy(accumulatedData.unifiedMapNode)) {
 		const fileExtension = getFileExtension(data.name)
-		if (data.type === NodeType.FILE && fileExtension !== undefined && !isPathBlacklisted(data.path, blacklist, BlacklistType.exclude)) {
+		if (data.type === NodeType.FILE && fileExtension !== undefined && !isPathBlacklisted(data.path, blacklist, "exclude")) {
 			const filesPerLanguage = numberOfFilesByLanguage.get(fileExtension) ?? 0
 			numberOfFilesByLanguage.set(fileExtension, filesPerLanguage + 1)
 			setMetricValuesByLanguage(data, metricValuesByLanguage, fileExtension)

--- a/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/blacklistPanel.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/blacklistPanel.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from "@angular/core/testing"
 import { render, screen } from "@testing-library/angular"
 import userEvent from "@testing-library/user-event"
 import { MaterialModule } from "../../../../material/material.module"
-import { BlacklistType } from "../../../codeCharta.model"
 import { setBlacklist } from "../../../state/store/fileSettings/blacklist/blacklist.actions"
 import { Store } from "../../../state/store/store"
 import { BlacklistPanelComponent } from "./blacklistPanel.component"
@@ -25,8 +24,8 @@ describe("blacklistPanel", () => {
 	it("should display all flattened and excluded items in the correct section and remove an item on click", async () => {
 		Store.dispatch(
 			setBlacklist([
-				{ type: BlacklistType.flatten, path: "some/flattened/building.ts" },
-				{ type: BlacklistType.exclude, path: "some/excluded/building.ts" }
+				{ type: "flatten", path: "some/flattened/building.ts" },
+				{ type: "exclude", path: "some/excluded/building.ts" }
 			])
 		)
 		await render(BlacklistPanelComponent)
@@ -37,7 +36,7 @@ describe("blacklistPanel", () => {
 
 		await userEvent.click(screen.getByText("some/excluded/building.ts"))
 		expect(Store.store.getState().fileSettings.blacklist).not.toContainEqual({
-			type: BlacklistType.exclude,
+			type: "exclude",
 			path: "some/excluded/building.ts"
 		})
 	})

--- a/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/blacklistPanel.component.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/blacklistPanel.component.ts
@@ -1,6 +1,6 @@
 import "./blacklistPanel.component.scss"
 import { Component, Inject } from "@angular/core"
-import { BlacklistItem, BlacklistType } from "../../../codeCharta.model"
+import { BlacklistItem } from "../../../codeCharta.model"
 import { Store } from "../../../state/angular-redux/store"
 import { removeBlacklistItem } from "../../../state/store/fileSettings/blacklist/blacklist.actions"
 import { createBlacklistItemSelector } from "./createBlacklistItemSelector"
@@ -10,8 +10,8 @@ import { createBlacklistItemSelector } from "./createBlacklistItemSelector"
 	template: require("./blacklistPanel.component.html")
 })
 export class BlacklistPanelComponent {
-	flattenedItems$ = this.store.select(createBlacklistItemSelector(BlacklistType.flatten))
-	excludedItems$ = this.store.select(createBlacklistItemSelector(BlacklistType.exclude))
+	flattenedItems$ = this.store.select(createBlacklistItemSelector("flatten"))
+	excludedItems$ = this.store.select(createBlacklistItemSelector("exclude"))
 
 	constructor(@Inject(Store) private store: Store) {}
 

--- a/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/createBlacklistItemSelector.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/blacklistPanel/createBlacklistItemSelector.spec.ts
@@ -1,21 +1,21 @@
-import { BlacklistType } from "../../../codeCharta.model"
+import { BlacklistItem } from "../../../codeCharta.model"
 import { _getFilteredAndSortedItems } from "./createBlacklistItemSelector"
 
 describe("createBlacklistItemSelector _getItems", () => {
 	it("should filter by type", () => {
-		const blacklist = [
-			{ type: BlacklistType.exclude, path: "something.ts" },
-			{ type: BlacklistType.flatten, path: "something-else.ts" }
+		const blacklist: BlacklistItem[] = [
+			{ type: "exclude", path: "something.ts" },
+			{ type: "flatten", path: "something-else.ts" }
 		]
-		expect(_getFilteredAndSortedItems(BlacklistType.flatten, blacklist)).toEqual([blacklist[1]])
+		expect(_getFilteredAndSortedItems("flatten", blacklist)).toEqual([blacklist[1]])
 	})
 
 	it("should sort by path", () => {
-		const blacklist = [
-			{ type: BlacklistType.flatten, path: "something.ts" },
-			{ type: BlacklistType.flatten, path: "another-something.ts" },
-			{ type: BlacklistType.flatten, path: "really/something-else.ts" }
+		const blacklist: BlacklistItem[] = [
+			{ type: "flatten", path: "something.ts" },
+			{ type: "flatten", path: "another-something.ts" },
+			{ type: "flatten", path: "really/something-else.ts" }
 		]
-		expect(_getFilteredAndSortedItems(BlacklistType.flatten, blacklist)).toEqual([blacklist[1], blacklist[2], blacklist[0]])
+		expect(_getFilteredAndSortedItems("flatten", blacklist)).toEqual([blacklist[1], blacklist[2], blacklist[0]])
 	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/matchingFilesCounter/selectors/matchingFilesCounter.selector.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/matchingFilesCounter/selectors/matchingFilesCounter.selector.ts
@@ -21,13 +21,13 @@ export const matchingFilesCounterSelector: (state: CcState) => MatchingFilesCoun
 		const searchedNodeLeaves = searchedNodes.filter(node => isLeaf(node))
 		return {
 			fileCount: `${searchedNodeLeaves.length}/${allNodes.length}`,
-			flattenCount: `${getBlacklistedFileCount(BlacklistType.flatten, searchedNodeLeaves, blacklist)}/${getBlacklistedFileCount(
-				BlacklistType.flatten,
+			flattenCount: `${getBlacklistedFileCount("flatten", searchedNodeLeaves, blacklist)}/${getBlacklistedFileCount(
+				"flatten",
 				allNodes,
 				blacklist
 			)}`,
-			excludeCount: `${getBlacklistedFileCount(BlacklistType.exclude, searchedNodeLeaves, blacklist)}/${getBlacklistedFileCount(
-				BlacklistType.exclude,
+			excludeCount: `${getBlacklistedFileCount("exclude", searchedNodeLeaves, blacklist)}/${getBlacklistedFileCount(
+				"exclude",
 				allNodes,
 				blacklist
 			)}`

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/blacklistSearchPattern.effect.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/blacklistSearchPattern.effect.spec.ts
@@ -4,7 +4,6 @@ import { MatDialog } from "@angular/material/dialog"
 import { Action } from "redux"
 import { Subject } from "rxjs"
 import { mocked } from "ts-jest/utils"
-import { BlacklistType } from "../../../codeCharta.model"
 import { EffectsModule } from "../../../state/angular-redux/effects/effects.module"
 import { AddBlacklistItemsIfNotResultsInEmptyMapEffect } from "../../../state/effects/addBlacklistItemsIfNotResultsInEmptyMap/addBlacklistItemsIfNotResultsInEmptyMap.effect"
 import { resultsInEmptyMap } from "../../../state/effects/addBlacklistItemsIfNotResultsInEmptyMap/resultsInEmptyMap"
@@ -42,19 +41,19 @@ describe("BlacklistSearchPatternEffect", () => {
 		mockedResultsInEmptyMap.mockImplementation(() => false)
 		Store.dispatch(setSearchPattern("needle"))
 
-		EffectsModule.actions$.next(blacklistSearchPattern(BlacklistType.exclude))
+		EffectsModule.actions$.next(blacklistSearchPattern("exclude"))
 
 		expect(Store.store.getState().dynamicSettings.searchPattern).toBe("")
-		expect(Store.store.getState().fileSettings.blacklist).toEqual([{ type: BlacklistType.exclude, path: "*needle*" }])
+		expect(Store.store.getState().fileSettings.blacklist).toEqual([{ type: "exclude", path: "*needle*" }])
 	})
 
 	it("should not reset search pattern, when excluding from search bar failed and afterwards excluding within CodeCharta map", () => {
 		mockedResultsInEmptyMap.mockImplementation(() => true)
 		Store.dispatch(setSearchPattern("root"))
-		EffectsModule.actions$.next(blacklistSearchPattern(BlacklistType.exclude))
+		EffectsModule.actions$.next(blacklistSearchPattern("exclude"))
 
 		mockedResultsInEmptyMap.mockImplementation(() => false)
-		EffectsModule.actions$.next(addBlacklistItemsIfNotResultsInEmptyMap([{ type: BlacklistType.exclude, path: "*needle*" }]))
+		EffectsModule.actions$.next(addBlacklistItemsIfNotResultsInEmptyMap([{ type: "exclude", path: "*needle*" }]))
 
 		expect(Store.store.getState().dynamicSettings.searchPattern).toBe("root")
 	})

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/blacklistSearchPattern.effect.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/blacklistSearchPattern.effect.ts
@@ -44,7 +44,7 @@ export class BlacklistSearchPatternEffect {
 	flattenSearchPattern$ = createEffect(
 		() =>
 			this.searchPattern2BlacklistItems$.pipe(
-				filter(searchPattern2BlacklistItems => searchPattern2BlacklistItems.type === BlacklistType.flatten),
+				filter(searchPattern2BlacklistItems => searchPattern2BlacklistItems.type === "flatten"),
 				tap(searchPattern2BlacklistItems => {
 					this.store.dispatch(addBlacklistItems(searchPattern2BlacklistItems.blacklistItems))
 					this.store.dispatch(setSearchPattern())
@@ -55,7 +55,7 @@ export class BlacklistSearchPatternEffect {
 
 	excludeSearchPattern$ = createEffect(() =>
 		this.searchPattern2BlacklistItems$.pipe(
-			filter(searchPattern2BlacklistItems => searchPattern2BlacklistItems.type === BlacklistType.exclude),
+			filter(searchPattern2BlacklistItems => searchPattern2BlacklistItems.type === "exclude"),
 			tap(() => {
 				this.addBlacklistItemsIfNotResultsInEmptyMapEffect.doBlacklistItemsResultInEmptyMap$
 					.pipe(

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/searchBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/searchBar.component.spec.ts
@@ -6,7 +6,6 @@ import { SearchBarModule } from "./searchBar.module"
 import userEvent from "@testing-library/user-event"
 import { Store as PlainStore } from "../../../state/store/store"
 import { searchPatternSelector } from "../../../state/store/dynamicSettings/searchPattern/searchPattern.selector"
-import { BlacklistType } from "../../../codeCharta.model"
 import { EffectsModule } from "../../../state/angular-redux/effects/effects.module"
 import { AddBlacklistItemsIfNotResultsInEmptyMapEffect } from "../../../state/effects/addBlacklistItemsIfNotResultsInEmptyMap/addBlacklistItemsIfNotResultsInEmptyMap.effect"
 import { Subject } from "rxjs"
@@ -72,7 +71,7 @@ describe("cc-search-bar", () => {
 
 		searchField = screen.getByPlaceholderText("Search: *.js, **/app/*")
 		expect(searchField.value).toBe("")
-		expect(PlainStore.store.getState().fileSettings.blacklist[0]).toEqual({ type: BlacklistType.flatten, path: "*needle*" })
+		expect(PlainStore.store.getState().fileSettings.blacklist[0]).toEqual({ type: "flatten", path: "*needle*" })
 	})
 
 	it("should exclude pattern", async () => {
@@ -88,6 +87,6 @@ describe("cc-search-bar", () => {
 
 		searchField = screen.getByPlaceholderText("Search: *.js, **/app/*")
 		expect(searchField.value).toBe("")
-		expect(PlainStore.store.getState().fileSettings.blacklist[0]).toEqual({ type: BlacklistType.exclude, path: "*needle*" })
+		expect(PlainStore.store.getState().fileSettings.blacklist[0]).toEqual({ type: "exclude", path: "*needle*" })
 	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/selectors/isExcludePatternDisabled.selector.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/selectors/isExcludePatternDisabled.selector.ts
@@ -1,4 +1,3 @@
-import { BlacklistType } from "../../../../codeCharta.model"
 import { createSelector } from "../../../../state/angular-redux/createSelector"
 import { searchPatternSelector } from "../../../../state/store/dynamicSettings/searchPattern/searchPattern.selector"
 import { blacklistSelector } from "../../../../state/store/fileSettings/blacklist/blacklist.selector"
@@ -11,6 +10,6 @@ export const isExcludePatternDisabledSelector = createSelector(
 		if (isSearchPatternEmpty) {
 			return true
 		}
-		return isPatternBlacklisted(blacklist, BlacklistType.exclude, searchPattern)
+		return isPatternBlacklisted(blacklist, "exclude", searchPattern)
 	}
 )

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/selectors/isFlattenPatternDisabled.selector.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/selectors/isFlattenPatternDisabled.selector.ts
@@ -1,4 +1,3 @@
-import { BlacklistType } from "../../../../codeCharta.model"
 import { createSelector } from "../../../../state/angular-redux/createSelector"
 import { searchPatternSelector } from "../../../../state/store/dynamicSettings/searchPattern/searchPattern.selector"
 import { blacklistSelector } from "../../../../state/store/fileSettings/blacklist/blacklist.selector"
@@ -11,6 +10,6 @@ export const isFlattenPatternDisabledSelector = createSelector(
 		if (isSearchPatternEmpty) {
 			return true
 		}
-		return isPatternBlacklisted(blacklist, BlacklistType.flatten, searchPattern)
+		return isPatternBlacklisted(blacklist, "flatten", searchPattern)
 	}
 )

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/utils/isPatternBlacklisted.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/utils/isPatternBlacklisted.spec.ts
@@ -1,20 +1,19 @@
-import { BlacklistType } from "../../../../codeCharta.model"
 import { isPatternBlacklisted } from "./isPatternBlacklisted"
 
 describe("isPatternBlacklisted", () => {
 	it("should recognized an exact match", () => {
-		expect(isPatternBlacklisted([{ type: BlacklistType.flatten, path: "*needle*" }], BlacklistType.flatten, "*needle*")).toBe(true)
+		expect(isPatternBlacklisted([{ type: "flatten", path: "*needle*" }], "flatten", "*needle*")).toBe(true)
 	})
 
 	it("should recognized * matches", () => {
-		expect(isPatternBlacklisted([{ type: BlacklistType.flatten, path: "*needle*" }], BlacklistType.flatten, "needle")).toBe(true)
+		expect(isPatternBlacklisted([{ type: "flatten", path: "*needle*" }], "flatten", "needle")).toBe(true)
 	})
 
 	it("should not recognized * vs absolute value", () => {
-		expect(isPatternBlacklisted([{ type: BlacklistType.flatten, path: "*needle*" }], BlacklistType.flatten, "/needle")).toBe(false)
+		expect(isPatternBlacklisted([{ type: "flatten", path: "*needle*" }], "flatten", "/needle")).toBe(false)
 	})
 
 	it("should ignore different blacklist type", () => {
-		expect(isPatternBlacklisted([{ type: BlacklistType.flatten, path: "*needle*" }], BlacklistType.exclude, "*needle*")).toBe(false)
+		expect(isPatternBlacklisted([{ type: "flatten", path: "*needle*" }], "exclude", "*needle*")).toBe(false)
 	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/searchBar/utils/parseBlacklistItems.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchBar/utils/parseBlacklistItems.spec.ts
@@ -1,18 +1,17 @@
-import { BlacklistType } from "../../../../codeCharta.model"
 import { parseBlacklistItems } from "./parseBlacklistItems"
 
 describe("parseBlacklistItems", () => {
 	it("should parse multiple items", () => {
-		expect(parseBlacklistItems(BlacklistType.flatten, "html,ts")).toEqual([
-			{ type: BlacklistType.flatten, path: "*html*" },
-			{ type: BlacklistType.flatten, path: "*ts*" }
+		expect(parseBlacklistItems("flatten", "html,ts")).toEqual([
+			{ type: "flatten", path: "*html*" },
+			{ type: "flatten", path: "*ts*" }
 		])
 	})
 
 	it("should parse multiple negated items", () => {
-		expect(parseBlacklistItems(BlacklistType.flatten, "!html,ts")).toEqual([
-			{ type: BlacklistType.flatten, path: "!*html*" },
-			{ type: BlacklistType.flatten, path: "!*ts*" }
+		expect(parseBlacklistItems("flatten", "!html,ts")).toEqual([
+			{ type: "flatten", path: "!*html*" },
+			{ type: "flatten", path: "!*ts*" }
 		])
 	})
 })

--- a/visualization/app/codeCharta/ui/searchPanel/searchPanelModeSelector/searchPanelModeSelector.component.spec.ts
+++ b/visualization/app/codeCharta/ui/searchPanel/searchPanelModeSelector/searchPanelModeSelector.component.spec.ts
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/angular"
-import { BlacklistType } from "../../../codeCharta.model"
 import { addBlacklistItem } from "../../../state/store/fileSettings/blacklist/blacklist.actions"
 import { Store } from "../../../state/store/store"
 import { SearchPanelModeSelectorComponent } from "./searchPanelModeSelector.component"
@@ -12,7 +11,7 @@ describe("SearchPanelModeSelectorComponent", () => {
 	})
 
 	it("should show blacklist items indicator when there are blacklist items", async () => {
-		Store.dispatch(addBlacklistItem({ path: "something.ts", type: BlacklistType.exclude }))
+		Store.dispatch(addBlacklistItem({ path: "something.ts", type: "exclude" }))
 
 		const { container } = await render(SearchPanelModeSelectorComponent)
 		expect(container.querySelector(".has-blacklist-items-indicator")["hidden"]).toBe(false)

--- a/visualization/app/codeCharta/ui/toolBar/downloadButton/downloadDialog/downloadDialog.component.ts
+++ b/visualization/app/codeCharta/ui/toolBar/downloadButton/downloadDialog/downloadDialog.component.ts
@@ -5,7 +5,6 @@ import { FileDownloader } from "../../../../util/fileDownloader"
 import { accumulatedDataSelector } from "../../../../state/selectors/accumulatedData/accumulatedData.selector"
 import { FileNameHelper } from "../../../../util/fileNameHelper"
 import { isDeltaState } from "../../../../model/files/files.helper"
-import { BlacklistType } from "../../../../codeCharta.model"
 import {
 	DownloadableProperty,
 	getAmountOfAttributeTypes,
@@ -43,8 +42,8 @@ export class DownloadDialogComponent {
 			}),
 			this.getProperty(2, getDownloadableProperty("Edges", edges.length)),
 			this.getProperty(3, getDownloadableProperty("MarkedPackages", markedPackages.length)),
-			this.getProperty(4, getDownloadableProperty("Excludes", getFilteredBlacklistLength(blacklist, BlacklistType.exclude))),
-			this.getProperty(5, getDownloadableProperty("Flattens", getFilteredBlacklistLength(blacklist, BlacklistType.flatten)))
+			this.getProperty(4, getDownloadableProperty("Excludes", getFilteredBlacklistLength(blacklist, "exclude"))),
+			this.getProperty(5, getDownloadableProperty("Flattens", getFilteredBlacklistLength(blacklist, "flatten")))
 		]
 	}
 

--- a/visualization/app/codeCharta/ui/toolBar/downloadButton/downloadDialog/util/propertyHelper.spec.ts
+++ b/visualization/app/codeCharta/ui/toolBar/downloadButton/downloadDialog/util/propertyHelper.spec.ts
@@ -1,4 +1,4 @@
-import { AttributeTypeValue, BlacklistType } from "../../../../../codeCharta.model"
+import { AttributeTypeValue } from "../../../../../codeCharta.model"
 import { BLACKLIST } from "../../../../../util/dataMocks"
 import { getAmountOfAttributeTypes, getDownloadableProperty, getFilteredBlacklistLength } from "./propertyHelper"
 
@@ -51,11 +51,11 @@ describe("propertyHelper", () => {
 
 	describe("getFilteredBlacklistLength", () => {
 		it("should get length of flattened buildings", () => {
-			expect(getFilteredBlacklistLength(BLACKLIST, BlacklistType.flatten)).toBe(1)
+			expect(getFilteredBlacklistLength(BLACKLIST, "flatten")).toBe(1)
 		})
 
 		it("should get length of excluded buildings", () => {
-			expect(getFilteredBlacklistLength(BLACKLIST, BlacklistType.exclude)).toBe(2)
+			expect(getFilteredBlacklistLength(BLACKLIST, "exclude")).toBe(2)
 		})
 	})
 })

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
@@ -1,4 +1,4 @@
-import { CodeMapNode, Node, State, NodeMetricData, BlacklistType, LayoutAlgorithm } from "../../../codeCharta.model"
+import { CodeMapNode, Node, State, NodeMetricData, LayoutAlgorithm } from "../../../codeCharta.model"
 import BoundingBox from "./boundingBox"
 import VerticalStreet from "./verticalStreet"
 import HorizontalStreet from "./horizontalStreet"
@@ -46,7 +46,7 @@ export class StreetLayoutGenerator {
 		const children: BoundingBox[] = []
 		const areaMetric = state.dynamicSettings.areaMetric
 		for (let child of node.children) {
-			if (isPathBlacklisted(child.path, state.fileSettings.blacklist, BlacklistType.exclude)) {
+			if (isPathBlacklisted(child.path, state.fileSettings.blacklist, "exclude")) {
 				continue
 			}
 			if (isLeaf(child)) {

--- a/visualization/app/codeCharta/util/algorithm/treeMapLayout/treeMapHelper.spec.ts
+++ b/visualization/app/codeCharta/util/algorithm/treeMapLayout/treeMapHelper.spec.ts
@@ -1,5 +1,5 @@
 import { TreeMapHelper } from "./treeMapHelper"
-import { BlacklistType, CodeMapNode, ColorMode, EdgeVisibility, NodeType, State } from "../../../codeCharta.model"
+import { CodeMapNode, ColorMode, EdgeVisibility, NodeType, State } from "../../../codeCharta.model"
 import { CODE_MAP_BUILDING, STATE } from "../../dataMocks"
 import { HierarchyRectangularNode } from "d3-hierarchy"
 
@@ -204,7 +204,7 @@ describe("TreeMapHelper", () => {
 			})
 
 			it("should be flat if node is flattened in blacklist", () => {
-				state.fileSettings.blacklist = [{ path: "*Anode", type: BlacklistType.flatten }]
+				state.fileSettings.blacklist = [{ path: "*Anode", type: "flatten" }]
 				squaredNode.data.isFlattened = true
 
 				expect(buildNode().flat).toBeTruthy()
@@ -245,7 +245,7 @@ describe("TreeMapHelper", () => {
 				})
 
 				it("creates flat colored building", () => {
-					state.fileSettings.blacklist = [{ path: "*Anode", type: BlacklistType.flatten }]
+					state.fileSettings.blacklist = [{ path: "*Anode", type: "flatten" }]
 					squaredNode.data.isFlattened = true
 
 					expect(buildNode().color).toBe(state.appSettings.mapColors.flat)

--- a/visualization/app/codeCharta/util/codeMapHelper.ts
+++ b/visualization/app/codeCharta/util/codeMapHelper.ts
@@ -67,7 +67,7 @@ export function returnIgnore(gitignorePath: string) {
 }
 
 export function isPathHiddenOrExcluded(path: string, blacklist: Array<BlacklistItem>) {
-	return isPathBlacklisted(path, blacklist, BlacklistType.exclude) || isPathBlacklisted(path, blacklist, BlacklistType.flatten)
+	return isPathBlacklisted(path, blacklist, "exclude") || isPathBlacklisted(path, blacklist, "flatten")
 }
 
 export function isPathBlacklisted(path: string, blacklist: Array<BlacklistItem>, type: BlacklistType) {

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -2239,15 +2239,15 @@ export const CODE_MAP_BUILDING_WITH_INCOMING_EDGE_NODE: CodeMapBuilding = new Co
 export const BLACKLIST: BlacklistItem[] = [
 	{
 		path: "/my/path",
-		type: BlacklistType.flatten
+		type: "flatten"
 	},
 	{
 		path: "/my/different/path",
-		type: BlacklistType.exclude
+		type: "exclude"
 	},
 	{
 		path: "/my/first/path",
-		type: BlacklistType.exclude
+		type: "exclude"
 	}
 ]
 
@@ -2285,7 +2285,7 @@ export function setIsBlacklisted(paths: string[], map: CodeMapNode, type: Blackl
 }
 
 function setBlacklistFlagByType(node: CodeMapNode, type: BlacklistType, flag: boolean) {
-	if (type === BlacklistType.exclude) {
+	if (type === "exclude") {
 		node.isExcluded = flag
 	} else {
 		node.isFlattened = flag

--- a/visualization/app/codeCharta/util/fileDownloader.spec.ts
+++ b/visualization/app/codeCharta/util/fileDownloader.spec.ts
@@ -1,6 +1,6 @@
 import { stubDate } from "../../../mocks/dateMock.helper"
 import { DownloadableSetting, FileDownloader } from "./fileDownloader"
-import { BlacklistType, CodeMapNode, FileMeta, FileSettings } from "../codeCharta.model"
+import { CodeMapNode, FileMeta, FileSettings } from "../codeCharta.model"
 import {
 	TEST_ATTRIBUTE_DESCRIPTORS_HALF_FILLED,
 	TEST_ATTRIBUTE_TYPES,
@@ -28,8 +28,8 @@ describe("fileDownloader", () => {
 		filesettings.attributeTypes = TEST_ATTRIBUTE_TYPES
 		filesettings.attributeDescriptors = TEST_ATTRIBUTE_DESCRIPTORS_HALF_FILLED
 		filesettings.blacklist = [
-			{ path: "/root/bigLeaf.ts", type: BlacklistType.flatten },
-			{ path: "/root/sample1OnlyLeaf.scss", type: BlacklistType.exclude }
+			{ path: "/root/bigLeaf.ts", type: "flatten" },
+			{ path: "/root/sample1OnlyLeaf.scss", type: "exclude" }
 		]
 		fileName = "foo_2019-04-22_18-01"
 		fileNameWithExtension = "foo_2019-04-22_18-01.cc.json"

--- a/visualization/app/codeCharta/util/fileDownloader.ts
+++ b/visualization/app/codeCharta/util/fileDownloader.ts
@@ -56,14 +56,14 @@ export class FileDownloader {
 
 		if (downloadSettings.includes("Flattens")) {
 			mergedBlacklist.push(
-				...this.getFilteredBlacklist(blacklist, BlacklistType.flatten).map(x => {
+				...this.getFilteredBlacklist(blacklist, "flatten").map(x => {
 					return { path: x.path, type: "hide" }
 				})
 			)
 		}
 
 		if (downloadSettings.includes("Excludes")) {
-			mergedBlacklist.push(...this.getFilteredBlacklist(blacklist, BlacklistType.exclude))
+			mergedBlacklist.push(...this.getFilteredBlacklist(blacklist, "exclude"))
 		}
 		return mergedBlacklist
 	}

--- a/visualization/app/codeCharta/util/fileHelper.spec.ts
+++ b/visualization/app/codeCharta/util/fileHelper.spec.ts
@@ -1,5 +1,5 @@
 import { ExportBlacklistType, ExportCCFile } from "../codeCharta.api.model"
-import { AttributeTypeValue, BlacklistType, CCFile, NameDataPair } from "../codeCharta.model"
+import { AttributeTypeValue, CCFile, NameDataPair } from "../codeCharta.model"
 import { getCCFile, getCCFileAndDecorateFileChecksum, getSelectedFilesSize } from "./fileHelper"
 import { TEST_ATTRIBUTE_DESCRIPTORS_HALF_FILLED, TEST_FILE_CONTENT } from "./dataMocks"
 import { clone } from "./clone"
@@ -28,7 +28,7 @@ describe("FileHelper", () => {
 			const nameDataPair: NameDataPair = { content: fileContent, fileName: "fileName", fileSize: 30 }
 			const result = getCCFile(nameDataPair)
 
-			expect(result.settings.fileSettings.blacklist).toEqual([{ path: "foo", type: BlacklistType.flatten }])
+			expect(result.settings.fileSettings.blacklist).toEqual([{ path: "foo", type: "flatten" }])
 		})
 
 		it("should ignore old attribute types", () => {

--- a/visualization/app/codeCharta/util/fileHelper.ts
+++ b/visualization/app/codeCharta/util/fileHelper.ts
@@ -1,5 +1,5 @@
 import { ExportBlacklistType, ExportCCFile, ExportWrappedCCFile, OldAttributeTypes } from "../codeCharta.api.model"
-import { AttributeDescriptors, AttributeTypes, BlacklistItem, BlacklistType, CCFile, NameDataPair } from "../codeCharta.model"
+import { AttributeDescriptors, AttributeTypes, BlacklistItem, CCFile, NameDataPair } from "../codeCharta.model"
 import { FileSelectionState, FileState } from "../model/files/files"
 import md5 from "md5"
 
@@ -48,7 +48,7 @@ function getAttributeDescriptors(attributeDescriptors: AttributeDescriptors): At
 function potentiallyUpdateBlacklistTypes(blacklist): BlacklistItem[] {
 	for (const entry of blacklist) {
 		if (entry.type === ExportBlacklistType.hide) {
-			entry.type = BlacklistType.flatten
+			entry.type = "flatten"
 		}
 	}
 	return blacklist

--- a/visualization/app/codeCharta/util/nodeDecorator.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.ts
@@ -1,6 +1,6 @@
 "use strict"
 import { hierarchy } from "d3-hierarchy"
-import { AttributeTypes, AttributeTypeValue, BlacklistItem, BlacklistType, CCFile, CodeMapNode, MetricData } from "../codeCharta.model"
+import { AttributeTypes, AttributeTypeValue, BlacklistItem, CCFile, CodeMapNode, MetricData } from "../codeCharta.model"
 import { isLeaf, isNodeExcludedOrFlattened } from "./codeMapHelper"
 import { UNARY_METRIC } from "../state/selectors/accumulatedData/metricData/nodeMetricData.selector"
 
@@ -21,7 +21,7 @@ export const NodeDecorator = {
 		for (const item of blacklist) {
 			for (const { data } of hierarchy(map)) {
 				if (blacklist.length > 0) {
-					if (item.type === BlacklistType.flatten) {
+					if (item.type === "flatten") {
 						data.isFlattened = data.isFlattened ? true : isNodeExcludedOrFlattened(data, item.path)
 					} else {
 						data.isExcluded = data.isExcluded ? true : isNodeExcludedOrFlattened(data, item.path) && isLeaf(data)


### PR DESCRIPTION
change 

```ts
export enum BlacklistType {
	flatten = "flatten",
	exclude = "exclude"
}
``` 

to

```ts
export type BlacklistType = "flatten" | "exclude"
```

which satisfies strict type checking for template of [searchBar.component](https://github.com/MaibornWolff/codecharta/blob/main/visualization/app/codeCharta/ui/searchPanel/searchBar/searchBar.component.html#L24)

ref #3116 
