### PR TITLE
refactor: replace md5 through native crypto

### DIFF
--- a/visualization/app/codeCharta/services/loadInitialFile/urlExtractor.ts
+++ b/visualization/app/codeCharta/services/loadInitialFile/urlExtractor.ts
@@ -55,7 +55,7 @@ export class UrlExtractor {
 		if (response.status >= 200 && response.status < 300) {
 			const data = response.body
 			const responseData: string | ExportCCFile | ExportWrappedCCFile = ungzip(data, { to: "string" })
-			const content = getCCFileAndDecorateFileChecksum(responseData)
+			const content: ExportCCFile = await getCCFileAndDecorateFileChecksum(responseData)
 			const parsedFileName = this.getFileName(fileName, content.projectName)
 			// see #3111 and PR #3110 for reason of hard coded file size
 			return { fileName: parsedFileName, fileSize: 13, content }
@@ -68,7 +68,7 @@ export class UrlExtractor {
 
 		if (response.status >= 200 && response.status < 300) {
 			const responseData = response.body as string | ExportCCFile | ExportWrappedCCFile
-			const content: ExportCCFile = getCCFileAndDecorateFileChecksum(responseData)
+			const content: ExportCCFile = await getCCFileAndDecorateFileChecksum(responseData)
 			fileName = this.getFileName(fileName, content.projectName)
 			// see #3111 and PR #3110 for reason of hard coded file size
 			return { fileName, fileSize: 15, content }

--- a/visualization/app/codeCharta/ui/customConfigs/addCustomConfigButton/addCustomConfigDialog/addCustomConfigDialog.component.ts
+++ b/visualization/app/codeCharta/ui/customConfigs/addCustomConfigButton/addCustomConfigDialog/addCustomConfigDialog.component.ts
@@ -37,8 +37,8 @@ export class AddCustomConfigDialogComponent implements OnInit {
 		return this.customConfigName.hasError("Error") ? this.customConfigName.getError("Error") : ""
 	}
 
-	addCustomConfig() {
-		const newCustomConfig = buildCustomConfigFromState(this.customConfigName.value, this.state.getValue(), {
+	async addCustomConfig() {
+		const newCustomConfig = await buildCustomConfigFromState(this.customConfigName.value, this.state.getValue(), {
 			camera: this.threeCameraService.camera.position,
 			cameraTarget: this.threeOrbitControlsService.controls.target
 		})

--- a/visualization/app/codeCharta/ui/toolBar/uploadFilesButton/uploadFiles.service.ts
+++ b/visualization/app/codeCharta/ui/toolBar/uploadFilesButton/uploadFiles.service.ts
@@ -14,7 +14,7 @@ export class UploadFilesService {
 
 	constructor(private store: Store, private loadFileService: LoadFileService) {}
 
-	uploadFiles() {
+	async uploadFiles() {
 		const ccFileInput = createCCFileInput()
 		ccFileInput.addEventListener("change", async () => {
 			try {
@@ -23,7 +23,7 @@ export class UploadFilesService {
 				this.store.dispatch(setIsLoadingMap(true))
 
 				const plainFileContents = await Promise.all(readFiles(ccFileInput.files))
-				const { customConfigs, ccFiles } = this.splitCustomConfigsAndCCFiles(ccFileInput.files, plainFileContents)
+				const { customConfigs, ccFiles } = await this.splitCustomConfigsAndCCFiles(ccFileInput.files, plainFileContents)
 
 				for (const customConfig of customConfigs) {
 					CustomConfigHelper.importCustomConfigs(customConfig)
@@ -42,7 +42,7 @@ export class UploadFilesService {
 		ccFileInput.click()
 	}
 
-	private splitCustomConfigsAndCCFiles(fileList: FileList, contents: string[]) {
+	private async splitCustomConfigsAndCCFiles(fileList: FileList, contents: string[]) {
 		const customConfigs = []
 		const ccFiles = []
 
@@ -54,7 +54,7 @@ export class UploadFilesService {
 				ccFiles.push({
 					fileName,
 					fileSize: fileList[index].size,
-					content: getCCFileAndDecorateFileChecksum(content)
+					content: await getCCFileAndDecorateFileChecksum(content)
 				})
 			}
 		}

--- a/visualization/app/codeCharta/util/customConfigBuilder.ts
+++ b/visualization/app/codeCharta/util/customConfigBuilder.ts
@@ -1,11 +1,11 @@
 import { State, stateObjectReplacer } from "../codeCharta.model"
 import { CustomConfig } from "../model/customConfig/customConfig.api.model"
-import md5 from "md5"
 import { visibleFilesBySelectionModeSelector } from "../ui/customConfigs/visibleFilesBySelectionMode.selector"
+import { hash } from "./hash"
 
 const CUSTOM_CONFIG_API_VERSION = "1.0.0"
 
-export function buildCustomConfigFromState(configName: string, state: State, camera: CustomConfig["camera"]): CustomConfig {
+export async function buildCustomConfigFromState(configName: string, state: State, camera: CustomConfig["camera"]): Promise<CustomConfig> {
 	const { mapSelectionMode, assignedMaps } = visibleFilesBySelectionModeSelector(state)
 
 	const customConfig: CustomConfig = {
@@ -33,7 +33,7 @@ export function buildCustomConfigFromState(configName: string, state: State, cam
 	// Override the default state settings with the stored CustomConfig values
 	deepMapOneToOther(state, customConfig.stateSettings)
 
-	customConfig.id = md5(JSON.stringify(customConfig, stateObjectReplacer))
+	customConfig.id = await hash(JSON.stringify(customConfig, stateObjectReplacer))
 	return customConfig
 }
 

--- a/visualization/app/codeCharta/util/gameObjectsParser/gameObjectsImporter.ts
+++ b/visualization/app/codeCharta/util/gameObjectsParser/gameObjectsImporter.ts
@@ -1,6 +1,6 @@
-import md5 from "md5"
 import { AttributeTypes, AttributeTypeValue, CodeMapNode, Edge, FixedPosition, NodeType } from "../../codeCharta.model"
 import { ExportWrappedCCFile } from "../../codeCharta.api.model"
+import { hash } from "../hash"
 
 export interface GameObject {
 	name: string
@@ -21,7 +21,7 @@ export interface Cycle {
 
 const BASE_NAME = "base"
 
-export function parseGameObjectsFile(data): ExportWrappedCCFile {
+export async function parseGameObjectsFile(data): Promise<ExportWrappedCCFile> {
 	const { gameObjectPositions: gameObjects, cycles = [] } = JSON.parse(data)
 
 	const codeChartaJson: ExportWrappedCCFile = {
@@ -51,7 +51,7 @@ export function parseGameObjectsFile(data): ExportWrappedCCFile {
 	codeChartaJson.data.nodes = nodes
 	codeChartaJson.data.edges = cycles.map(cycle => createEdge(cycle))
 	codeChartaJson.data.attributeTypes = createAttributeTypes()
-	codeChartaJson.checksum = md5(JSON.stringify(codeChartaJson.data))
+	codeChartaJson.checksum = await hash(JSON.stringify(codeChartaJson.data))
 	return codeChartaJson
 }
 

--- a/visualization/app/codeCharta/util/hash.ts
+++ b/visualization/app/codeCharta/util/hash.ts
@@ -1,0 +1,5 @@
+export async function hash(text: string): Promise<string> {
+	const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text))
+	const hashHex = [...new Uint8Array(hashBuffer)].map(b => b.toString(16)).join("")
+	return hashHex
+}

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -27,7 +27,6 @@
 				"lodash.debounce": "^4.0.8",
 				"lodash.isequal": "^4.5.0",
 				"material-icons": "^1.10.4",
-				"md5": "^2.3.0",
 				"ngx-color": "^7.3.3",
 				"nw": "^0.72.0",
 				"pako": "^2.0.4",
@@ -6760,13 +6759,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/charenc": {
-			"version": "0.0.2",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"dev": true,
@@ -7466,13 +7458,6 @@
 			},
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/crypt": {
-			"version": "0.0.2",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/css-loader": {
@@ -10775,6 +10760,7 @@
 		},
 		"node_modules/is-buffer": {
 			"version": "1.1.6",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-builtin-module": {
@@ -14920,15 +14906,6 @@
 		"node_modules/material-icons": {
 			"version": "1.13.1",
 			"license": "Apache-2.0"
-		},
-		"node_modules/md5": {
-			"version": "2.3.0",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
-			}
 		},
 		"node_modules/mdast-util-definitions": {
 			"version": "4.0.0",
@@ -25380,9 +25357,6 @@
 			"version": "0.7.0",
 			"dev": true
 		},
-		"charenc": {
-			"version": "0.0.2"
-		},
 		"chokidar": {
 			"version": "3.5.3",
 			"dev": true,
@@ -25821,9 +25795,6 @@
 				"is-wsl": "^2.2.0",
 				"which": "^2.0.2"
 			}
-		},
-		"crypt": {
-			"version": "0.0.2"
 		},
 		"css-loader": {
 			"version": "6.7.3",
@@ -27955,7 +27926,8 @@
 			}
 		},
 		"is-buffer": {
-			"version": "1.1.6"
+			"version": "1.1.6",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "3.2.0",
@@ -30642,14 +30614,6 @@
 		},
 		"material-icons": {
 			"version": "1.13.1"
-		},
-		"md5": {
-			"version": "2.3.0",
-			"requires": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
-			}
 		},
 		"mdast-util-definitions": {
 			"version": "4.0.0",

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -85,7 +85,6 @@
 		"lodash.debounce": "^4.0.8",
 		"lodash.isequal": "^4.5.0",
 		"material-icons": "^1.10.4",
-		"md5": "^2.3.0",
 		"ngx-color": "^7.3.3",
 		"nw": "^0.72.0",
 		"pako": "^2.0.4",


### PR DESCRIPTION
as Angular warns about it "CommonJS or AMD dependencies can cause optimization bailouts"

ref #3116

I haven't adjusted the tests so far. @BridgeAR  do you have objections against the replacement of md5 to native crypto?