### PR TITLE
Test/3116/cleanup

### DIFF
--- a/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
+++ b/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core"
+import { Injectable, OnDestroy } from "@angular/core"
 import { tap } from "rxjs"
 import { MatLegacyDialog as MatDialog } from "@angular/material/legacy-dialog"
 import { clone } from "../../util/clone"
@@ -15,7 +15,7 @@ import { enrichFileStatesAndRecentFilesWithValidationResults } from "./fileParse
 import { fileRoot } from "./fileRoot"
 
 @Injectable({ providedIn: "root" })
-export class LoadFileService {
+export class LoadFileService implements OnDestroy {
 	static readonly CC_FILE_EXTENSION = ".cc.json"
 
 	referenceFileSubscription = this.store
@@ -30,6 +30,10 @@ export class LoadFileService {
 		.subscribe()
 
 	constructor(private store: Store, private state: State, private dialog: MatDialog) {}
+
+	ngOnDestroy(): void {
+		this.referenceFileSubscription.unsubscribe()
+	}
 
 	loadFiles(nameDataPairs: NameDataPair[]) {
 		const fileStates: FileState[] = clone(this.state.getValue().files)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.spec.ts
@@ -107,8 +107,7 @@ describe("CodeMapArrowService", () => {
 			expect(threeSceneService["selected"]).toMatchSnapshot()
 		})
 		it("should debounce the edge reset of buildings to improve performance", async () => {
-			codeMapArrowService["resetEdgesOfBuildings"] = () => {}
-			const resetEdgesOfBuildingMock = jest.fn().mockImplementation()
+			const resetEdgesOfBuildingMock = jest.fn()
 			codeMapArrowService["resetEdgesOfBuildings"] = resetEdgesOfBuildingMock
 			codeMapArrowService.onBuildingHovered(CODE_MAP_BUILDING_WITH_OUTGOING_EDGE_NODE)
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core"
+import { Injectable, OnDestroy } from "@angular/core"
 import { CodeMapMesh } from "./rendering/codeMapMesh"
 import { createTreemapNodes } from "../../util/algorithm/treeMapLayout/treeMapGenerator"
 import { CodeMapLabelService } from "./codeMap.label.service"
@@ -11,18 +11,19 @@ import { ThreeStatsService } from "./threeViewer/threeStats.service"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 import { Store } from "../../state/angular-redux/store"
 import { isLoadingFileSelector } from "../../state/store/appSettings/isLoadingFile/isLoadingFile.selector"
-import { tap } from "rxjs"
+import { Subscription, tap } from "rxjs"
 import { State } from "../../state/angular-redux/state"
 import { metricDataSelector } from "../../state/selectors/accumulatedData/metricData/metricData.selector"
 
 @Injectable({ providedIn: "root" })
-export class CodeMapRenderService {
+export class CodeMapRenderService implements OnDestroy {
 	private nodesByColor = {
 		positive: [],
 		neutral: [],
 		negative: []
 	}
 	private unflattenedNodes
+	private subscription: Subscription
 
 	constructor(
 		private store: Store,
@@ -33,7 +34,11 @@ export class CodeMapRenderService {
 		private threeStatsService: ThreeStatsService,
 		private codeMapMouseEventService: CodeMapMouseEventService
 	) {
-		this.store.select(isLoadingFileSelector).pipe(tap(this.onIsLoadingFileChanged)).subscribe()
+		this.subscription = this.store.select(isLoadingFileSelector).pipe(tap(this.onIsLoadingFileChanged)).subscribe()
+	}
+
+	ngOnDestroy(): void {
+		this.subscription.unsubscribe()
 	}
 
 	onIsLoadingFileChanged = (isLoadingFile: boolean) => {

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
@@ -10,7 +10,7 @@ import { idToNodeSelector } from "../../../state/selectors/accumulatedData/idToN
 import { IdToBuildingService } from "../../../services/idToBuilding/idToBuilding.service"
 import { mapColorsSelector } from "../../../state/store/appSettings/mapColors/mapColors.selector"
 import { ThreeRendererService } from "./threeRenderer.service"
-import { Injectable } from "@angular/core"
+import { Injectable, OnDestroy } from "@angular/core"
 import { Store } from "../../../state/angular-redux/store"
 import { defaultMapColors } from "../../../state/store/appSettings/mapColors/mapColors.actions"
 import { State } from "../../../state/angular-redux/state"
@@ -23,7 +23,7 @@ type BuildingSelectedEvents = {
 }
 
 @Injectable({ providedIn: "root" })
-export class ThreeSceneService {
+export class ThreeSceneService implements OnDestroy {
 	scene: Scene
 	labels: Group
 	floorLabelPlanes: Group
@@ -49,6 +49,10 @@ export class ThreeSceneService {
 	private highlightedLabel = null
 	private highlightedLineIndex = -1
 	private highlightedLine = null
+	private subscription = this.store.select(mapColorsSelector).subscribe(mapColors => {
+		this.folderLabelColorSelected = mapColors.selected
+		this.numberSelectionColor = ColorConverter.convertHexToNumber(this.folderLabelColorSelected)
+	})
 
 	constructor(
 		private store: Store,
@@ -56,11 +60,6 @@ export class ThreeSceneService {
 		private idToBuilding: IdToBuildingService,
 		private threeRendererService: ThreeRendererService
 	) {
-		this.store.select(mapColorsSelector).subscribe(mapColors => {
-			this.folderLabelColorSelected = mapColors.selected
-			this.numberSelectionColor = ColorConverter.convertHexToNumber(this.folderLabelColorSelected)
-		})
-
 		this.scene = new Scene()
 		this.mapGeometry = new Group()
 		this.lights = new Group()
@@ -75,6 +74,10 @@ export class ThreeSceneService {
 		this.scene.add(this.labels)
 		this.scene.add(this.lights)
 		this.scene.add(this.floorLabelPlanes)
+	}
+
+	ngOnDestroy(): void {
+		this.subscription.unsubscribe()
 	}
 
 	private initFloorLabels(nodes: Node[]) {


### PR DESCRIPTION
I noticed that very rarely codeMap.arrow.service.spec.ts fails in pipeline (e.g. [here](https://github.com/MaibornWolff/codecharta/actions/runs/4102205565/jobs/7074874968#step:6:1865). I have the assumption that it happens, when any parallel running test dispatches hoveredNodeId as we call the debounced function in subscription of constructor. But I couldn't reproduce it.

However I noticed, that we don't clean up our subscriptions. As far as I know in root provided services are never cleaned up in production. So this effects only tests.

ref #3116
