### PR TITLE
Enable safari compatibility and add babel class-static-block package

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -48,6 +48,7 @@
 				"@angular/cli": "^15.1.2",
 				"@angular/compiler": "^15.1.1",
 				"@angular/compiler-cli": "^15.1.1",
+				"@babel/plugin-proposal-class-static-block": "^7.20.7",
 				"@testing-library/angular": "^13.1.0",
 				"@testing-library/user-event": "^14.0.0",
 				"@types/color-convert": "^2.0.0",
@@ -1203,8 +1204,9 @@
 		},
 		"node_modules/@babel/plugin-proposal-class-static-block": {
 			"version": "7.20.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+			"integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-create-class-features-plugin": "^7.20.7",
 				"@babel/helper-plugin-utils": "^7.20.2",
@@ -21552,6 +21554,8 @@
 		},
 		"@babel/plugin-proposal-class-static-block": {
 			"version": "7.20.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+			"integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.20.7",

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -40,7 +40,8 @@
 	"main": "dist/webpack/index.html",
 	"browserslist": [
 		"last 2 chrome version",
-		"last 2 firefox version"
+		"last 2 firefox version",
+		"last 2 safari version"
 	],
 	"scripts": {
 		"start": "nw .",
@@ -103,6 +104,7 @@
 		"@angular/cli": "^15.1.2",
 		"@angular/compiler": "^15.1.1",
 		"@angular/compiler-cli": "^15.1.1",
+		"@babel/plugin-proposal-class-static-block": "^7.20.7",
 		"@testing-library/angular": "^13.1.0",
 		"@testing-library/user-event": "^14.0.0",
 		"@types/color-convert": "^2.0.0",


### PR DESCRIPTION
# Fix Issue with Safari compatibility in dev mode after Angular 15 Update

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

## Description

Add a missing babel package and enable safari compatibility for last 2 browser versions.
