### PR TITLE
Optimize animations by reducing debounce time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Unselecting a folder in Presentation Mode leads to console error [#3215](https://github.com/MaibornWolff/codecharta/pull/3215)
 -   Fix Shrunken FileExplorer's file list on small displays [#3235](https://github.com/MaibornWolff/codecharta/pull/3235)
 -   Fix various margin problems in the UI [#3226](https://github.com/MaibornWolff/codecharta/pull/3226)
+-   Fix bumpy animations when moving/turning the map, hover buildings (showing labels and edges) [#3244](https://github.com/MaibornWolff/codecharta/pull/3244)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.arrow.service.ts
@@ -16,7 +16,7 @@ export class CodeMapArrowService implements OnDestroy {
 	private map: Map<string, Node>
 	private VERTICES_PER_LINE = 5
 	private arrows: Object3D[] = new Array<Object3D>()
-	private HIGHLIGHT_BUILDING_DELAY = 15
+	private HIGHLIGHT_BUILDING_DELAY = 1
 	private debounceCalculation: (hoveredBuilding: CodeMapBuilding) => void = debounce(
 		(hoveredBuilding: CodeMapBuilding) => this.resetEdgesOfBuildings(hoveredBuilding),
 		this.HIGHLIGHT_BUILDING_DELAY

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -99,7 +99,7 @@ export class CodeMapMouseEventService implements OnDestroy {
 	}
 
 	start() {
-		this.threeRendererService.renderer.domElement.addEventListener("mousemove", debounce(this.onDocumentMouseMove, 60))
+		this.threeRendererService.renderer.domElement.addEventListener("mousemove", debounce(this.onDocumentMouseMove, 1))
 		this.threeRendererService.renderer.domElement.addEventListener("mouseup", event => this.onDocumentMouseUp(event))
 		this.threeRendererService.renderer.domElement.addEventListener("mousedown", event => this.onDocumentMouseDown(event))
 		this.threeRendererService.renderer.domElement.addEventListener("dblclick", () => this.onDocumentDoubleClick())
@@ -107,7 +107,7 @@ export class CodeMapMouseEventService implements OnDestroy {
 		this.threeRendererService.renderer.domElement.addEventListener("mouseenter", () => this.onDocumentMouseEnter())
 		this.threeRendererService.renderer.domElement.addEventListener(
 			"wheel",
-			debounce(() => this.threeRendererService.render(), 60)
+			debounce(() => this.threeRendererService.render(), 1)
 		)
 		this.viewCubeMouseEvents.subscribe("viewCubeEventPropagation", this.onViewCubeEventPropagation)
 	}


### PR DESCRIPTION
# Optimize animations by reducing debounce time of...
- showing arrows and labels (on hovering a building)
- map movements 
- mouse wheel zooming

closes: #3040
