### PR TITLE
Fix/improve custom views dialog styling

### DIFF
--- a/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigItemGroup/customConfigDescription/applyCustomConfigButton.component.html
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigItemGroup/customConfigDescription/applyCustomConfigButton.component.html
@@ -7,15 +7,20 @@
 	<p class="config-name" title="{{ customConfigItem.name }}">
 		<b>{{ customConfigItem.name }}</b>
 	</p>
-	<p class="config-metric"><i class="fa fa-arrows-alt"></i> {{ customConfigItem.metrics.areaMetric }}</p>
-	<p class="config-metric"><i class="fa fa-arrows-v"></i> {{ customConfigItem.metrics.heightMetric }}</p>
-	<p class="config-metric"><i class="fa fa-paint-brush"></i> {{ customConfigItem.metrics.colorMetric }}</p>
-	<p class="config-metric" *ngIf="customConfigItem.metrics.edgeMetric">
-		<i class="fa fa-exchange"></i> {{ customConfigItem.metrics.edgeMetric }}
-	</p>
-	<div class="color-schema-container">
-		<div class="color-swatch-container" *ngFor="let mapColor of customConfigItem | customConfigColorSchemaBySelectionMode">
-			<span class="color-swatch" [style.background-color]="customConfigItem.isApplicable ? mapColor : 'rgb(204, 204, 204)'"></span>
+	<div class="config-metric-list">
+		<p class="config-metric"><i class="fa fa-arrows-alt"></i> {{ customConfigItem.metrics.areaMetric }}</p>
+		<p class="config-metric"><i class="fa fa-arrows-v"></i> {{ customConfigItem.metrics.heightMetric }}</p>
+		<p class="config-metric"><i class="fa fa-paint-brush"></i> {{ customConfigItem.metrics.colorMetric }}</p>
+		<p class="config-metric" *ngIf="customConfigItem.metrics.edgeMetric">
+			<i class="fa fa-exchange"></i> {{ customConfigItem.metrics.edgeMetric }}
+		</p>
+		<div class="color-schema-container">
+			<div class="color-swatch-container" *ngFor="let mapColor of customConfigItem | customConfigColorSchemaBySelectionMode">
+				<span
+					class="color-swatch"
+					[style.background-color]="customConfigItem.isApplicable ? mapColor : 'rgb(204, 204, 204)'"
+				></span>
+			</div>
 		</div>
 	</div>
 </button>

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigItemGroup/customConfigDescription/applyCustomConfigButton.component.scss
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigItemGroup/customConfigDescription/applyCustomConfigButton.component.scss
@@ -3,15 +3,17 @@ cc-apply-custom-config-button {
 	flex: 1;
 
 	button {
-		flex-direction: row;
-		flex-wrap: wrap;
-		align-items: center;
-		display: flex;
-		flex: 1;
-		gap: 10px;
+		flex-direction: column;
+		width: 100%;
 
 		&:disabled {
 			cursor: default;
+		}
+
+		.config-metric-list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px;
 		}
 
 		p {

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.html
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.html
@@ -1,8 +1,7 @@
+<mat-toolbar color="primary">Custom Views</mat-toolbar>
+
 <mat-dialog-content class="content" *ngIf="customConfigService.customConfigItemGroups$ | async; let dropDownCustomConfigItemGroups">
 	<div class="row">
-		<div class="title">
-			<h3>Custom Views</h3>
-		</div>
 		<div class="action-buttons">
 			<cc-upload-custom-config-button></cc-upload-custom-config-button>
 			<cc-download-custom-configs-button></cc-download-custom-configs-button>

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.html
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.html
@@ -1,17 +1,18 @@
-<mat-toolbar color="primary">Custom Views</mat-toolbar>
-
-<mat-dialog-content class="content" *ngIf="customConfigService.customConfigItemGroups$ | async; let dropDownCustomConfigItemGroups">
+<mat-toolbar color="primary"
+	>Custom Views
 	<div class="row">
 		<div class="action-buttons">
 			<cc-upload-custom-config-button></cc-upload-custom-config-button>
 			<cc-download-custom-configs-button></cc-download-custom-configs-button>
 			<cc-add-custom-config-button class="custom-configs-button-in-custom-views"></cc-add-custom-config-button>
-		</div>
-	</div>
-	<div class="custom-config-documentation-hint">
+		</div></div
+></mat-toolbar>
+
+<mat-dialog-content class="content" *ngIf="customConfigService.customConfigItemGroups$ | async; let dropDownCustomConfigItemGroups">
+	<p class="custom-config-documentation-hint">
 		Custom Views allow you to save and upload your individual configurations for certain maps. Find out more about Custom Views in the
 		<a href="https://maibornwolff.github.io/codecharta/docs/custom-view/" target="_blank" rel="noopener noreferrer">documentation</a>.
-	</div>
+	</p>
 	<mat-divider></mat-divider>
 	<div
 		class="no-custom-configs-box"

--- a/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.scss
+++ b/visualization/app/codeCharta/ui/customConfigs/customConfigList/customConfigList.component.scss
@@ -1,33 +1,35 @@
 @use "../../../../material/theme";
 
-.cc-custom-config-list .mat-mdc-dialog-container {
-	padding: 5px 16px;
-	max-height: 90vh;
-
-	.mat-mdc-dialog-content.content {
+.cc-custom-config-list {
+	.mat-mdc-dialog-content {
 		max-height: 100%;
-		margin: 0;
-		padding: 0;
+		padding: 16px;
+		max-height: 90vh;
 	}
 
 	.row {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		margin-left: auto;
 	}
 
 	.custom-config-documentation-hint {
 		margin: 10px 0 20px 0;
+		font-size: 1.4em;
+		line-height: 1.4em;
+		color: black;
 	}
 
 	.action-buttons button {
 		margin: 0 3px;
 		min-width: 12%;
 		height: 48px;
-		width: 65px;
+		width: 48px;
+		border-radius: 100%;
 		line-height: 48px;
-		background-color: theme.$cc-primary-color;
-		color: #ffffff;
+		background-color: #ffffff;
+		color: theme.$cc-primary-color;
 
 		&:disabled,
 		&[disabled] {
@@ -75,10 +77,15 @@
 		}
 
 		.mdc-list-item__content {
-			display: flex;
-			justify-content: space-between;
+			width: 100%;
 			border-bottom: 1px solid #000000;
 			padding: 0 5px;
+
+			.mdc-list-item__primary-text {
+				display: flex;
+				width: inherit;
+				align-items: center;
+			}
 
 			&:hover {
 				background-color: rgba(0, 0, 0, 0.04);
@@ -90,7 +97,6 @@
 				&.remove-button {
 					font-size: 16px;
 					padding: 8px 10px;
-					margin: 0;
 
 					&:hover {
 						background-color: rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
# Improve custom views dialog styling

## Description

**Descriptive pull request text**, answering:
  - Fix custom views dialog styling and make it consistent with the others.
 
Note: I discovered that the expansion panel / accordion is not being styled correctly  from material UI. I couldn't find the reason as everything is imported correctly.
It should look like this per default:
![image](https://user-images.githubusercontent.com/48621967/225004309-b05359b7-cd50-4b4f-980e-598bdc1f7b80.png)

## Screenshots or gifs
Before:
![image](https://user-images.githubusercontent.com/48621967/225003467-2f25c4d4-0066-4174-a0e8-7ccaa0b59256.png)
After:
![image](https://user-images.githubusercontent.com/48621967/225003191-d73f1f12-d6b0-4b12-b69e-92283bced92d.png)
![image](https://user-images.githubusercontent.com/48621967/225003262-23ee0fc4-42af-4640-ab10-bc23a1bdd46d.png)
