### PR TITLE
Remove expired support for old custom config api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Removed 🗑
+
+-   Support for Custom Views created before CodeCharta version 1.110.0 or older is no longer be maintained [#3265](https://github.com/MaibornWolff/codecharta/pull/3265)
+
 ### Fixed 🐞
 
 -   Fix the disappearance of the suspicious metrics labels [#3263](https://github.com/MaibornWolff/codecharta/pull/3263)

--- a/visualization/app/codeCharta/util/customConfigHelper.ts
+++ b/visualization/app/codeCharta/util/customConfigHelper.ts
@@ -38,23 +38,7 @@ export class CustomConfigHelper {
 
 	static loadCustomConfigsFromLocalStorage() {
 		const ccLocalStorage = this.getCcLocalStorage()
-		const configs = new Map(ccLocalStorage?.customConfigs)
-		this.mapOldConfigStructureToNew(configs)
-		return configs
-	}
-
-	// TODO [2023-04-01] remove support
-	private static mapOldConfigStructureToNew(configs: Map<string, CustomConfig>) {
-		for (const config of configs.values()) {
-			if (config["mapChecksum"]) {
-				const checksums = config["mapChecksum"].split(";")
-				config.assignedMaps = new Map(checksums.map((checksum, index) => [checksum, config["assignedMaps"][index]]))
-			}
-			// @ts-ignore
-			if (config.mapSelectionMode === "MULTIPLE") {
-				config.mapSelectionMode = CustomConfigMapSelectionMode.MULTIPLE
-			}
-		}
+		return new Map(ccLocalStorage?.customConfigs)
 	}
 
 	private static getCcLocalStorage() {
@@ -112,8 +96,6 @@ export class CustomConfigHelper {
 
 	static importCustomConfigs(content: string) {
 		const importedCustomConfigsFile: CustomConfigsDownloadFile = JSON.parse(content, stateObjectReviver)
-
-		this.mapOldConfigStructureToNew(importedCustomConfigsFile.customConfigs)
 
 		for (const exportedConfig of importedCustomConfigsFile.customConfigs.values()) {
 			const alreadyExistingConfig = CustomConfigHelper.getCustomConfigSettings(exportedConfig.id)
@@ -215,8 +197,6 @@ export class CustomConfigHelper {
 		threeOrbitControlsService: ThreeOrbitControlsService
 	) {
 		const customConfig = this.getCustomConfigSettings(configId)
-		CustomConfigHelper.deleteUnusedKeyPropsOfCustomConfig(customConfig)
-
 		store.dispatch(setState(customConfig.stateSettings))
 
 		// TODO: remove this dirty timeout and set camera settings properly
@@ -226,14 +206,6 @@ export class CustomConfigHelper {
 				threeOrbitControlsService.setControlTarget(customConfig.camera.cameraTarget)
 				threeCameraService.setPosition(customConfig.camera.camera)
 			}, 100)
-		}
-	}
-
-	// TODO [2023-04-01] remove support
-	private static deleteUnusedKeyPropsOfCustomConfig(customConfig: any) {
-		if (customConfig.stateSettings.treeMap || customConfig.stateSettings.fileSettings.attributeTypes) {
-			delete customConfig.stateSettings.treeMap
-			delete customConfig.stateSettings.fileSettings.attributeTypes
 		}
 	}
 }


### PR DESCRIPTION
# Remove expired support for old custom config api

-Support for Custom Views created before CodeCharta version 1.110.0 or older is no longer be maintained

