### PR TITLE
fix/3286/add-all-doc-entries-to-sidebar

### DIFF
--- a/gh-pages/_data/navigation.yml
+++ b/gh-pages/_data/navigation.yml
@@ -74,6 +74,10 @@ docs:
             url: /docs/timeline/
           - title: "Custom View"
             url: /docs/custom-view/
+          - title: "Suspicious metrics"
+            url: /docs/suspicious-metrics/
+          - title: "Risk profile"
+            url: /docs/risk-profile/
 
     - title: Reference
       children:


### PR DESCRIPTION
# Fix missing entries in navigation menu

Issue: #3286 

## Description

This fixes the suspicious metrics and risk profile documentation pages not being shown in the navigation menu on the left side of the screen.
