### PR TITLE
fix/3297/fix-invalid-ccsh-doc-examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Show again delta of a building which have nothing in common in red or green [#3271](https://github.com/MaibornWolff/codecharta/pull/3271)
 -   Always show description of suspicious metrics [#3285](https://github.com/MaibornWolff/codecharta/pull/3285)
 -   Show suspicious metrics and risk profile documentation pages in navigation bar [#3290](https://github.com/MaibornWolff/codecharta/pull/3290)
+-   Fix formatting issues in docs turning `--` to `–` [#3301](https://github.com/MaibornWolff/codecharta/pull/3301)
 
 ### Changed
 

--- a/gh-pages/_docs/04-04-svnlogparser.md
+++ b/gh-pages/_docs/04-04-svnlogparser.md
@@ -48,7 +48,9 @@ The names of authors are saved when the --add-author flag is set.
 
 Standard usage:
 
-> `ccsh svnlogparser <log_file>`
+```
+ccsh svnlogparser <log_file>
+```
 
 The result is written as JSON to standard out or into an output file (if specified by `-o` option).
 

--- a/gh-pages/_docs/04-05-sonarimporter.md
+++ b/gh-pages/_docs/04-05-sonarimporter.md
@@ -21,7 +21,7 @@ The Sonar-Importer generates visualisation data from SonarQube data through an A
 The command
 
 ```
-ccsh sonarimport \<url of server> \<project id>
+ccsh sonarimport <url of server> <project id>
 ```
 
 prints the visualisation data to stdout (or a file if option `-o <filename>` is given).
@@ -42,7 +42,7 @@ The resulting project has the project name specified for the SonarImporter.
 ### Example
 
 ```
-ccsh sonarimport \<url> \<projectKey> --user=\<userToken> --output-file=\<fileName> --merge-modules=\<Boolean>
+ccsh sonarimport <url> <projectKey> --user=<userToken> --output-file=<fileName> --merge-modules=<Boolean>
 ```
 
 If you use SonarQube locally, an example command would look like the following:

--- a/gh-pages/_docs/04-05-sonarimporter.md
+++ b/gh-pages/_docs/04-05-sonarimporter.md
@@ -20,7 +20,9 @@ The Sonar-Importer generates visualisation data from SonarQube data through an A
 
 The command
 
-> ccsh sonarimport \<url of server> \<project id>
+```
+ccsh sonarimport \<url of server> \<project id>
+```
 
 prints the visualisation data to stdout (or a file if option `-o <filename>` is given).
 
@@ -28,7 +30,9 @@ SonarImporter ignores the multi-module structure of sonar projects if the toggle
 
 Further usage information may be retrieved through
 
-> ccsh sonarimport -h
+```
+ccsh sonarimport -h
+```
 
 _Alternatively you can use the interactive mode, if you type `ccsh` into your terminal and select the sonar importer._
 
@@ -37,8 +41,12 @@ The resulting project has the project name specified for the SonarImporter.
 
 ### Example
 
-> ccsh sonarimport \<url> \<projectKey> --user=\<userToken> --output-file=\<fileName> --merge-modules=\<Boolean>
+```
+ccsh sonarimport \<url> \<projectKey> --user=\<userToken> --output-file=\<fileName> --merge-modules=\<Boolean>
+```
 
 If you use SonarQube locally, an example command would look like the following:
 
-> ccsh sonarimport "http://localhost:9000/" "CodeCharta" "--user=squ_12345" "--output-file=output" "--merge-modules=false"
+```
+ccsh sonarimport "http://localhost:9000/" "CodeCharta" "--user=squ_12345" "--output-file=output" "--merge-modules=false"
+```

--- a/gh-pages/_docs/04-07-sourcemonitor.md
+++ b/gh-pages/_docs/04-07-sourcemonitor.md
@@ -34,7 +34,7 @@ Currently, SourceMonitorImporter does not support metrics for methods in csv fil
 If SourceMonitor v3.5 is installed in 'C:\Program Files (x86)\SourceMonitor' you may use the wrapper script sourcemonImport.bat to generate and import metrics from SourceMonitor in one step:
 
 ```
-sourcemonImport.bat \<projectBuilder name> \<source code path> \<language>
+sourcemonImport.bat <projectBuilder name> <source code path> <language>
 ```
 
 If SourceMonitor is installed in a different directory the script must be changed accordingly.

--- a/gh-pages/_docs/04-07-sourcemonitor.md
+++ b/gh-pages/_docs/04-07-sourcemonitor.md
@@ -33,7 +33,9 @@ Currently, SourceMonitorImporter does not support metrics for methods in csv fil
 
 If SourceMonitor v3.5 is installed in 'C:\Program Files (x86)\SourceMonitor' you may use the wrapper script sourcemonImport.bat to generate and import metrics from SourceMonitor in one step:
 
-> sourcemonImport.bat \<projectBuilder name> \<source code path> \<language>
+```
+sourcemonImport.bat \<projectBuilder name> \<source code path> \<language>
+```
 
 If SourceMonitor is installed in a different directory the script must be changed accordingly.
 

--- a/gh-pages/_docs/04-12-gitlogparser.md
+++ b/gh-pages/_docs/04-12-gitlogparser.md
@@ -43,7 +43,9 @@ The names of authors are saved when the --add-author flag is set.
 
 See `ccsh gitlogparser repo-scan -h` for help. Standard usage:
 
-> `ccsh gitlogparser repo-scan --repo-path <path>`
+```
+ccsh gitlogparser repo-scan --repo-path <path>
+```
 
 With the sub command `repo-scan` you can parse a local git repository on your disk. During scanning a git log of the
 repository in the current working directory (or from the directory specified by repo-path) is created in your
@@ -64,7 +66,9 @@ The resulting project has the project name specified for the GitLogParser.
 
 See `ccsh gitlogparser log-scan -h` for help. Standard usage:
 
-> `ccsh gitlogparser log-scan --git-log <path> --repo-files <path>`
+```
+ccsh gitlogparser log-scan --git-log <path> --repo-files <path>
+```
 
 With the sub command `log-scan`, an existing git log and file name list are used for parsing.
 
@@ -85,7 +89,9 @@ which generates a git log with anonymized authors for usage with CodeCharta.
 
 #### Creating the git files list of the repository for metric generation
 
-> `git ls-files > file-name-list.txt`
+```
+git ls-files > file-name-list.txt
+```
 
 Please make sure to execute this command in the root folder of your repository.
 

--- a/gh-pages/_docs/05-03-ccsh.md
+++ b/gh-pages/_docs/05-03-ccsh.md
@@ -56,7 +56,9 @@ if they did not exist before.
 
 ### Usage
 
-`ccsh edgefilter edges.cc.json -o visual_edges.cc.json`
+```
+ccsh edgefilter edges.cc.json -o visual_edges.cc.json
+```
 
 ## Merge
 
@@ -64,9 +66,15 @@ Reads the specified files, merges visualisation data and prints to stdout.
 
 ### Usage
 
-> `ccsh merge <reference json file> <json files>`
-> or
-> `ccsh merge <folder>`
+```
+ccsh merge <reference json file> <json files>
+```
+
+or
+
+```
+ccsh merge <folder>
+```
 
 The first file with visualisation data is used as reference for the merging strategy.
 The visualisation data in the additional
@@ -83,11 +91,19 @@ Both strategies will merge the unique list entries for `attributeTypes` and `bla
 
 ### Examples
 
-> `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json`
+```
+ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json
+```
 
-> `ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json --leaf --add-missing`
+```
+ccsh merge file1.cc.json ../foo/file2.cc.json -o=test.cc.json --leaf --add-missing
+```
 
-> `ccsh merge file1.cc.json ../foo/ -o=test.cc.json` (Merges all project files in foo with the reference file)
+```
+ccsh merge file1.cc.json ../foo/ -o=test.cc.json
+```
+
+(Merges all project files in foo with the reference file)
 
 ## Structure Modifier
 
@@ -123,13 +139,21 @@ ccsh modify [-h] [-f=<moveFrom>] [-o=<outputFile>]
 
 ### Examples
 
-> sh ccsh modify foo.cc.json -p=2
+```
+sh ccsh modify foo.cc.json -p=2
+```
 
-> sh ccsh modify foo.cc.json --remove=/root/foo --remove=/root/bar/
+```
+sh ccsh modify foo.cc.json --remove=/root/foo --remove=/root/bar/
+```
 
-> sh ccsh modify foo.cc.json --move-from=/root/foo --move-to=/root/bar -output-file=project.cc.json
+```
+sh ccsh modify foo.cc.json --move-from=/root/foo --move-to=/root/bar -output-file=project.cc.json
+```
 
-> sh ccsh modify foo.cc.json --set-root=/root/foo/
+```
+sh ccsh modify foo.cc.json --set-root=/root/foo/
+```
 
 ### Piped input
 
@@ -158,8 +182,12 @@ _Conventions for csv output:_
 
 ### Example
 
-> ccsh csvexport visual.cc.json
+```
+ccsh csvexport visual.cc.json
+```
 
 Further usage information may be retrieved through
 
-> ccsh csvexport -h
+```
+ccsh csvexport -h
+```

--- a/gh-pages/_docs/05-04-custom-metrics.md
+++ b/gh-pages/_docs/05-04-custom-metrics.md
@@ -19,11 +19,15 @@ service/Service1.ts,40,20
 
 You can transform that file into a `.cc.json` via command-line:
 
-`ccsh csvimport newmetrics.csv -o newmetrics.cc.json`
+```
+ccsh csvimport newmetrics.csv -o newmetrics.cc.json
+```
 
 This will result in a new file which you can merge into your existing `standardmetrics.cc.json` files via:
 
-`ccsh merge newmetrics.cc.json standardmetrics.cc.json -o mergedmetrics.cc.json`
+```
+ccsh merge newmetrics.cc.json standardmetrics.cc.json -o mergedmetrics.cc.json
+```
 
 If you are interested the `newmetrics.cc.json` looks like this:
 

--- a/gh-pages/_docs/05-05-analyze-with-sonarqube.md
+++ b/gh-pages/_docs/05-05-analyze-with-sonarqube.md
@@ -33,7 +33,7 @@ You can also run SonarQube with Docker, for further information read [here](http
 1. Download and install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) if not already present on your system
 2. [Download](https://hub.docker.com/_/sonarqube/) the latest version of SonarQube Docker Image
 3. Start the Sonar Server with the following command:
-    > $ docker run -d --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 sonarqube:latest
+    > `$ docker run -d --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 sonarqube:latest`
 4. Open `localhost:9000` in your browser and log in with
     - login: admin
     - password: admin


### PR DESCRIPTION
# Fix formatting issues in example commands in docs

Issue: #3297 

## Description

This PR fixes the formatting issue in the docs which turned double dashes into single dashes. 
Additionally, I unified the way we format code snippets in the command examples, so that the docs mostly follow the same structure (I excluded some specific cases where formatting code snippets in other ways looked better).
