### PR TITLE
Fix the version of nw-builder to 3.7.4 (from 3.8.6)

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -72,7 +72,7 @@
 				"jest-puppeteer": "^6.1.1",
 				"lint-staged": "^13.0.0",
 				"marked": "^4.3.0",
-				"nw-builder": "^3.7.4",
+				"nw-builder": "3.7.4",
 				"puppeteer": "^17.0.0",
 				"ts-jest": "^29.0.5",
 				"typescript": "~4.9.4",
@@ -3169,6 +3169,8 @@
 		},
 		"node_modules/@malept/cross-spawn-promise": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3180,7 +3182,6 @@
 					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
 				}
 			],
-			"license": "Apache-2.0",
 			"dependencies": {
 				"cross-spawn": "^7.0.1"
 			},
@@ -4163,6 +4164,15 @@
 			"integrity": "sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==",
 			"dev": true
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.6",
 			"dev": true,
@@ -4187,6 +4197,18 @@
 			"dev": true,
 			"dependencies": {
 				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
+			"dependencies": {
+				"defer-to-connect": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@testing-library/angular": {
@@ -5263,6 +5285,15 @@
 				"ajv": "^6.9.1"
 			}
 		},
+		"node_modules/ansi-align": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.1.0"
+			}
+		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
 			"dev": true,
@@ -5329,8 +5360,9 @@
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -5492,16 +5524,18 @@
 		},
 		"node_modules/asn1": {
 			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
 			}
@@ -5570,16 +5604,18 @@
 		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws4": {
 			"version": "1.12.0",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+			"dev": true
 		},
 		"node_modules/axios": {
 			"version": "0.25.0",
@@ -5816,8 +5852,9 @@
 		},
 		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -6002,6 +6039,104 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/boxen": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+			"integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-align": "^3.0.0",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.1.0",
+				"cli-boxes": "^2.2.1",
+				"string-width": "^4.2.2",
+				"type-fest": "^0.20.2",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/boxen/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/boxen/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/boxen/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/boxen/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"license": "MIT",
@@ -6176,6 +6311,48 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/cacheable-request": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"dev": true,
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^3.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"dev": true,
@@ -6241,8 +6418,9 @@
 		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
-			"dev": true,
-			"license": "Apache-2.0"
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+			"dev": true
 		},
 		"node_modules/caw": {
 			"version": "2.0.1",
@@ -6391,6 +6569,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/cli-boxes": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cli-cursor": {
 			"version": "3.1.0",
 			"dev": true,
@@ -6400,17 +6590,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/cli-progress": {
-			"version": "3.11.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"string-width": "^4.2.3"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/cli-spinners": {
@@ -6531,6 +6710,18 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/co": {
@@ -6683,6 +6874,35 @@
 		"node_modules/config-chain/node_modules/ini": {
 			"version": "1.3.8",
 			"license": "ISC"
+		},
+		"node_modules/configstore": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+			"dev": true,
+			"dependencies": {
+				"dot-prop": "^5.2.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^3.0.0",
+				"unique-string": "^2.0.0",
+				"write-file-atomic": "^3.0.0",
+				"xdg-basedir": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/configstore/node_modules/write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
+			}
 		},
 		"node_modules/connect-history-api-fallback": {
 			"version": "2.0.0",
@@ -6965,6 +7185,8 @@
 		},
 		"node_modules/cross-spawn-windows-exe": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
+			"integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
 			"dev": true,
 			"funding": [
 				{
@@ -6976,7 +7198,6 @@
 					"url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
 				}
 			],
-			"license": "Apache-2.0",
 			"dependencies": {
 				"@malept/cross-spawn-promise": "^1.1.0",
 				"is-wsl": "^2.2.0",
@@ -6991,6 +7212,15 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/crypto-random-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/css-loader": {
@@ -7102,8 +7332,9 @@
 		},
 		"node_modules/dashdash": {
 			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			},
@@ -7166,6 +7397,18 @@
 				"make-dir": "^1.0.0",
 				"pify": "^2.3.0",
 				"strip-dirs": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=4"
@@ -7370,6 +7613,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"dev": true,
@@ -7405,6 +7657,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+			"dev": true
 		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
@@ -7460,8 +7718,9 @@
 		},
 		"node_modules/deprecate": {
 			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.1.tgz",
+			"integrity": "sha512-ZGDXefq1xknT292LnorMY5s8UVU08/WKdzDZCUT6t9JzsiMSP4uzUhgpqugffNVcT5WC6wMBiSQ+LFjlv3v7iQ==",
+			"dev": true
 		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
@@ -7630,6 +7889,18 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"dependencies": {
+				"is-obj": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/download": {
 			"version": "5.0.3",
 			"license": "MIT",
@@ -7665,8 +7936,9 @@
 		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -7872,6 +8144,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/escape-html": {
@@ -8588,8 +8869,9 @@
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
@@ -8639,11 +8921,12 @@
 		},
 		"node_modules/extsprintf": {
 			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
 			"dev": true,
 			"engines": [
 				"node >=0.6.0"
-			],
-			"license": "MIT"
+			]
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -8766,8 +9049,9 @@
 		},
 		"node_modules/fill-keys": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"is-object": "~1.0.1",
 				"merge-descriptors": "~1.0.0"
@@ -9009,8 +9293,9 @@
 		},
 		"node_modules/forever-agent": {
 			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
@@ -9076,8 +9361,9 @@
 		},
 		"node_modules/fs-extra": {
 			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+			"integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^2.1.0",
@@ -9088,8 +9374,9 @@
 		},
 		"node_modules/fs-extra/node_modules/glob": {
 			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -9107,8 +9394,9 @@
 		},
 		"node_modules/fs-extra/node_modules/rimraf": {
 			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -9239,8 +9527,9 @@
 		},
 		"node_modules/getpass": {
 			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0"
 			}
@@ -9294,6 +9583,30 @@
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/global-dirs": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+			"integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+			"dev": true,
+			"dependencies": {
+				"ini": "2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/global-dirs/node_modules/ini": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9418,8 +9731,9 @@
 		},
 		"node_modules/graceful-fs-extra": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/graceful-fs-extra/-/graceful-fs-extra-2.0.0.tgz",
+			"integrity": "sha512-TdHFKs8ZsxSlywA/8yU8IVJpRMzyTkOQlYNRWes1yjImhZ2BPhnYmXTOnMSkD6SDCwqglIWYUENGeqR7IVXg6Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^0.30.0",
 				"graceful-ncp": "^3.0.0",
@@ -9428,8 +9742,9 @@
 		},
 		"node_modules/graceful-ncp": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/graceful-ncp/-/graceful-ncp-3.0.0.tgz",
+			"integrity": "sha512-G6QJTyxiW0lO0njYNx3572+d4BbsxvfayjndnP4cDTjQss+yK5f/p5+DjOBo1gk561ULfKo9nrdtSP6rQyQZJA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.1.4",
 				"ncp": "^2.0.0",
@@ -9448,16 +9763,19 @@
 		},
 		"node_modules/har-schema": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
 			"dev": true,
-			"license": "ISC",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/har-validator": {
 			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"deprecated": "this library is no longer supported",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
@@ -9566,6 +9884,15 @@
 			"version": "2.0.1",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/has-yarn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/hdr-histogram-js": {
 			"version": "2.0.3",
@@ -9838,8 +10165,9 @@
 		},
 		"node_modules/http-signature": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -9991,6 +10319,15 @@
 			"version": "4.0.0",
 			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -10267,6 +10604,24 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"dependencies": {
+				"ci-info": "^2.0.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
+		},
+		"node_modules/is-ci/node_modules/ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
 		"node_modules/is-core-module": {
 			"version": "2.11.0",
 			"license": "MIT",
@@ -10348,6 +10703,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-installed-globally": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+			"dev": true,
+			"dependencies": {
+				"global-dirs": "^3.0.0",
+				"is-path-inside": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
 			"dev": true,
@@ -10373,6 +10744,18 @@
 			"version": "4.0.1",
 			"license": "MIT"
 		},
+		"node_modules/is-npm": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"dev": true,
@@ -10393,6 +10776,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-object": {
@@ -10534,8 +10926,9 @@
 		},
 		"node_modules/is-typedarray": {
 			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+			"dev": true
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
@@ -10592,6 +10985,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+			"dev": true
+		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
 			"dev": true,
@@ -10612,8 +11011,9 @@
 		},
 		"node_modules/isstream": {
 			"version": "0.1.2",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+			"dev": true
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -12817,8 +13217,9 @@
 		},
 		"node_modules/jsbn": {
 			"version": "0.1.1",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+			"dev": true
 		},
 		"node_modules/jsdom": {
 			"version": "20.0.3",
@@ -12876,6 +13277,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+			"dev": true
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"dev": true,
@@ -12883,8 +13290,9 @@
 		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
-			"dev": true,
-			"license": "(AFL-2.1 OR BSD-3-Clause)"
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -12897,8 +13305,9 @@
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
-			"dev": true,
-			"license": "ISC"
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -12918,8 +13327,9 @@
 		},
 		"node_modules/jsonfile": {
 			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
 			"dev": true,
-			"license": "MIT",
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -12934,8 +13344,9 @@
 		},
 		"node_modules/jsprim": {
 			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -12954,6 +13365,15 @@
 				"source-map-support": "^0.5.5"
 			}
 		},
+		"node_modules/keyv": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
+			"dependencies": {
+				"json-buffer": "3.0.0"
+			}
+		},
 		"node_modules/kind-of": {
 			"version": "3.2.2",
 			"dev": true,
@@ -12967,8 +13387,9 @@
 		},
 		"node_modules/klaw": {
 			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
 			"dev": true,
-			"license": "MIT",
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.9"
 			}
@@ -12986,6 +13407,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/latest-version": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+			"dev": true,
+			"dependencies": {
+				"package-json": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/lazy-cache": {
@@ -13968,6 +14401,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"dev": true,
@@ -14262,8 +14704,9 @@
 		},
 		"node_modules/module-not-found-error": {
 			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+			"dev": true
 		},
 		"node_modules/moo-color": {
 			"version": "1.0.3",
@@ -14318,8 +14761,9 @@
 		},
 		"node_modules/ncp": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+			"integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"ncp": "bin/ncp"
 			}
@@ -14540,6 +14984,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/npm-bundled": {
 			"version": "3.0.0",
 			"dev": true,
@@ -14758,115 +15211,86 @@
 			}
 		},
 		"node_modules/nw-builder": {
-			"version": "3.8.6",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-3.7.4.tgz",
+			"integrity": "sha512-rkjoeGBl8YmFobIcsnJZsawr6yBvLJ74ml+j04LRDVRsqevDspih6zI1+ybA28RLLrcqzgR7nJivKaUlAcuS7g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"archiver": "^5.3.1",
-				"deprecate": "^1.1.1",
-				"graceful-fs-extra": "^2.0.0",
-				"inherits": "^2.0.4",
-				"lodash": "^4.17.21",
-				"nw-install": "^0.3.4",
-				"plist": "^3.0.5",
-				"progress": "^2.0.3",
-				"rcedit": "^3.0.1",
-				"recursive-readdir-sync": "^1.0.6",
-				"request": "^2.88.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.7",
-				"simple-glob": "^0.2.0",
-				"temp": "^0.9.4",
-				"thenify": "^3.3.1",
-				"winresourcer": "^0.9.0",
-				"yargs": "^17.5.1"
+				"archiver": "5.3.1",
+				"deprecate": "1.1.1",
+				"extract-zip": "2.0.1",
+				"graceful-fs-extra": "2.0.0",
+				"graceful-ncp": "3.0.0",
+				"inherits": "2.0.4",
+				"lodash": "4.17.21",
+				"plist": "3.0.5",
+				"progress": "2.0.3",
+				"rcedit": "3.0.1",
+				"recursive-readdir-sync": "1.0.6",
+				"request": "2.88.2",
+				"rimraf": "3.0.2",
+				"semver": "7.3.7",
+				"simple-glob": "0.2.0",
+				"tar-fs": "2.1.1",
+				"temp": "github:adam-lynch/node-temp#remove_tmpdir_dep",
+				"thenify": "3.3.1",
+				"update-notifier": "5.1.0",
+				"winresourcer": "0.9.0",
+				"yargs": "17.5.1"
 			},
 			"bin": {
 				"nwbuild": "bin/nwbuild.cjs"
 			}
 		},
-		"node_modules/nw-install": {
-			"version": "0.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cli-progress": "3.11.2",
-				"extract-zip": "2.0.1",
-				"tar": "6.1.11",
-				"yargs": "17.5.1"
-			},
-			"bin": {
-				"nw-install": "bin/nw-install.js"
-			}
-		},
-		"node_modules/nw-install/node_modules/cliui": {
+		"node_modules/nw-builder/node_modules/cliui": {
 			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/nw-install/node_modules/fs-minipass": {
-			"version": "2.1.0",
+		"node_modules/nw-builder/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/nw-install/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nw-install/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
-		"node_modules/nw-install/node_modules/tar": {
-			"version": "6.1.11",
+		"node_modules/nw-builder/node_modules/semver": {
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=10"
 			}
 		},
-		"node_modules/nw-install/node_modules/yallist": {
+		"node_modules/nw-builder/node_modules/yallist": {
 			"version": "4.0.0",
-			"dev": true,
-			"license": "ISC"
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
-		"node_modules/nw-install/node_modules/yargs": {
+		"node_modules/nw-builder/node_modules/yargs": {
 			"version": "17.5.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+			"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -15049,8 +15473,9 @@
 		},
 		"node_modules/oauth-sign": {
 			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
 			}
@@ -15283,6 +15708,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"dev": true,
@@ -15362,6 +15796,85 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/package-json": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+			"dev": true,
+			"dependencies": {
+				"got": "^9.6.0",
+				"registry-auth-token": "^4.0.0",
+				"registry-url": "^5.0.0",
+				"semver": "^6.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/package-json/node_modules/get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/package-json/node_modules/got": {
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"dev": true,
+			"dependencies": {
+				"@sindresorhus/is": "^0.14.0",
+				"@szmarczak/http-timer": "^1.1.2",
+				"cacheable-request": "^6.0.0",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^4.1.0",
+				"lowercase-keys": "^1.0.1",
+				"mimic-response": "^1.0.1",
+				"p-cancelable": "^1.0.0",
+				"to-readable-stream": "^1.0.0",
+				"url-parse-lax": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/package-json/node_modules/prepend-http": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/package-json/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/package-json/node_modules/url-parse-lax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+			"dev": true,
+			"dependencies": {
+				"prepend-http": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/pacote": {
@@ -15589,8 +16102,9 @@
 		},
 		"node_modules/performance-now": {
 			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+			"dev": true
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
@@ -15678,12 +16192,13 @@
 			}
 		},
 		"node_modules/plist": {
-			"version": "3.0.6",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+			"integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.5.1",
-				"xmlbuilder": "^15.1.1"
+				"xmlbuilder": "^9.0.7"
 			},
 			"engines": {
 				"node": ">=6"
@@ -15942,8 +16457,9 @@
 		},
 		"node_modules/proxyquire": {
 			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+			"integrity": "sha512-mZZq4F50qaBkngvlf9paNfaSb5gtJ0mFPnBjda4NxCpXpMAaVfSLguRr9y2KXF6koOSBf4AanD2inuEQw3aCcA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"fill-keys": "^1.0.2",
 				"module-not-found-error": "^1.0.0",
@@ -15952,8 +16468,9 @@
 		},
 		"node_modules/proxyquire/node_modules/resolve": {
 			"version": "1.1.7",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+			"dev": true
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",
@@ -15980,6 +16497,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/pupa": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+			"dev": true,
+			"dependencies": {
+				"escape-goat": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/puppeteer": {
@@ -16026,8 +16555,9 @@
 		},
 		"node_modules/qs": {
 			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -16095,10 +16625,41 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/rcedit": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rcedit/-/rcedit-3.0.1.tgz",
+			"integrity": "sha512-XM0Jv40/y4hVAqj/MO70o/IWs4uOsaSoo2mLyk3klFDW+SStLnCtzuQu+1OBTIMGlM8CvaK9ftlYCp6DJ+cMsw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"cross-spawn-windows-exe": "^1.1.0"
 			},
@@ -16285,8 +16846,9 @@
 		},
 		"node_modules/recursive-readdir-sync": {
 			"version": "1.0.6",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz",
+			"integrity": "sha512-QhkBh/V7T3L2m8FrwZEZ/VnSZU35bv7DSy/VlKVfcq10zvwwuxeuDLH7DZYFGHFyXefHchZmsHFLELR7poGjog==",
+			"dev": true
 		},
 		"node_modules/reflect-metadata": {
 			"version": "0.1.13",
@@ -16378,6 +16940,30 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/registry-auth-token": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+			"dev": true,
+			"dependencies": {
+				"rc": "1.2.8"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/registry-url": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+			"dev": true,
+			"dependencies": {
+				"rc": "^1.2.8"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/regjsgen": {
 			"version": "0.7.1",
 			"dev": true,
@@ -16411,8 +16997,10 @@
 		},
 		"node_modules/request": {
 			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -16441,8 +17029,9 @@
 		},
 		"node_modules/request/node_modules/form-data": {
 			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -16454,8 +17043,9 @@
 		},
 		"node_modules/request/node_modules/tough-cookie": {
 			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -16574,6 +17164,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+			"dev": true,
+			"dependencies": {
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -16888,6 +17487,27 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/semver-diff": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/semver-diff/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/semver/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"dev": true,
@@ -17152,6 +17772,8 @@
 		},
 		"node_modules/simple-glob": {
 			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.2.0.tgz",
+			"integrity": "sha512-CnCJ+SEDIWYviwBUp7pGxdq4QZgaR5xVzoxL/gujEwn2/vOJ4PVQrmd8Z0spH1cPsLxgF83cNjNcy4zYvSWiZA==",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.2",
@@ -17165,8 +17787,9 @@
 		},
 		"node_modules/simple-glob/node_modules/glob": {
 			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -17425,8 +18048,9 @@
 		},
 		"node_modules/sshpk": {
 			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -17732,43 +18356,22 @@
 			"license": "ISC"
 		},
 		"node_modules/temp": {
-			"version": "0.9.4",
+			"version": "0.8.3",
+			"resolved": "git+ssh://git@github.com/adam-lynch/node-temp.git#279c1350cb7e4f02515d91da9e35d39a40774016",
 			"dev": true,
+			"engines": [
+				"node >=4.0.0"
+			],
 			"license": "MIT",
 			"dependencies": {
-				"mkdirp": "^0.5.1",
-				"rimraf": "~2.6.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/temp/node_modules/glob": {
-			"version": "7.2.3",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"rimraf": "~2.2.6"
 			}
 		},
 		"node_modules/temp/node_modules/rimraf": {
-			"version": "2.6.3",
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+			"integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
 			"bin": {
 				"rimraf": "bin.js"
 			}
@@ -17919,8 +18522,9 @@
 		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
 			}
@@ -17976,6 +18580,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -18182,8 +18795,9 @@
 		},
 		"node_modules/tweetnacl": {
 			"version": "0.14.5",
-			"dev": true,
-			"license": "Unlicense"
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -18231,6 +18845,15 @@
 			"version": "1.0.9",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"dependencies": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "4.9.5",
@@ -18350,6 +18973,18 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/unique-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+			"dev": true,
+			"dependencies": {
+				"crypto-random-string": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -18397,6 +19032,86 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/update-notifier": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+			"integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+			"dev": true,
+			"dependencies": {
+				"boxen": "^5.0.0",
+				"chalk": "^4.1.0",
+				"configstore": "^5.0.1",
+				"has-yarn": "^2.1.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^2.0.0",
+				"is-installed-globally": "^0.4.0",
+				"is-npm": "^5.0.0",
+				"is-yarn-global": "^0.3.0",
+				"latest-version": "^5.1.0",
+				"pupa": "^2.1.1",
+				"semver": "^7.3.4",
+				"semver-diff": "^3.1.1",
+				"xdg-basedir": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
+			}
+		},
+		"node_modules/update-notifier/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/update-notifier/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/update-notifier/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/update-notifier/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/uri-js": {
@@ -18447,8 +19162,10 @@
 		},
 		"node_modules/uuid": {
 			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"uuid": "bin/uuid"
 			}
@@ -18501,11 +19218,12 @@
 		},
 		"node_modules/verror": {
 			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"dev": true,
 			"engines": [
 				"node >=0.6.0"
 			],
-			"license": "MIT",
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -18967,6 +19685,18 @@
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
+		"node_modules/widest-line": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wildcard": {
 			"version": "2.0.0",
 			"dev": true,
@@ -18984,6 +19714,8 @@
 		},
 		"node_modules/winresourcer": {
 			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/winresourcer/-/winresourcer-0.9.0.tgz",
+			"integrity": "sha512-0fYI+QlSFg1TXmFYRc4pGCk04mooQBiBCDbHmqjmo5kkfVjKo+fG6jzZA2qFEyiUBqJwlf/51zyeanV0YxjJSA==",
 			"dev": true,
 			"bin": {
 				"winresourcer": "lib/WinResourcer"
@@ -19065,6 +19797,15 @@
 				}
 			}
 		},
+		"node_modules/xdg-basedir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -19075,11 +19816,12 @@
 			}
 		},
 		"node_modules/xmlbuilder": {
-			"version": "15.1.1",
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=8.0"
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/xmlchars": {
@@ -21168,6 +21910,8 @@
 		},
 		"@malept/cross-spawn-promise": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.1"
@@ -21996,6 +22740,12 @@
 			"integrity": "sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==",
 			"dev": true
 		},
+		"@sindresorhus/is": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"dev": true
+		},
 		"@sinonjs/commons": {
 			"version": "1.8.6",
 			"dev": true,
@@ -22021,6 +22771,15 @@
 						"type-detect": "4.0.8"
 					}
 				}
+			}
+		},
+		"@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^1.0.1"
 			}
 		},
 		"@testing-library/angular": {
@@ -22801,6 +23560,15 @@
 			"dev": true,
 			"requires": {}
 		},
+		"ansi-align": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.1.0"
+			}
+		},
 		"ansi-colors": {
 			"version": "4.1.3",
 			"dev": true
@@ -22841,6 +23609,8 @@
 		},
 		"any-promise": {
 			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true
 		},
 		"anymatch": {
@@ -22965,6 +23735,8 @@
 		},
 		"asn1": {
 			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
@@ -22972,6 +23744,8 @@
 		},
 		"assert-plus": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true
 		},
 		"astral-regex": {
@@ -23006,10 +23780,14 @@
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
 			"dev": true
 		},
 		"aws4": {
 			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
 			"dev": true
 		},
 		"axios": {
@@ -23165,6 +23943,8 @@
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -23298,6 +24078,70 @@
 			"version": "1.0.0",
 			"dev": true
 		},
+		"boxen": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+			"integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+			"dev": true,
+			"requires": {
+				"ansi-align": "^3.0.0",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.1.0",
+				"cli-boxes": "^2.2.1",
+				"string-width": "^4.2.2",
+				"type-fest": "^0.20.2",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
+				}
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"requires": {
@@ -23405,6 +24249,38 @@
 				}
 			}
 		},
+		"cacheable-request": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"dev": true,
+			"requires": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^3.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^1.0.2"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				}
+			}
+		},
 		"call-bind": {
 			"version": "1.0.2",
 			"dev": true,
@@ -23440,6 +24316,8 @@
 		},
 		"caseless": {
 			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
 			"dev": true
 		},
 		"caw": {
@@ -23529,18 +24407,17 @@
 			"version": "2.2.0",
 			"dev": true
 		},
+		"cli-boxes": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+			"dev": true
+		},
 		"cli-cursor": {
 			"version": "3.1.0",
 			"dev": true,
 			"requires": {
 				"restore-cursor": "^3.1.0"
-			}
-		},
-		"cli-progress": {
-			"version": "3.11.2",
-			"dev": true,
-			"requires": {
-				"string-width": "^4.2.3"
 			}
 		},
 		"cli-spinners": {
@@ -23616,6 +24493,15 @@
 				"kind-of": "^3.0.2",
 				"lazy-cache": "^1.0.3",
 				"shallow-clone": "^0.1.2"
+			}
+		},
+		"clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"co": {
@@ -23726,6 +24612,34 @@
 			"dependencies": {
 				"ini": {
 					"version": "1.3.8"
+				}
+			}
+		},
+		"configstore": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "^5.2.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^3.0.0",
+				"unique-string": "^2.0.0",
+				"write-file-atomic": "^3.0.0",
+				"xdg-basedir": "^4.0.0"
+			},
+			"dependencies": {
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
+					}
 				}
 			}
 		},
@@ -23907,6 +24821,8 @@
 		},
 		"cross-spawn-windows-exe": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
+			"integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
 			"dev": true,
 			"requires": {
 				"@malept/cross-spawn-promise": "^1.1.0",
@@ -23916,6 +24832,12 @@
 		},
 		"crypt": {
 			"version": "0.0.2"
+		},
+		"crypto-random-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+			"dev": true
 		},
 		"css-loader": {
 			"version": "6.7.3",
@@ -23990,6 +24912,8 @@
 		},
 		"dashdash": {
 			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
@@ -24046,6 +24970,15 @@
 						}
 					}
 				}
+			}
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"decompress-tar": {
@@ -24185,6 +25118,12 @@
 				"which-typed-array": "^1.1.9"
 			}
 		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
+		},
 		"deep-is": {
 			"version": "0.1.4",
 			"dev": true
@@ -24208,6 +25147,12 @@
 			"requires": {
 				"clone": "^1.0.2"
 			}
+		},
+		"defer-to-connect": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+			"dev": true
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
@@ -24239,6 +25184,8 @@
 		},
 		"deprecate": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.1.tgz",
+			"integrity": "sha512-ZGDXefq1xknT292LnorMY5s8UVU08/WKdzDZCUT6t9JzsiMSP4uzUhgpqugffNVcT5WC6wMBiSQ+LFjlv3v7iQ==",
 			"dev": true
 		},
 		"dequal": {
@@ -24348,6 +25295,15 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"requires": {
+				"is-obj": "^2.0.0"
+			}
+		},
 		"download": {
 			"version": "5.0.3",
 			"requires": {
@@ -24376,6 +25332,8 @@
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
 			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
@@ -24520,6 +25478,12 @@
 		},
 		"escalade": {
 			"version": "3.1.1"
+		},
+		"escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -24981,6 +25945,8 @@
 		},
 		"extend": {
 			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
 		"external-editor": {
@@ -25013,6 +25979,8 @@
 		},
 		"extsprintf": {
 			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
 			"dev": true
 		},
 		"fast-deep-equal": {
@@ -25100,6 +26068,8 @@
 		},
 		"fill-keys": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
 			"dev": true,
 			"requires": {
 				"is-object": "~1.0.1",
@@ -25251,6 +26221,8 @@
 		},
 		"forever-agent": {
 			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
 			"dev": true
 		},
 		"form-data": {
@@ -25289,6 +26261,8 @@
 		},
 		"fs-extra": {
 			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+			"integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -25300,6 +26274,8 @@
 			"dependencies": {
 				"glob": {
 					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -25312,6 +26288,8 @@
 				},
 				"rimraf": {
 					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -25393,6 +26371,8 @@
 		},
 		"getpass": {
 			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
@@ -25435,6 +26415,23 @@
 		"glob-to-regexp": {
 			"version": "0.4.1",
 			"dev": true
+		},
+		"global-dirs": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+			"integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+			"dev": true,
+			"requires": {
+				"ini": "2.0.0"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+					"dev": true
+				}
+			}
 		},
 		"global-modules": {
 			"version": "0.2.3",
@@ -25519,6 +26516,8 @@
 		},
 		"graceful-fs-extra": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/graceful-fs-extra/-/graceful-fs-extra-2.0.0.tgz",
+			"integrity": "sha512-TdHFKs8ZsxSlywA/8yU8IVJpRMzyTkOQlYNRWes1yjImhZ2BPhnYmXTOnMSkD6SDCwqglIWYUENGeqR7IVXg6Q==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "^0.30.0",
@@ -25528,6 +26527,8 @@
 		},
 		"graceful-ncp": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/graceful-ncp/-/graceful-ncp-3.0.0.tgz",
+			"integrity": "sha512-G6QJTyxiW0lO0njYNx3572+d4BbsxvfayjndnP4cDTjQss+yK5f/p5+DjOBo1gk561ULfKo9nrdtSP6rQyQZJA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.4",
@@ -25545,10 +26546,14 @@
 		},
 		"har-schema": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
 			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.3",
@@ -25609,6 +26614,12 @@
 		},
 		"has-unicode": {
 			"version": "2.0.1",
+			"dev": true
+		},
+		"has-yarn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
 			"dev": true
 		},
 		"hdr-histogram-js": {
@@ -25807,6 +26818,8 @@
 		},
 		"http-signature": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -25896,6 +26909,12 @@
 					"dev": true
 				}
 			}
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+			"dev": true
 		},
 		"import-local": {
 			"version": "3.1.0",
@@ -26062,6 +27081,23 @@
 			"version": "1.2.7",
 			"dev": true
 		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				}
+			}
+		},
 		"is-core-module": {
 			"version": "2.11.0",
 			"requires": {
@@ -26103,6 +27139,16 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-installed-globally": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+			"dev": true,
+			"requires": {
+				"global-dirs": "^3.0.0",
+				"is-path-inside": "^3.0.2"
+			}
+		},
 		"is-interactive": {
 			"version": "1.0.0",
 			"dev": true
@@ -26118,6 +27164,12 @@
 		"is-natural-number": {
 			"version": "4.0.1"
 		},
+		"is-npm": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"dev": true
@@ -26128,6 +27180,12 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
+		},
+		"is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.2"
@@ -26205,6 +27263,8 @@
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
 			"dev": true
 		},
 		"is-unicode-supported": {
@@ -26238,6 +27298,12 @@
 				"is-docker": "^2.0.0"
 			}
 		},
+		"is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+			"dev": true
+		},
 		"isarray": {
 			"version": "2.0.5",
 			"dev": true
@@ -26252,6 +27318,8 @@
 		},
 		"isstream": {
 			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -27838,6 +28906,8 @@
 		},
 		"jsbn": {
 			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
 			"dev": true
 		},
 		"jsdom": {
@@ -27878,12 +28948,20 @@
 			"version": "2.5.2",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+			"dev": true
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"dev": true
 		},
 		"json-schema": {
 			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -27895,6 +28973,8 @@
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
 		"json5": {
@@ -27907,6 +28987,8 @@
 		},
 		"jsonfile": {
 			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
@@ -27918,6 +29000,8 @@
 		},
 		"jsprim": {
 			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
@@ -27933,6 +29017,15 @@
 				"source-map-support": "^0.5.5"
 			}
 		},
+		"keyv": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.0"
+			}
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"dev": true,
@@ -27942,6 +29035,8 @@
 		},
 		"klaw": {
 			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.9"
@@ -27953,6 +29048,15 @@
 		},
 		"klona": {
 			"version": "2.0.6"
+		},
+		"latest-version": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+			"dev": true,
+			"requires": {
+				"package-json": "^6.3.0"
+			}
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
@@ -28599,6 +29703,12 @@
 			"version": "2.1.0",
 			"dev": true
 		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true
+		},
 		"min-indent": {
 			"version": "1.0.1",
 			"dev": true
@@ -28807,6 +29917,8 @@
 		},
 		"module-not-found-error": {
 			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
 			"dev": true
 		},
 		"moo-color": {
@@ -28846,6 +29958,8 @@
 		},
 		"ncp": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+			"integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
 			"dev": true
 		},
 		"needle": {
@@ -28992,6 +30106,12 @@
 		},
 		"normalize-range": {
 			"version": "0.1.2",
+			"dev": true
+		},
+		"normalize-url": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
 			"dev": true
 		},
 		"npm-bundled": {
@@ -29270,41 +30390,38 @@
 			}
 		},
 		"nw-builder": {
-			"version": "3.8.6",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-3.7.4.tgz",
+			"integrity": "sha512-rkjoeGBl8YmFobIcsnJZsawr6yBvLJ74ml+j04LRDVRsqevDspih6zI1+ybA28RLLrcqzgR7nJivKaUlAcuS7g==",
 			"dev": true,
 			"requires": {
-				"archiver": "^5.3.1",
-				"deprecate": "^1.1.1",
-				"graceful-fs-extra": "^2.0.0",
-				"inherits": "^2.0.4",
-				"lodash": "^4.17.21",
-				"nw-install": "^0.3.4",
-				"plist": "^3.0.5",
-				"progress": "^2.0.3",
-				"rcedit": "^3.0.1",
-				"recursive-readdir-sync": "^1.0.6",
-				"request": "^2.88.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.7",
-				"simple-glob": "^0.2.0",
-				"temp": "^0.9.4",
-				"thenify": "^3.3.1",
-				"winresourcer": "^0.9.0",
-				"yargs": "^17.5.1"
-			}
-		},
-		"nw-install": {
-			"version": "0.3.4",
-			"dev": true,
-			"requires": {
-				"cli-progress": "3.11.2",
+				"archiver": "5.3.1",
+				"deprecate": "1.1.1",
 				"extract-zip": "2.0.1",
-				"tar": "6.1.11",
+				"graceful-fs-extra": "2.0.0",
+				"graceful-ncp": "3.0.0",
+				"inherits": "2.0.4",
+				"lodash": "4.17.21",
+				"plist": "3.0.5",
+				"progress": "2.0.3",
+				"rcedit": "3.0.1",
+				"recursive-readdir-sync": "1.0.6",
+				"request": "2.88.2",
+				"rimraf": "3.0.2",
+				"semver": "7.3.7",
+				"simple-glob": "0.2.0",
+				"tar-fs": "2.1.1",
+				"temp": "github:adam-lynch/node-temp#remove_tmpdir_dep",
+				"thenify": "3.3.1",
+				"update-notifier": "5.1.0",
+				"winresourcer": "0.9.0",
 				"yargs": "17.5.1"
 			},
 			"dependencies": {
 				"cliui": {
 					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "^4.2.0",
@@ -29312,42 +30429,34 @@
 						"wrap-ansi": "^7.0.0"
 					}
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
-				"minipass": {
-					"version": "3.3.6",
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
 				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"dev": true
-				},
-				"tar": {
-					"version": "6.1.11",
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 					"dev": true,
 					"requires": {
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"minipass": "^3.0.0",
-						"minizlib": "^2.1.1",
-						"mkdirp": "^1.0.3",
-						"yallist": "^4.0.0"
+						"lru-cache": "^6.0.0"
 					}
 				},
 				"yallist": {
 					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				},
 				"yargs": {
 					"version": "17.5.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+					"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
 					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",
@@ -29369,6 +30478,8 @@
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"object-assign": {
@@ -29506,6 +30617,12 @@
 			"version": "1.0.2",
 			"dev": true
 		},
+		"p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true
+		},
 		"p-limit": {
 			"version": "3.1.0",
 			"dev": true,
@@ -29553,6 +30670,69 @@
 		"p-try": {
 			"version": "2.2.0",
 			"dev": true
+		},
+		"package-json": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+			"dev": true,
+			"requires": {
+				"got": "^9.6.0",
+				"registry-auth-token": "^4.0.0",
+				"registry-url": "^5.0.0",
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "9.6.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "^0.14.0",
+						"@szmarczak/http-timer": "^1.1.2",
+						"cacheable-request": "^6.0.0",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^4.1.0",
+						"lowercase-keys": "^1.0.1",
+						"mimic-response": "^1.0.1",
+						"p-cancelable": "^1.0.0",
+						"to-readable-stream": "^1.0.0",
+						"url-parse-lax": "^3.0.0"
+					}
+				},
+				"prepend-http": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+					"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"url-parse-lax": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+					"integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+					"dev": true,
+					"requires": {
+						"prepend-http": "^2.0.0"
+					}
+				}
+			}
 		},
 		"pacote": {
 			"version": "15.0.8",
@@ -29715,6 +30895,8 @@
 		},
 		"performance-now": {
 			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
 			"dev": true
 		},
 		"picocolors": {
@@ -29767,11 +30949,13 @@
 			}
 		},
 		"plist": {
-			"version": "3.0.6",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+			"integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
 			"dev": true,
 			"requires": {
 				"base64-js": "^1.5.1",
-				"xmlbuilder": "^15.1.1"
+				"xmlbuilder": "^9.0.7"
 			}
 		},
 		"pluralize": {
@@ -29915,6 +31099,8 @@
 		},
 		"proxyquire": {
 			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+			"integrity": "sha512-mZZq4F50qaBkngvlf9paNfaSb5gtJ0mFPnBjda4NxCpXpMAaVfSLguRr9y2KXF6koOSBf4AanD2inuEQw3aCcA==",
 			"dev": true,
 			"requires": {
 				"fill-keys": "^1.0.2",
@@ -29924,6 +31110,8 @@
 			"dependencies": {
 				"resolve": {
 					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
 					"dev": true
 				}
 			}
@@ -29947,6 +31135,15 @@
 		},
 		"punycode": {
 			"version": "2.3.0"
+		},
+		"pupa": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+			"dev": true,
+			"requires": {
+				"escape-goat": "^2.0.0"
+			}
 		},
 		"puppeteer": {
 			"version": "17.1.3",
@@ -29974,6 +31171,8 @@
 		},
 		"qs": {
 			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"querystringify": {
@@ -30013,8 +31212,36 @@
 				}
 			}
 		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "1.3.8",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+					"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+					"dev": true
+				}
+			}
+		},
 		"rcedit": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rcedit/-/rcedit-3.0.1.tgz",
+			"integrity": "sha512-XM0Jv40/y4hVAqj/MO70o/IWs4uOsaSoo2mLyk3klFDW+SStLnCtzuQu+1OBTIMGlM8CvaK9ftlYCp6DJ+cMsw==",
 			"dev": true,
 			"requires": {
 				"cross-spawn-windows-exe": "^1.1.0"
@@ -30150,6 +31377,8 @@
 		},
 		"recursive-readdir-sync": {
 			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz",
+			"integrity": "sha512-QhkBh/V7T3L2m8FrwZEZ/VnSZU35bv7DSy/VlKVfcq10zvwwuxeuDLH7DZYFGHFyXefHchZmsHFLELR7poGjog==",
 			"dev": true
 		},
 		"reflect-metadata": {
@@ -30211,6 +31440,24 @@
 				"unicode-match-property-value-ecmascript": "^2.1.0"
 			}
 		},
+		"registry-auth-token": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.8"
+			}
+		},
+		"registry-url": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+			"dev": true,
+			"requires": {
+				"rc": "^1.2.8"
+			}
+		},
 		"regjsgen": {
 			"version": "0.7.1",
 			"dev": true
@@ -30234,6 +31481,8 @@
 		},
 		"request": {
 			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -30260,6 +31509,8 @@
 			"dependencies": {
 				"form-data": {
 					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -30269,6 +31520,8 @@
 				},
 				"tough-cookie": {
 					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
@@ -30348,6 +31601,15 @@
 			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
 			"integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
 			"dev": true
+		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^1.0.0"
+			}
 		},
 		"restore-cursor": {
 			"version": "3.1.0",
@@ -30531,6 +31793,23 @@
 				},
 				"yallist": {
 					"version": "4.0.0",
+					"dev": true
+				}
+			}
+		},
+		"semver-diff": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -30720,6 +31999,8 @@
 		},
 		"simple-glob": {
 			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.2.0.tgz",
+			"integrity": "sha512-CnCJ+SEDIWYviwBUp7pGxdq4QZgaR5xVzoxL/gujEwn2/vOJ4PVQrmd8Z0spH1cPsLxgF83cNjNcy4zYvSWiZA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.2",
@@ -30730,6 +32011,8 @@
 			"dependencies": {
 				"glob": {
 					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -30912,6 +32195,8 @@
 		},
 		"sshpk": {
 			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -31114,31 +32399,18 @@
 			}
 		},
 		"temp": {
-			"version": "0.9.4",
+			"version": "git+ssh://git@github.com/adam-lynch/node-temp.git#279c1350cb7e4f02515d91da9e35d39a40774016",
 			"dev": true,
+			"from": "temp@github:adam-lynch/node-temp#remove_tmpdir_dep",
 			"requires": {
-				"mkdirp": "^0.5.1",
-				"rimraf": "~2.6.2"
+				"rimraf": "~2.2.6"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.2.3",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.1.1",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"rimraf": {
-					"version": "2.6.3",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+					"dev": true
 				}
 			}
 		},
@@ -31229,6 +32501,8 @@
 		},
 		"thenify": {
 			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"dev": true,
 			"requires": {
 				"any-promise": "^1.0.0"
@@ -31268,6 +32542,12 @@
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
+			"dev": true
+		},
+		"to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -31385,6 +32665,8 @@
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true
 		},
 		"type-check": {
@@ -31413,6 +32695,15 @@
 		"typed-assert": {
 			"version": "1.0.9",
 			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"typescript": {
 			"version": "4.9.5",
@@ -31491,6 +32782,15 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"unique-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "^2.0.0"
+			}
+		},
 		"universalify": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -31510,6 +32810,64 @@
 			"requires": {
 				"escalade": "^3.1.1",
 				"picocolors": "^1.0.0"
+			}
+		},
+		"update-notifier": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+			"integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+			"dev": true,
+			"requires": {
+				"boxen": "^5.0.0",
+				"chalk": "^4.1.0",
+				"configstore": "^5.0.1",
+				"has-yarn": "^2.1.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^2.0.0",
+				"is-installed-globally": "^0.4.0",
+				"is-npm": "^5.0.0",
+				"is-yarn-global": "^0.3.0",
+				"latest-version": "^5.1.0",
+				"pupa": "^2.1.1",
+				"semver": "^7.3.4",
+				"semver-diff": "^3.1.1",
+				"xdg-basedir": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"uri-js": {
@@ -31546,6 +32904,8 @@
 		},
 		"uuid": {
 			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8-compile-cache-lib": {
@@ -31583,6 +32943,8 @@
 		},
 		"verror": {
 			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -31892,6 +33254,15 @@
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
+		"widest-line": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.0.0"
+			}
+		},
 		"wildcard": {
 			"version": "2.0.0",
 			"dev": true
@@ -31901,6 +33272,8 @@
 		},
 		"winresourcer": {
 			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/winresourcer/-/winresourcer-0.9.0.tgz",
+			"integrity": "sha512-0fYI+QlSFg1TXmFYRc4pGCk04mooQBiBCDbHmqjmo5kkfVjKo+fG6jzZA2qFEyiUBqJwlf/51zyeanV0YxjJSA==",
 			"dev": true
 		},
 		"word-wrap": {
@@ -31941,6 +33314,12 @@
 			"dev": true,
 			"requires": {}
 		},
+		"xdg-basedir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+			"dev": true
+		},
 		"xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -31948,7 +33327,9 @@
 			"dev": true
 		},
 		"xmlbuilder": {
-			"version": "15.1.1",
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
 			"dev": true
 		},
 		"xmlchars": {

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -128,7 +128,7 @@
 		"jest-puppeteer": "^6.1.1",
 		"lint-staged": "^13.0.0",
 		"marked": "^4.3.0",
-		"nw-builder": "^3.7.4",
+		"nw-builder": "3.7.4",
 		"puppeteer": "^17.0.0",
 		"ts-jest": "^29.0.5",
 		"typescript": "~4.9.4",


### PR DESCRIPTION
# Fix the `npm i` and `npm ci` of our developer dependencies in visualization

Fix the version of nw-builder to 3.7.4 (from 3.8.6 in package-lock.json)

Version 3.8.6 requires nw-install, a package that is no longer distributed over npm-registry. This caused the installation to fail, because the dependency could not be downloaded, as it no longer exists on the server.

[nw-builder 3.8.6](https://www.npmjs.com/package/nw-builder/v/3.8.6?activeTab=dependencies)
[nw-install dependency](https://www.npmjs.com/package/nw-install)

Closes #3313 
