### PR TITLE
feature/3320/print-parser-before-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Expand and restructure documentation regarding Docker usage [#3312](https://github.com/MaibornWolff/codecharta/pull/3312)
 -   Add current working directories as hint or default value to interactive parser and parser suggestions when asking for input [#3319](https://github.com/MaibornWolff/codecharta/pull/3319)
 -   Add helpful status messages when calculating parser suggestions [#3329](https://github.com/MaibornWolff/codecharta/pull/3329)
+-   Add message outputting which parser is being configured during parser suggestions [#3335](https://github.com/MaibornWolff/codecharta/pull/3335)
 
 ### Fixed 🐞
 

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/ParserService.kt
@@ -20,6 +20,7 @@ class ParserService {
         fun configureParserSelection(commandLine: CommandLine, parserRepository: PicocliParserRepository, selectedParsers: List<String>): Map<String, List<String>> {
             val configuredParsers = mutableMapOf<String, List<String>>()
             for (selectedParser in selectedParsers) {
+                println(System.lineSeparator() + "Now configuring $selectedParser.")
                 val interactiveParser = parserRepository.getInteractiveParser(commandLine, selectedParser)
                 if (interactiveParser == null) {
                     throw IllegalArgumentException("Tried to configure non existing parser!")

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/ParserServiceTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/ParserServiceTest.kt
@@ -124,6 +124,7 @@ class ParserServiceTest {
                 "modify",
                 "csvexport",
                 "codemaatimport")
+
         val mockPicocliParserRepository = mockParserRepository(selectedParserList[0], emptyList())
 
         val configuredParsers = ParserService.configureParserSelection(cmdLine, mockPicocliParserRepository, selectedParserList)
@@ -166,6 +167,16 @@ class ParserServiceTest {
         Assertions.assertThatExceptionOfType(NoSuchElementException::class.java).isThrownBy {
             ParserService.executePreconfiguredParser(cmdLine, Pair("unknownparser", listOf("dummyArg")))
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("providerParserArguments")
+    fun `should output message informing about which parser is being configured`(parser: String) {
+        val mockParserRepository = mockParserRepository(parser, listOf(parser))
+
+        ParserService.configureParserSelection(cmdLine, mockParserRepository, listOf(parser))
+
+        Assertions.assertThat(outContent.toString()).contains("Now configuring $parser.")
     }
 
     private fun mockParserObject(name: String): InteractiveParser {


### PR DESCRIPTION
# Output which parser is currently being configured

Issue: #3320 

## Description

This PR adds a message telling which parser is being configured before the interactive dialog of each parser that was chosen. 