### PR TITLE
Fix/3321/fix stuck metric gardener importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix command not found issue for --version and --help in the analysis [#3377](https://github.com/MaibornWolff/codecharta/pull/3377)
+-   Fix metric gardener importer getting stuck for large inputs [#3382](https://github.com/MaibornWolff/codecharta/pull/3382)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/analysis/import/MetricGardenerImporter/build.gradle
+++ b/analysis/import/MetricGardenerImporter/build.gradle
@@ -15,8 +15,6 @@ dependencies {
     implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jersey_version
     implementation group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
 
-    implementation group: 'com.lordcodes.turtle', name: 'turtle', version: '0.8.0'
-
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junit5_version
     testImplementation group: 'org.assertj', name: 'assertj-core', version: assertj_version
     testImplementation group: 'io.mockk', name: 'mockk', version: mockk_version

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -9,13 +9,13 @@ import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.tools.interactiveparser.util.InteractiveParserHelper
 import de.maibornwolff.codecharta.util.InputHelper
 import de.maibornwolff.codecharta.util.ResourceSearchHelper
+import jdk.jshell.spi.ExecutionControl.InternalException
 import picocli.CommandLine
 import java.io.File
 import java.io.IOException
 import java.io.PrintStream
 import java.nio.charset.Charset
 import java.util.concurrent.Callable
-import kotlin.system.exitProcess
 
 @CommandLine.Command(
     name = InteractiveParserHelper.MetricGardenerImporterConstants.name,
@@ -74,8 +74,7 @@ class MetricGardenerImporter(
                     .waitFor()
             inputFile = tempMgOutput
             if (processExitCode != 0) {
-                println("Error while executing metric gardener! Process returned with status $processExitCode.")
-                exitProcess(processExitCode)
+                throw InternalException("Error while executing metric gardener! Process returned with status $processExitCode.")
             }
         }
         val metricGardenerNodes: MetricGardenerNodes =

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -15,6 +15,7 @@ import java.io.IOException
 import java.io.PrintStream
 import java.nio.charset.Charset
 import java.util.concurrent.Callable
+import kotlin.system.exitProcess
 
 @CommandLine.Command(
     name = InteractiveParserHelper.MetricGardenerImporterConstants.name,
@@ -65,13 +66,17 @@ class MetricGardenerImporter(
                 inputFile!!.absolutePath, "--output-path", tempMgOutput.absolutePath
             )
             println("Running metric gardener, this might take some time for larger inputs...")
-            ProcessBuilder(commandToExecute)
+            val processExitCode = ProcessBuilder(commandToExecute)
                     // Not actively discarding or redirecting the output of MetricGardener loses performance on larger folders
                     .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                     .redirectError(ProcessBuilder.Redirect.INHERIT)
                     .start()
                     .waitFor()
             inputFile = tempMgOutput
+            if (processExitCode != 0) {
+                println("Error while executing metric gardener! Process returned with status $processExitCode.")
+                exitProcess(processExitCode)
+            }
         }
         val metricGardenerNodes: MetricGardenerNodes =
             mapper.readValue(inputFile!!.reader(Charset.defaultCharset()), MetricGardenerNodes::class.java)

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.codecharta.importer.metricgardenerimporter
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.maibornwolff.codecharta.importer.metricgardenerimporter.json.MetricGardenerProjectBuilder
+import de.maibornwolff.codecharta.importer.metricgardenerimporter.model.MetricGardenerException
 import de.maibornwolff.codecharta.importer.metricgardenerimporter.model.MetricGardenerNodes
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
@@ -9,7 +10,6 @@ import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.tools.interactiveparser.util.InteractiveParserHelper
 import de.maibornwolff.codecharta.util.InputHelper
 import de.maibornwolff.codecharta.util.ResourceSearchHelper
-import jdk.jshell.spi.ExecutionControl.InternalException
 import picocli.CommandLine
 import java.io.File
 import java.io.IOException
@@ -74,7 +74,7 @@ class MetricGardenerImporter(
                     .waitFor()
             inputFile = tempMgOutput
             if (processExitCode != 0) {
-                throw InternalException("Error while executing metric gardener! Process returned with status $processExitCode.")
+                throw MetricGardenerException("Error while executing metric gardener! Process returned with status $processExitCode.")
             }
         }
         val metricGardenerNodes: MetricGardenerNodes =

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -1,7 +1,6 @@
 package de.maibornwolff.codecharta.importer.metricgardenerimporter
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.lordcodes.turtle.ShellLocation
 import de.maibornwolff.codecharta.importer.metricgardenerimporter.json.MetricGardenerProjectBuilder
 import de.maibornwolff.codecharta.importer.metricgardenerimporter.model.MetricGardenerNodes
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
@@ -61,18 +60,18 @@ class MetricGardenerImporter(
             tempMgOutput.deleteOnExit()
 
             val npm = if (isWindows()) "npm.cmd" else "npm"
-            val processStartTime = System.currentTimeMillis() * 0.001
             val commandToExecute = listOf(
                 npm, "exec", "-y", "metric-gardener", "--", "parse",
                 inputFile!!.absolutePath, "--output-path", tempMgOutput.absolutePath
             )
             println("Running metric gardener, this might take some time for larger inputs...")
+            val processStartTime = System.currentTimeMillis() * 0.001
             ProcessBuilder(commandToExecute)
-                .redirectOutput(ProcessBuilder.Redirect.DISCARD) // we need to actively discard the output or redirect it, otherwise the program hangs for larger outputs of MetricGardener
-                .redirectError(ProcessBuilder.Redirect.INHERIT)
-                .directory(ShellLocation.CURRENT_WORKING) // check if this is necessary. If not, we completely remove the dependency on turtle package
-                .start()
-                .waitFor()
+                    // not actively discarding or redirecting the output of MetricGardener loses performance on larger folders
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.INHERIT)
+                    .start()
+                    .waitFor()
             val processEndTime = System.currentTimeMillis() * 0.001
             println("Metric gardener execution completed in %.2fs.".format(processEndTime - processStartTime))
             inputFile = tempMgOutput

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporter.kt
@@ -65,15 +65,12 @@ class MetricGardenerImporter(
                 inputFile!!.absolutePath, "--output-path", tempMgOutput.absolutePath
             )
             println("Running metric gardener, this might take some time for larger inputs...")
-            val processStartTime = System.currentTimeMillis() * 0.001
             ProcessBuilder(commandToExecute)
-                    // not actively discarding or redirecting the output of MetricGardener loses performance on larger folders
+                    // Not actively discarding or redirecting the output of MetricGardener loses performance on larger folders
                     .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                     .redirectError(ProcessBuilder.Redirect.INHERIT)
                     .start()
                     .waitFor()
-            val processEndTime = System.currentTimeMillis() * 0.001
-            println("Metric gardener execution completed in %.2fs.".format(processEndTime - processStartTime))
             inputFile = tempMgOutput
         }
         val metricGardenerNodes: MetricGardenerNodes =

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerException.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerException.kt
@@ -1,8 +1,3 @@
 package de.maibornwolff.codecharta.importer.metricgardenerimporter.model
 
-class MetricGardenerException : Exception {
-    constructor() : super()
-    constructor(message: String) : super(message)
-    constructor(message: String, cause: Throwable) : super(message, cause)
-    constructor(cause: Throwable) : super(cause)
-}
+class MetricGardenerException(message: String) : Exception(message)

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerException.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerException.kt
@@ -1,0 +1,8 @@
+package de.maibornwolff.codecharta.importer.metricgardenerimporter.model
+
+class MetricGardenerException : Exception {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
@@ -142,13 +142,14 @@ class MetricGardenerImporterTest {
 
     @Test
     fun `should stop execution if error happens while executing metric gardener`() {
+        val npm = if (System.getProperty("os.name").contains("win", ignoreCase = true)) "npm.cmd" else "npm"
         val metricGardenerInvalidCommand = listOf(
-                "npm", "exec", "metric-gardener",
+                npm, "exec", "metric-gardener",
                 "--", "parse", "this/path/is/invalid", "-o", "MGout.json"
         )
         val metricGardenerInvalidInputProcess = ProcessBuilder(metricGardenerInvalidCommand)
         mockkConstructor(ProcessBuilder::class)
-        every { anyConstructed<ProcessBuilder>().start().waitFor() } returns metricGardenerInvalidInputProcess.inheritIO().start().waitFor()
+        every { anyConstructed<ProcessBuilder>().start().waitFor() } returns metricGardenerInvalidInputProcess.start().waitFor()
 
         System.setErr(PrintStream(errContent))
         CommandLine(MetricGardenerImporter()).execute("src").toString()

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
@@ -149,7 +149,10 @@ class MetricGardenerImporterTest {
         )
         val metricGardenerInvalidInputProcess = ProcessBuilder(metricGardenerInvalidCommand)
         mockkConstructor(ProcessBuilder::class)
-        every { anyConstructed<ProcessBuilder>().start().waitFor() } returns metricGardenerInvalidInputProcess.start().waitFor()
+        every { anyConstructed<ProcessBuilder>().start().waitFor() } returns metricGardenerInvalidInputProcess
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+                .waitFor()
 
         System.setErr(PrintStream(errContent))
         CommandLine(MetricGardenerImporter()).execute("src").toString()

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
@@ -4,6 +4,7 @@ import de.maibornwolff.codecharta.importer.metricgardenerimporter.MetricGardener
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
@@ -137,5 +138,21 @@ class MetricGardenerImporterTest {
         System.setErr(originalErr)
 
         Assertions.assertThat(errContent.toString()).contains("Input invalid file for MetricGardenerImporter, stopping execution")
+    }
+
+    @Test
+    fun `should stop execution if error happens while executing metric gardener`() {
+        val metricGardenerInvalidCommand = listOf(
+                "npm", "exec", "metric-gardener",
+                "--", "parse", "this/path/is/invalid", "-o", "MGout.json"
+        )
+        val metricGardenerInvalidInputProcess = ProcessBuilder(metricGardenerInvalidCommand)
+        mockkConstructor(ProcessBuilder::class)
+        every { anyConstructed<ProcessBuilder>().start().waitFor() } returns metricGardenerInvalidInputProcess.inheritIO().start().waitFor()
+
+        System.setErr(PrintStream(errContent))
+        CommandLine(MetricGardenerImporter()).execute("src").toString()
+        System.setErr(originalErr)
+        Assertions.assertThat(errContent.toString()).contains("Error while executing metric gardener! Process returned with status")
     }
 }


### PR DESCRIPTION
# Fix metric gardener importer getting stuck on larger folders

A known issue in the ShellRun function caused extensive runtimes for folders where the output of metric gardener was long. This was fixed by swapping out the ShellRun function for ProcessBuilder and discarding the output of metric gardener.

Issue: #3321

## Notes

Tested on Mac in zsh shell
