### PR TITLE
feature/3338/improve-parser-suggestion-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+-   Only ask to merge results after parser suggestion execution when more than one parser was executed [#3384](https://github.com/MaibornWolff/codecharta/pull/3384)
+
 ### Fixed 🐞
 
 -   Fix command not found issue for --version and --help in the analysis [#3377](https://github.com/MaibornWolff/codecharta/pull/3377)

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -137,14 +137,14 @@ class Ccsh : Callable<Void?> {
             if (finalExitCode != 0) {
                 return finalExitCode
             }
-            // Improvement: Try to extract merge commands before so user does not have to configure merge args?
             if (configuredParsers.size == 1) {
                 logger.info { "Parser was successfully executed and created a cc.json file." }
                 return 0
-            } else {
-                logger.info { "Each parser was successfully executed and created a cc.json file." }
-                return askAndMergeResults(commandLine)
             }
+
+            // Improvement: Try to extract merge commands before so user does not have to configure merge args?
+            logger.info { "Each parser was successfully executed and created a cc.json file." }
+            return askAndMergeResults(commandLine)
         }
 
         private fun askAndMergeResults(commandLine: CommandLine): Int {

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -138,12 +138,12 @@ class Ccsh : Callable<Void?> {
                 return finalExitCode
             }
             // Improvement: Try to extract merge commands before so user does not have to configure merge args?
-            return if (configuredParsers.size == 1) {
+            if (configuredParsers.size == 1) {
                 logger.info { "Parser was successfully executed and created a cc.json file." }
-                0
+                return 0
             } else {
                 logger.info { "Each parser was successfully executed and created a cc.json file." }
-                askAndMergeResults(commandLine)
+                return askAndMergeResults(commandLine)
             }
         }
 

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -125,7 +125,7 @@ class Ccsh : Callable<Void?> {
                     val currentExitCode = executeConfiguredParser(commandLine, configuredParser)
                     if (currentExitCode != 0) {
                         exitCode.set(currentExitCode)
-                        logger.info("Code: $currentExitCode")
+                        logger.info { "Code: $currentExitCode" }
                     }
                 }
             }
@@ -133,13 +133,18 @@ class Ccsh : Callable<Void?> {
             threadPool.awaitTermination(1, TimeUnit.DAYS)
 
             val finalExitCode = exitCode.get()
-            logger.info("Code: $finalExitCode")
+            logger.info { "Code: $finalExitCode" }
             if (finalExitCode != 0) {
                 return finalExitCode
             }
             // Improvement: Try to extract merge commands before so user does not have to configure merge args?
-            logger.info("Each parser was successfully executed and created a cc.json file.")
-            return askAndMergeResults(commandLine)
+            return if (configuredParsers.size == 1) {
+                logger.info { "Parser was successfully executed and created a cc.json file." }
+                0
+            } else {
+                logger.info { "Each parser was successfully executed and created a cc.json file." }
+                askAndMergeResults(commandLine)
+            }
         }
 
         private fun askAndMergeResults(commandLine: CommandLine): Int {
@@ -178,7 +183,7 @@ class Ccsh : Callable<Void?> {
             val exitCode = ParserService.executePreconfiguredParser(commandLine, Pair(configuredParser.key, configuredParser.value))
 
             if (exitCode != 0) {
-                logger.info("Error executing ${configuredParser.key}, code $exitCode")
+                logger.info { "Error executing ${configuredParser.key}, code $exitCode" }
             }
 
             return exitCode

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -14,7 +14,6 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -13,7 +13,9 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -29,19 +31,72 @@ class CcshTest {
 
     private val cmdLine = CommandLine(Ccsh())
 
-    @BeforeAll
-    fun setUpStreams() {
+    @BeforeEach
+    fun setupStreams() {
         System.setOut(PrintStream(outContent))
+        System.setErr(PrintStream(errContent))
     }
 
-    @AfterAll
+    @AfterEach
     fun restoreStreams() {
         System.setOut(originalOut)
+        System.setErr(originalErr)
     }
 
     @AfterAll
     fun afterTest() {
         unmockkAll()
+    }
+
+    private fun mockSuccessfulParserService() {
+        mockkObject(ParserService)
+        every {
+            ParserService.selectParser(any(), any())
+        } returns "someparser"
+
+        every {
+            ParserService.executeSelectedParser(any(), any())
+        } returns 0
+
+        every {
+            ParserService.executePreconfiguredParser(any(), any())
+        } returns 0
+    }
+
+    private fun mockUnsuccessfulParserService() {
+        mockkObject(ParserService)
+
+        every {
+            ParserService.executeSelectedParser(any(), any())
+        } returns -1
+
+        every {
+            ParserService.executePreconfiguredParser(any(), any())
+        } returns -1
+    }
+
+    private fun mockInteractiveParserSuggestionDialog(selectedParsers: List<String>,
+                                                      parserArgs: List<List<String>>) {
+        if (selectedParsers.size != parserArgs.size) {
+            throw IllegalArgumentException("There must be the same amount of args as parsers!")
+        }
+
+        val parsersAndArgs = mutableMapOf<String, List<String>>()
+        selectedParsers.zip(parserArgs) { currentParserName, currentParserArgs ->
+            parsersAndArgs.put(currentParserName, currentParserArgs)
+        }
+
+        mockkObject(InteractiveParserSuggestionDialog)
+        every {
+            InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(any())
+        } returns parsersAndArgs
+    }
+
+    private fun mockKInquirerConfirm(shouldConfirm: Boolean) {
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns shouldConfirm
     }
 
     @Test
@@ -77,20 +132,9 @@ class CcshTest {
         val selectedParsers = listOf("parser1", "parser2")
         val args = listOf(listOf("dummyArg1"), listOf("dummyArg2"))
 
-        mockkObject(InteractiveParserSuggestionDialog)
-        every {
-            InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(any())
-        } returns mapOf(selectedParsers[0] to args[0], selectedParsers[1] to args[1])
-
-        mockkObject(ParserService)
-        every {
-            ParserService.executePreconfiguredParser(any(), any())
-        } returns 0
-
-        mockkStatic("com.github.kinquirer.components.ConfirmKt")
-        every {
-            KInquirer.promptConfirm(any(), any())
-        } returns true
+        mockInteractiveParserSuggestionDialog(selectedParsers, args)
+        mockSuccessfulParserService()
+        mockKInquirerConfirm(true)
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -106,18 +150,8 @@ class CcshTest {
 
     @Test
     fun `should only execute parsers when configuration was successful`() {
-        mockkObject(InteractiveParserSuggestionDialog)
-        every {
-            InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(any())
-        } returns emptyMap()
-
-        mockkObject(ParserService)
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns 0
-        every {
-            ParserService.executePreconfiguredParser(any(), any())
-        } returns 0
+        mockInteractiveParserSuggestionDialog(emptyList(), emptyList())
+        mockSuccessfulParserService()
 
         val exitCode = Ccsh.executeCommandLine(emptyArray())
 
@@ -131,23 +165,9 @@ class CcshTest {
         val selectedParsers = listOf("parser1", "parser2")
         val args = listOf(listOf("dummyArg1"), listOf("dummyArg2"))
 
-        mockkObject(InteractiveParserSuggestionDialog)
-        every {
-            InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(any())
-        } returns mapOf(selectedParsers[0] to args[0], selectedParsers[1] to args[1])
-
-        mockkObject(ParserService)
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns 0
-        every {
-            ParserService.executePreconfiguredParser(any(), any())
-        } returns 0
-
-        mockkStatic("com.github.kinquirer.components.ConfirmKt")
-        every {
-            KInquirer.promptConfirm(any(), any())
-        } returns false
+        mockInteractiveParserSuggestionDialog(selectedParsers, args)
+        mockSuccessfulParserService()
+        mockKInquirerConfirm(false)
 
         val exitCode = Ccsh.executeCommandLine(emptyArray())
 
@@ -158,16 +178,11 @@ class CcshTest {
 
     @Test
     fun `should continue executing parsers even if there is an error while executing one`() {
-        mockkObject(ParserService)
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns -1
-        every {
-            ParserService.executePreconfiguredParser(any(), any())
-        } returns -1
+        mockUnsuccessfulParserService()
 
-        val dummyConfiguredParsers = mapOf("dummyParser1" to listOf("dummyArg1", "dummyArg2"), "dummyParser2" to listOf("dummyArg1", "dummyArg2"))
-
+        val dummyConfiguredParsers =
+                mapOf("dummyParser1" to listOf("dummyArg1", "dummyArg2"),
+                        "dummyParser2" to listOf("dummyArg1", "dummyArg2"))
         Ccsh.executeConfiguredParsers(cmdLine, dummyConfiguredParsers)
 
         verify(exactly = 2) { ParserService.executePreconfiguredParser(any(), any()) }
@@ -176,13 +191,7 @@ class CcshTest {
 
     @Test
     fun `should execute interactive parser when passed parser is unknown`() {
-        mockkObject(ParserService)
-        every {
-            ParserService.selectParser(any(), any())
-        } returns "someparser"
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns 0
+        mockSuccessfulParserService()
 
         val exitCode = Ccsh.executeCommandLine(arrayOf("unknownparser"))
         Assertions.assertThat(exitCode).isZero
@@ -192,13 +201,7 @@ class CcshTest {
 
     @Test
     fun `should execute interactive parser when -i option is passed`() {
-        mockkObject(ParserService)
-        every {
-            ParserService.selectParser(any(), any())
-        } returns "someparser"
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns 0
+        mockSuccessfulParserService()
 
         val exitCode = Ccsh.executeCommandLine(arrayOf("-i"))
         Assertions.assertThat(exitCode).isZero
@@ -208,14 +211,9 @@ class CcshTest {
 
     @Test
     fun `should execute the selected interactive parser when only called with name and no args`() {
-        mockkObject(ParserService)
-        every {
-            ParserService.executeSelectedParser(any(), any())
-        } returns 0
+        mockSuccessfulParserService()
 
-        System.setErr(PrintStream(errContent))
         val exitCode = Ccsh.executeCommandLine(arrayOf("sonarimport"))
-        System.setErr(originalErr)
 
         Assertions.assertThat(exitCode).isEqualTo(0)
         Assertions.assertThat(errContent.toString())
@@ -227,24 +225,11 @@ class CcshTest {
         val selectedParsers = listOf("parser1")
         val args = listOf(listOf("dummyArg1"))
 
-        mockkObject(InteractiveParserSuggestionDialog)
-        every {
-            InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(any())
-        } returns mapOf(selectedParsers[0] to args[0])
+        mockInteractiveParserSuggestionDialog(selectedParsers, args)
+        mockSuccessfulParserService()
+        mockKInquirerConfirm(true)
 
-        mockkObject(ParserService)
-        every {
-            ParserService.executePreconfiguredParser(any(), any())
-        } returns 0
-
-        mockkStatic("com.github.kinquirer.components.ConfirmKt")
-        every {
-            KInquirer.promptConfirm(any(), any())
-        } returns true
-
-        System.setErr(PrintStream(errContent))
         val exitCode = Ccsh.executeCommandLine(emptyArray())
-        System.setErr(originalErr)
 
         Assertions.assertThat(exitCode).isZero()
         Assertions.assertThat(errContent.toString())


### PR DESCRIPTION
# No longer ask to merge when only executing one parser

Issue: #3338

## Description

This PR simply adds a check to only ask for and merge output from parser suggestions, when more than one parser was executed. Additionally I fixed a few wrong usages of the KotlinLogger and also refactored the CCSH Unit-Tests because there was a whole lot of duplication with mocking which made these tests very confusing to understand.

