### PR TITLE
Fix/3330/web demo white screen on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+-   Fix an issue with web demo on Safari showing a white screen and not loading [#3396](https://github.com/MaibornWolff/codecharta/pull/3396)
+
 ### Chore 👨‍💻 👩‍💻
 
 -   Add documentation for the installation requirements for metric-gardener [#3395](https://github.com/MaibornWolff/codecharta/pull/3395)

--- a/visualization/app/codeCharta/codeCharta.component.spec.ts
+++ b/visualization/app/codeCharta/codeCharta.component.spec.ts
@@ -24,14 +24,14 @@ describe("codeChartaComponent", () => {
 		expect(mockedLoadInitialFileService.loadFileOrSample).toHaveBeenCalled()
 	})
 
-	it("should set isInitilized on windows' load event, so the app doesn't flicker on initial page load", () => {
+	it("should set isInitialized on angulars init event after fileService is loaded", async () => {
 		const mockedStore = { dispatch: jest.fn() } as unknown as Store
 		const mockedLoadInitialFileService = { loadFileOrSample: jest.fn() } as unknown as LoadInitialFileService
 
 		const codeChartaComponent = new CodeChartaComponent(mockedStore, mockedLoadInitialFileService)
 		expect(codeChartaComponent.isInitialized).toBe(false)
 
-		window.dispatchEvent(new Event("load"))
+		await codeChartaComponent.ngOnInit()
 		expect(codeChartaComponent.isInitialized).toBe(true)
 	})
 })

--- a/visualization/app/codeCharta/codeCharta.component.ts
+++ b/visualization/app/codeCharta/codeCharta.component.ts
@@ -14,14 +14,11 @@ export class CodeChartaComponent implements OnInit {
 	version = packageJson.version
 	isInitialized = false
 
-	constructor(private store: Store, private loadInitialFileService: LoadInitialFileService) {
-		window.addEventListener("load", () => {
-			this.isInitialized = true
-		})
-	}
+	constructor(private store: Store, private loadInitialFileService: LoadInitialFileService) {}
 
 	async ngOnInit(): Promise<void> {
 		this.store.dispatch(setIsLoadingFile({ value: true }))
 		await this.loadInitialFileService.loadFileOrSample()
+		this.isInitialized = true
 	}
 }


### PR DESCRIPTION
# Fixes loading issues in web demo for Safari

Issue: #3330

## Description

Fixes an issue with the web demo showing a white screen on Safari. 
This is caused by Safari not firing a "load" event and was fixed by utilizing angulars "ngOnInit" function to load the visible components.

## Developer Notes
This was tested on Safari for Mac (CodeCharta v. 1.120.0)
It is unclear if this also fixes the issue for mobile browsers.
