### PR TITLE
feature/3393/remove-new-label-badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Removed 🗑
 
 -   Deprecated download button removed (functionality has been replaced by custom views) [#3398](https://github.com/MaibornWolff/codecharta/pull/3398)
+-   Remove the 'new' badges from the 'Custom Views' and 'Suspicious Metrics' features as these features are no longer new [#3393](https://github.com/MaibornWolff/codecharta/pull/3399)
 
 ### Fixed 🐞
 

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.html
@@ -10,7 +10,6 @@
 </mat-card>
 
 <mat-card appearance="outlined" id="custom-configs-card" class="custom-configs-card">
-	<span class="badge-custom-configs">New</span>
 	<div class="section">
 		<div class="section-header">
 			<cc-custom-configs></cc-custom-configs>
@@ -20,7 +19,6 @@
 </mat-card>
 
 <mat-card appearance="outlined" id="ai-card" class="ai-card">
-	<span class="badge-ai">New</span>
 	<div class="section">
 		<div class="section-header">
 			<cc-artificial-intelligence></cc-artificial-intelligence>

--- a/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/ribbonBar.component.scss
@@ -22,28 +22,6 @@ cc-ribbon-bar {
 		}
 	}
 
-	.badge-custom-configs {
-		position: absolute;
-		top: -5px;
-		padding: 4px 6px;
-		border-radius: 50%;
-		background: red;
-		color: white;
-		font-size: 10px;
-		line-height: 10px;
-	}
-
-	.badge-ai {
-		position: absolute;
-		top: -5px;
-		padding: 4px 6px;
-		border-radius: 50%;
-		background: red;
-		color: white;
-		font-size: 10px;
-		line-height: 10px;
-	}
-
 	.cc-ribbon-bar-menu-button {
 		height: 22px;
 		line-height: 22px;


### PR DESCRIPTION
# Remove the 'new' label-badges

The badges were placed on the Custom views and Suspicious metrics menu points

Closes: #3393

## Description

The badges were placed on the menu points to indicate they were new but they are not anymore so they can be removed.
This removes the badges from the html and their sccs-styling.