### PR TITLE
fix/3400/ccsh-not-finding-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix an issue with web demo on Safari showing a white screen and not loading [#3396](https://github.com/MaibornWolff/codecharta/pull/3396)
--   Fix ccsh not finding parsers when run without flags [#3401](https://github.com/MaibornWolff/codecharta/pull/3401)
 
 ### Chore 👨‍💻 👩‍💻
 
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Only ask to merge results after parser suggestion execution when more than one parser was executed [#3384](https://github.com/MaibornWolff/codecharta/pull/3384)
+-   Add the description of each parser to the list of suggested parsers [#3387](https://github.com/MaibornWolff/codecharta/pull/3387)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix an issue with web demo on Safari showing a white screen and not loading [#3396](https://github.com/MaibornWolff/codecharta/pull/3396)
+-   Fix ccsh not finding parsers when run without flags [#3401](https://github.com/MaibornWolff/codecharta/pull/3401)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
@@ -21,12 +21,14 @@ class InteractiveParserSuggestionDialog {
                 return emptyMap()
             }
 
+            val parserRepository = PicocliParserRepository()
             val selectedParsers = selectToBeExecutedInteractiveParsers(applicableParsers)
+            val selectedParsersWithoutDescription = selectedParsers.map { parserRepository.extractParserName(it) }
 
             return if (selectedParsers.isEmpty()) {
                 emptyMap()
             } else {
-                ParserService.configureParserSelection(commandLine, PicocliParserRepository(), selectedParsers)
+                ParserService.configureParserSelection(commandLine, parserRepository, selectedParsersWithoutDescription)
             }
         }
 

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
@@ -23,11 +23,11 @@ class InteractiveParserSuggestionDialog {
 
             val parserRepository = PicocliParserRepository()
             val selectedParsers = selectToBeExecutedInteractiveParsers(applicableParsers)
-            val selectedParsersWithoutDescription = selectedParsers.map { parserRepository.extractParserName(it) }
 
             return if (selectedParsers.isEmpty()) {
                 emptyMap()
             } else {
+                val selectedParsersWithoutDescription = selectedParsers.map { parserRepository.extractParserName(it) }
                 ParserService.configureParserSelection(commandLine, parserRepository, selectedParsersWithoutDescription)
             }
         }

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/parser/InteractiveParserSuggestionDialog.kt
@@ -21,12 +21,12 @@ class InteractiveParserSuggestionDialog {
                 return emptyMap()
             }
 
-            val parserRepository = PicocliParserRepository()
             val selectedParsers = selectToBeExecutedInteractiveParsers(applicableParsers)
 
             return if (selectedParsers.isEmpty()) {
                 emptyMap()
             } else {
+                val parserRepository = PicocliParserRepository()
                 val selectedParsersWithoutDescription = selectedParsers.map { parserRepository.extractParserName(it) }
                 ParserService.configureParserSelection(commandLine, parserRepository, selectedParsersWithoutDescription)
             }

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
@@ -6,10 +6,7 @@ import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.ccsh.Ccsh
 import de.maibornwolff.codecharta.tools.ccsh.parser.InteractiveParserSuggestionDialog
 import de.maibornwolff.codecharta.tools.ccsh.parser.ParserService
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
+import io.mockk.*
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -95,31 +92,35 @@ class InteractiveParserSuggestionDialogTest {
             KInquirer.promptInput(any(), any(), any(), any(), any())
         } returns "src"
 
-        val parser = "dummyParser"
+        val parserWithDescription = "dummyParser - dummyDescription"
+        val parserWithoutDescription = "dummyParser"
         val configuration = listOf("dummyArg")
-        val parserList = listOf(parser)
+        val parserListWithDescription = listOf(parserWithDescription)
+        val parserListWithoutDescription = listOf(parserWithoutDescription)
 
         mockkStatic("com.github.kinquirer.components.CheckboxKt")
         every {
             KInquirer.promptCheckbox(any(), any(), any(), any(), any(), any(), any())
-        } returns parserList
+        } returns parserListWithDescription
 
         mockkObject(ParserService)
         every {
             ParserService.getParserSuggestions(any(), any(), any())
-        } returns parserList
+        } returns parserListWithDescription
 
         every {
             ParserService.configureParserSelection(any(), any(), any())
-        } returns mapOf(parser to configuration)
+        } returns mapOf(parserWithoutDescription to configuration)
 
         val configuredParsers = InteractiveParserSuggestionDialog.offerAndGetInteractiveParserSuggestionsAndConfigurations(cmdLine)
+
+        verify { ParserService.configureParserSelection(any(), any(), parserListWithoutDescription) }
 
         Assertions.assertThat(configuredParsers).isNotNull
         Assertions.assertThat(configuredParsers).isNotEmpty
 
-        Assertions.assertThat(configuredParsers).containsKey(parser)
-        Assertions.assertThat(configuredParsers[parser] == configuration).isTrue()
+        Assertions.assertThat(configuredParsers).containsKey(parserWithoutDescription)
+        Assertions.assertThat(configuredParsers[parserWithoutDescription] == configuration).isTrue()
     }
 
     @Test

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
@@ -6,7 +6,11 @@ import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.ccsh.Ccsh
 import de.maibornwolff.codecharta.tools.ccsh.parser.InteractiveParserSuggestionDialog
 import de.maibornwolff.codecharta.tools.ccsh.parser.ParserService
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll


### PR DESCRIPTION
# Fix ccsh not finding parsers without flags

Closes: #3400

## Description

**Descriptive pull request text**, answering:
Fixes ccsh not being able to select parsers because parsers were being selected with parsername and description
Fixed by removing parser description when calling the selected parsers