### PR TITLE
Fix/3336/add default value for tab width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix an issue with web demo on Safari showing a white screen and not loading [#3396](https://github.com/MaibornWolff/codecharta/pull/3396)
+-   Allow user to skip the value for tabwidth when configuring the rawtextparser and estimate its value [#3404](https://github.com/MaibornWolff/codecharta/pull/3404)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix an issue with web demo on Safari showing a white screen and not loading [#3396](https://github.com/MaibornWolff/codecharta/pull/3396)
--   Allow user to skip the value for tabwidth when configuring the rawtextparser and estimate its value [#3404](https://github.com/MaibornWolff/codecharta/pull/3404)
+-   Fix the ability for users to skip the value for tab-width when configuring the rawtextparser and estimate its value [#3404](https://github.com/MaibornWolff/codecharta/pull/3404)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -34,8 +34,9 @@ class ParserDialog {
                 hint = "metric1, metric2, metric3 (leave empty for all metrics)"
             )
 
-            val tabWidth: Int =
-                KInquirer.promptInput(message = "What is the tab width used (estimated if unknown)?", default = "unknown", hint = "unknown").toIntOrNull() ?: 0
+            val tabWidth: String =
+                KInquirer.promptInput(message = "What is the tab width used (estimated if unknown)?", default = "unknown", hint = "unknown")
+            val tabWidthValue = tabWidth.toIntOrNull() ?: 0
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")
 
@@ -54,7 +55,7 @@ class ParserDialog {
                 if (isCompressed) null else "--not-compressed",
                 "--verbose=$verbose",
                 "--metrics=$metrics",
-                "--tab-width=$tabWidth",
+                "--tab-width=$tabWidthValue",
                 "--max-indentation-level=$maxIndentationLevel",
                 "--exclude=$exclude",
                 "--file-extensions=$fileExtensions",

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -35,7 +35,7 @@ class ParserDialog {
             )
 
             val tabWidth: String =
-                KInquirer.promptInput(message = "What is the tab width used (estimated if unknown)?", default = "unknown", hint = "unknown")
+                KInquirer.promptInput(message = "What is the tab width used (estimated if empty)?", default = "")
             val tabWidthValue = tabWidth.toIntOrNull() ?: 0
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -35,7 +35,7 @@ class ParserDialog {
             )
 
             val tabWidth: BigDecimal =
-                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if not provided)?", default="")
+                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if kept at 0)?", default="0", hint="0")
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")
 

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -6,7 +6,6 @@ import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import java.math.BigDecimal
-import java.math.BigInteger
 import java.nio.file.Paths
 
 class ParserDialog {

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -6,6 +6,7 @@ import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.nio.file.Paths
 
 class ParserDialog {
@@ -34,8 +35,8 @@ class ParserDialog {
                 hint = "metric1, metric2, metric3 (leave empty for all metrics)"
             )
 
-            val tabWidth: BigDecimal =
-                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if kept at 0)?", default = "0", hint = "0")
+            val tabWidth: Int =
+                KInquirer.promptInput(message = "What is the tab width used (estimated if unknown)?", default = "unknown", hint = "unknown").toIntOrNull() ?: 0
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")
 

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -35,7 +35,7 @@ class ParserDialog {
             )
 
             val tabWidth: BigDecimal =
-                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if not provided)?")
+                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if not provided)?", default="")
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")
 

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -35,7 +35,7 @@ class ParserDialog {
             )
 
             val tabWidth: BigDecimal =
-                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if kept at 0)?", default="0", hint="0")
+                KInquirer.promptInputNumber(message = "What is the tab width used (estimated if kept at 0)?", default = "0", hint = "0")
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")
 

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -35,7 +35,7 @@ class ParserDialog {
             )
 
             val tabWidth: String =
-                KInquirer.promptInput(message = "What is the tab width used (estimated if empty)?", default = "")
+                KInquirer.promptInput(message = "How many spaces represent one indentation level when using spaces for indentation (estimated if empty)?", default = "")
             val tabWidthValue = tabWidth.toIntOrNull() ?: 0
 
             val maxIndentationLevel: BigDecimal = KInquirer.promptInputNumber(message = "What is the maximum Indentation Level?", default = "10", hint = "10")

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/metrics/IndentationCounter.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/metrics/IndentationCounter.kt
@@ -72,7 +72,7 @@ class IndentationCounter(
     }
 
     override fun getValue(): FileMetrics {
-        if (tabWidth == 0) {
+        if (tabWidth <= 0) {
             guessTabWidth()
         }
         correctMismatchingIndents(tabWidth)

--- a/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
+++ b/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
@@ -13,6 +13,9 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import picocli.CommandLine
 import java.io.File
 import java.math.BigDecimal
@@ -25,6 +28,42 @@ class ParserDialogTest {
         unmockkAll()
     }
 
+    companion object {
+        @JvmStatic
+        fun provideInvalidTabWidth(): List<Arguments> {
+            return listOf(
+                    Arguments.of("unknown"),
+                    Arguments.of("string-value"),
+                    Arguments.of("12."),
+                    Arguments.of("12.0"))
+        }
+    }
+
+    private fun setupMockedInquirer(
+            fileName: String,
+            outputFileName: String,
+            metrics: String,
+            tabWidth: String,
+            exclude: String,
+            fileExtensions: String,
+            maxIndentLvl: BigDecimal,
+            isCompressed: Boolean,
+            verbose: Boolean,
+            withoutDefaultExcludes: Boolean
+                                   ) {
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns fileName andThen outputFileName andThen metrics andThen tabWidth andThen exclude andThen fileExtensions
+        every {
+            KInquirer.promptInputNumber(any(), any(), any())
+        } returns maxIndentLvl
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed andThen verbose andThen withoutDefaultExcludes
+    }
+
     @Test
     fun `should output correct arguments that can be parsed`() {
         val fileName = "test.txt"
@@ -32,33 +71,54 @@ class ParserDialogTest {
         val isCompressed = false
         val verbose = false
         val metrics = "metric1"
-        val tabWidth = BigDecimal(0)
+        val tabWidth = "5"
+        val tabWidthValue = 5
         val maxIndentLvl = BigDecimal(10)
         val exclude = "file1"
         val fileExtensions = ""
         val withoutDefaultExcludes = false
 
-        mockkStatic("com.github.kinquirer.components.InputKt")
-        every {
-            KInquirer.promptInput(any(), any(), any())
-        } returns fileName andThen outputFileName andThen metrics andThen exclude andThen fileExtensions
-        every {
-            KInquirer.promptInputNumber(any(), any(), any())
-        } returns tabWidth andThen maxIndentLvl
-        mockkStatic("com.github.kinquirer.components.ConfirmKt")
-        every {
-            KInquirer.promptConfirm(any(), any())
-        } returns isCompressed andThen verbose andThen withoutDefaultExcludes
+        setupMockedInquirer(fileName, outputFileName, metrics, tabWidth, exclude, fileExtensions, maxIndentLvl, isCompressed, verbose, withoutDefaultExcludes)
 
         val parserArguments = ParserDialog.collectParserArgs()
-
         val commandLine = CommandLine(RawTextParser())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
         Assertions.assertThat(parseResult.matchedOption("metrics").getValue<List<String>>()).isEqualTo(listOf(metrics))
         Assertions.assertThat(parseResult.matchedOption("max-indentation-level").getValue<Int>()).isEqualTo(maxIndentLvl.toInt())
-        Assertions.assertThat(parseResult.matchedOption("tab-width").getValue<Int>()).isEqualTo(tabWidth.toInt())
+        Assertions.assertThat(parseResult.matchedOption("tab-width").getValue<Int>()).isEqualTo(tabWidthValue)
+        Assertions.assertThat(parseResult.matchedOption("file-extensions").getValue<Array<String>>()).isEqualTo(arrayOf(fileExtensions))
+        Assertions.assertThat(parseResult.matchedOption("without-default-excludes").getValue<Boolean>()).isEqualTo(withoutDefaultExcludes)
+        Assertions.assertThat(parseResult.matchedOption("verbose").getValue<Boolean>()).isEqualTo(withoutDefaultExcludes)
+        Assertions.assertThat(parseResult.matchedOption("exclude").getValue<Array<String>>()).isEqualTo(arrayOf(exclude))
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidTabWidth")
+    fun `should set non-integer tab-width to 0`(invalidTabWidth: String) {
+        val fileName = "test.txt"
+        val outputFileName = "test.cc.json"
+        val isCompressed = false
+        val verbose = false
+        val metrics = "metric1"
+        val tabWidthValue = 0
+        val maxIndentLvl = BigDecimal(10)
+        val exclude = "file1"
+        val fileExtensions = ""
+        val withoutDefaultExcludes = false
+
+        setupMockedInquirer(fileName, outputFileName, metrics, invalidTabWidth, exclude, fileExtensions, maxIndentLvl, isCompressed, verbose, withoutDefaultExcludes)
+
+        val parserArguments = ParserDialog.collectParserArgs()
+        val commandLine = CommandLine(RawTextParser())
+        val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedOption("metrics").getValue<List<String>>()).isEqualTo(listOf(metrics))
+        Assertions.assertThat(parseResult.matchedOption("max-indentation-level").getValue<Int>()).isEqualTo(maxIndentLvl.toInt())
+        Assertions.assertThat(parseResult.matchedOption("tab-width").getValue<Int>()).isEqualTo(tabWidthValue)
         Assertions.assertThat(parseResult.matchedOption("file-extensions").getValue<Array<String>>()).isEqualTo(arrayOf(fileExtensions))
         Assertions.assertThat(parseResult.matchedOption("without-default-excludes").getValue<Boolean>()).isEqualTo(withoutDefaultExcludes)
         Assertions.assertThat(parseResult.matchedOption("verbose").getValue<Boolean>()).isEqualTo(withoutDefaultExcludes)

--- a/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
+++ b/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
@@ -32,8 +32,8 @@ class ParserDialogTest {
         @JvmStatic
         fun provideInvalidTabWidth(): List<Arguments> {
             return listOf(
-                    Arguments.of("unknown"),
                     Arguments.of("string-value"),
+                    Arguments.of(""),
                     Arguments.of("12."),
                     Arguments.of("12.0"))
         }


### PR DESCRIPTION
# Provide default value for tabwidth

Closes: #3336 

## Description

  - Sets the default value of tabwidth to 'unknown' when no value is entered 
     by the user during configuration of the RawTextParser and tabwidth will get estimated
  - When user enters a non-integer value, the tabwidth gets estimated as well

## Screenshots or gifs
<img width="478" alt="Default tabwidth 3" src="https://github.com/MaibornWolff/codecharta/assets/149768491/711d050a-e14b-4047-9539-81cea4f00117">