### PR TITLE
Fix file extension for merged project #3409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Fix RawTextParser producing incorrect output when no (or multiple) file extensions were specified in interactive mode [#3405](https://github.com/MaibornWolff/codecharta/pull/3405)
 -   Fix handling of empty inputs for the `--metrics`, `--exclude`, `--file-extensions` flags in the RawTextParser [#3415](https://github.com/MaibornWolff/codecharta/pull/3415)
 -   Fix the csv-exporter so that it exports multiple projects instead of just one when multiple projects are specified [#3414](https://github.com/MaibornWolff/codecharta/pull/3414)
+-   Fix file extensions of output files for merged projects [#3421](https://github.com/MaibornWolff/codecharta/pull/3421)
 
 ### Added 🚀
 

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandler.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/OutputFileHandler.kt
@@ -24,7 +24,7 @@ object OutputFileHandler {
                                   if (compressed) FileExtension.GZIP.extension else String()
             FileExtension.CSV -> outputName
                     .removeSuffix(FileExtension.CSV.extension) +
-                                 FileExtension.CSV.extension
+                                  FileExtension.CSV.extension
             else -> throw IllegalArgumentException()
         }
     }

--- a/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
+++ b/analysis/tools/ccsh/src/main/kotlin/de/maibornwolff/codecharta/tools/ccsh/Ccsh.kt
@@ -163,7 +163,7 @@ class Ccsh : Callable<Void?> {
                 val mergeArguments =
                         listOf(
                                 ccJsonFilePath,
-                                "--output-file=$outputFilePath+",
+                                "--output-file=$outputFilePath",
                                 "--not-compressed=true",
                                 "--add-missing=false",
                                 "--recursive=true",

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -3,7 +3,6 @@ package de.maibornwolff.codecharta.ccsh
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
-import de.maibornwolff.codecharta.importer.sourcecodeparser.SourceCodeParserMain
 import de.maibornwolff.codecharta.tools.ccsh.Ccsh
 import de.maibornwolff.codecharta.tools.ccsh.parser.InteractiveParserSuggestionDialog
 import de.maibornwolff.codecharta.tools.ccsh.parser.ParserService
@@ -16,7 +15,6 @@ import io.mockk.verify
 import mu.KLogger
 import mu.KotlinLogging
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -268,7 +266,6 @@ class CcshTest {
 
         // when
         val exitCode = Ccsh.executeCommandLine(emptyArray())
-
 
         // then
         Assertions.assertThat(exitCode).isZero()

--- a/analysis/tools/ccsh/src/test/resources/tomerge.json
+++ b/analysis/tools/ccsh/src/test/resources/tomerge.json
@@ -1,0 +1,323 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "java",
+                  "type": "Folder",
+                  "children": [
+                    {
+                      "name": "de",
+                      "type": "Folder",
+                      "children": [
+                        {
+                          "name": "mwea",
+                          "type": "Folder",
+                          "children": [
+                            {
+                              "name": "codecharta",
+                              "type": "Folder",
+                              "children": [
+                                {
+                                  "name": "importer",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "sourcemon",
+                                      "type": "Folder",
+                                      "children": [
+                                        {
+                                          "name": "SourceMonCsvConverter.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "Lines*": 80.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 4.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 2.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 1.0,
+                                            "Statements at block level 3": 4.0,
+                                            "Line Number of Most Complex Method*": 81.0,
+                                            "Statements at block level 2": 30.0,
+                                            "Maximum Complexity*": 4.0,
+                                            "Statements at block level 1": 15.0,
+                                            "Statements at block level 0": 14.0,
+                                            "Line Number of Deepest Block": 85.0,
+                                            "Methods per Class": 6.0,
+                                            "Percent Branch Statements": 7.8,
+                                            "Average Statements per Method": 5.83,
+                                            "Statements": 64.0,
+                                            "Average Block Depth": 1.42,
+                                            "Method Call Statements": 38.0
+                                          }
+                                        },
+                                        {
+                                          "name": "SourcemonCsvImporter.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "Lines*": 25.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 4.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 3.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 1.0,
+                                            "Statements at block level 3": 3.0,
+                                            "Line Number of Most Complex Method*": 18.0,
+                                            "Statements at block level 2": 7.0,
+                                            "Maximum Complexity*": 4.0,
+                                            "Statements at block level 1": 2.0,
+                                            "Statements at block level 0": 6.0,
+                                            "Line Number of Deepest Block": 24.0,
+                                            "Methods per Class": 2.0,
+                                            "Percent Branch Statements": 21.1,
+                                            "Average Statements per Method": 5.5,
+                                            "Statements": 19.0,
+                                            "Average Block Depth": 1.53,
+                                            "Method Call Statements": 9.0
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "json",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "JsonAccessor.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 15.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 14.0,
+                                        "Statements at block level 2": 2.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 1.0,
+                                        "Statements at block level 0": 10.0,
+                                        "Line Number of Deepest Block": 15.0,
+                                        "Methods per Class": 1.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 2.0,
+                                        "Statements": 13.0,
+                                        "Average Block Depth": 0.38,
+                                        "Method Call Statements": 2.0
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "model",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "Node.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 34.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 11.0,
+                                        "Statements at block level 2": 10.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 12.0,
+                                        "Statements at block level 0": 3.0,
+                                        "Line Number of Deepest Block": 12.0,
+                                        "Methods per Class": 8.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 1.25,
+                                        "Statements": 25.0,
+                                        "Average Block Depth": 1.28,
+                                        "Method Call Statements": 2.0
+                                      }
+                                    },
+                                    {
+                                      "name": "NodeType.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 4.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 0.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 0.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Statements at block level 2": 0.0,
+                                        "Maximum Complexity*": 0.0,
+                                        "Statements at block level 1": 0.0,
+                                        "Statements at block level 0": 2.0,
+                                        "Line Number of Deepest Block": 1.0,
+                                        "Methods per Class": 0.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 0.0,
+                                        "Statements": 2.0,
+                                        "Average Block Depth": 0.0,
+                                        "Method Call Statements": 0.0
+                                      }
+                                    },
+                                    {
+                                      "name": "Project.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 17.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 10.0,
+                                        "Statements at block level 2": 3.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 6.0,
+                                        "Statements at block level 0": 4.0,
+                                        "Line Number of Deepest Block": 11.0,
+                                        "Methods per Class": 3.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 1.0,
+                                        "Statements": 13.0,
+                                        "Average Block Depth": 0.92,
+                                        "Method Call Statements": 0.0
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "java",
+                  "type": "Folder",
+                  "children": [
+                    {
+                      "name": "de",
+                      "type": "Folder",
+                      "children": [
+                        {
+                          "name": "mwea",
+                          "type": "Folder",
+                          "children": [
+                            {
+                              "name": "codecharta",
+                              "type": "Folder",
+                              "children": [
+                                {
+                                  "name": "importer",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "sourcemon",
+                                      "type": "Folder",
+                                      "children": [
+                                        {
+                                          "name": "SourceMonCsvConverterTest.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "Lines*": 18.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 2.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 1.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 0.0,
+                                            "Statements at block level 3": 0.0,
+                                            "Line Number of Most Complex Method*": 13.0,
+                                            "Statements at block level 2": 4.0,
+                                            "Maximum Complexity*": 1.0,
+                                            "Statements at block level 1": 3.0,
+                                            "Statements at block level 0": 7.0,
+                                            "Line Number of Deepest Block": 14.0,
+                                            "Methods per Class": 2.0,
+                                            "Percent Branch Statements": 0.0,
+                                            "Average Statements per Method": 2.0,
+                                            "Statements": 14.0,
+                                            "Average Block Depth": 0.79,
+                                            "Method Call Statements": 5.0
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/tools/ccsh/src/test/resources/tomerge2.json
+++ b/analysis/tools/ccsh/src/test/resources/tomerge2.json
@@ -1,0 +1,323 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "java",
+                  "type": "Folder",
+                  "children": [
+                    {
+                      "name": "de",
+                      "type": "Folder",
+                      "children": [
+                        {
+                          "name": "mwea",
+                          "type": "Folder",
+                          "children": [
+                            {
+                              "name": "codecharta",
+                              "type": "Folder",
+                              "children": [
+                                {
+                                  "name": "importer",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "sourcemon",
+                                      "type": "Folder",
+                                      "children": [
+                                        {
+                                          "name": "SourceMonCsvConverter.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "AdditionalAttributeForTest": 0.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 4.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 2.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 1.0,
+                                            "Statements at block level 3": 4.0,
+                                            "Line Number of Most Complex Method*": 81.0,
+                                            "Statements at block level 2": 30.0,
+                                            "Maximum Complexity*": 4.0,
+                                            "Statements at block level 1": 15.0,
+                                            "Statements at block level 0": 14.0,
+                                            "Line Number of Deepest Block": 85.0,
+                                            "Methods per Class": 6.0,
+                                            "Percent Branch Statements": 7.8,
+                                            "Average Statements per Method": 5.83,
+                                            "Statements": 64.0,
+                                            "Average Block Depth": 1.42,
+                                            "Method Call Statements": 38.0
+                                          }
+                                        },
+                                        {
+                                          "name": "SourcemonCsvImporter.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "Lines*": 25.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 4.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 3.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 1.0,
+                                            "Statements at block level 3": 3.0,
+                                            "Line Number of Most Complex Method*": 18.0,
+                                            "Statements at block level 2": 7.0,
+                                            "Maximum Complexity*": 4.0,
+                                            "Statements at block level 1": 2.0,
+                                            "Statements at block level 0": 6.0,
+                                            "Line Number of Deepest Block": 24.0,
+                                            "Methods per Class": 2.0,
+                                            "Percent Branch Statements": 21.1,
+                                            "Average Statements per Method": 5.5,
+                                            "Statements": 19.0,
+                                            "Average Block Depth": 1.53,
+                                            "Method Call Statements": 9.0
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "json",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "JsonAccessor.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 15.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 14.0,
+                                        "Statements at block level 2": 2.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 1.0,
+                                        "Statements at block level 0": 10.0,
+                                        "Line Number of Deepest Block": 15.0,
+                                        "Methods per Class": 1.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 2.0,
+                                        "Statements": 13.0,
+                                        "Average Block Depth": 0.38,
+                                        "Method Call Statements": 2.0
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "model",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "Node.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 34.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 11.0,
+                                        "Statements at block level 2": 10.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 12.0,
+                                        "Statements at block level 0": 3.0,
+                                        "Line Number of Deepest Block": 12.0,
+                                        "Methods per Class": 8.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 1.25,
+                                        "Statements": 25.0,
+                                        "Average Block Depth": 1.28,
+                                        "Method Call Statements": 2.0
+                                      }
+                                    },
+                                    {
+                                      "name": "NodeType.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 4.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 0.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 0.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Statements at block level 2": 0.0,
+                                        "Maximum Complexity*": 0.0,
+                                        "Statements at block level 1": 0.0,
+                                        "Statements at block level 0": 2.0,
+                                        "Line Number of Deepest Block": 1.0,
+                                        "Methods per Class": 0.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 0.0,
+                                        "Statements": 2.0,
+                                        "Average Block Depth": 0.0,
+                                        "Method Call Statements": 0.0
+                                      }
+                                    },
+                                    {
+                                      "name": "Project.java",
+                                      "type": "File",
+                                      "attributes": {
+                                        "Lines*": 17.0,
+                                        "Classes and Interfaces": 1.0,
+                                        "Statements at block level 9": 0.0,
+                                        "Maximum Block Depth": 2.0,
+                                        "Statements at block level 8": 0.0,
+                                        "Statements at block level 7": 0.0,
+                                        "Percent Lines with Comments": 0.0,
+                                        "Average Complexity*": 1.0,
+                                        "Statements at block level 6": 0.0,
+                                        "Statements at block level 5": 0.0,
+                                        "Statements at block level 4": 0.0,
+                                        "Statements at block level 3": 0.0,
+                                        "Line Number of Most Complex Method*": 10.0,
+                                        "Statements at block level 2": 3.0,
+                                        "Maximum Complexity*": 1.0,
+                                        "Statements at block level 1": 6.0,
+                                        "Statements at block level 0": 4.0,
+                                        "Line Number of Deepest Block": 11.0,
+                                        "Methods per Class": 3.0,
+                                        "Percent Branch Statements": 0.0,
+                                        "Average Statements per Method": 1.0,
+                                        "Statements": 13.0,
+                                        "Average Block Depth": 0.92,
+                                        "Method Call Statements": 0.0
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "java",
+                  "type": "Folder",
+                  "children": [
+                    {
+                      "name": "de",
+                      "type": "Folder",
+                      "children": [
+                        {
+                          "name": "mwea",
+                          "type": "Folder",
+                          "children": [
+                            {
+                              "name": "codecharta",
+                              "type": "Folder",
+                              "children": [
+                                {
+                                  "name": "importer",
+                                  "type": "Folder",
+                                  "children": [
+                                    {
+                                      "name": "sourcemon",
+                                      "type": "Folder",
+                                      "children": [
+                                        {
+                                          "name": "SourceMonCsvConverterTest.java",
+                                          "type": "File",
+                                          "attributes": {
+                                            "Lines*": 18.0,
+                                            "Classes and Interfaces": 1.0,
+                                            "Statements at block level 9": 0.0,
+                                            "Maximum Block Depth": 2.0,
+                                            "Statements at block level 8": 0.0,
+                                            "Statements at block level 7": 0.0,
+                                            "Percent Lines with Comments": 0.0,
+                                            "Average Complexity*": 1.0,
+                                            "Statements at block level 6": 0.0,
+                                            "Statements at block level 5": 0.0,
+                                            "Statements at block level 4": 0.0,
+                                            "Statements at block level 3": 0.0,
+                                            "Line Number of Most Complex Method*": 13.0,
+                                            "Statements at block level 2": 4.0,
+                                            "Maximum Complexity*": 1.0,
+                                            "Statements at block level 1": 3.0,
+                                            "Statements at block level 0": 7.0,
+                                            "Line Number of Deepest Block": 14.0,
+                                            "Methods per Class": 2.0,
+                                            "Percent Branch Statements": 0.0,
+                                            "Average Statements per Method": 2.0,
+                                            "Statements": 14.0,
+                                            "Average Block Depth": 0.79,
+                                            "Method Call Statements": 5.0
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Fix file extension for merged project #3409

Closes: #3409

## Description

  - The problem with unsupported API versions occurs when selecting the analysis folder. This happens because there are test files in this folder with API versions lower than 1.0, used for testing invalid versions. When using the analysis folder as input for the merge filter, it correctly throws an error
  - Fix: The file extension of the merged project was set incorrectly and has now been corrected

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualisation READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated