### PR TITLE
Fix/3348/deselect building reset color

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,11 +13,11 @@ _**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/
 ## Definition of Done
 
 A PR is only ready for merge once all the following acceptance criteria are fulfilled:
--[ ] Changes have been manually tested
--[ ] All TODOs related to this PR have been closed
--[ ] There are automated tests for newly written code and bug fixes
--[ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
--[ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
--[ ] CHANGELOG.md has been updated
+- [ ] Changes have been manually tested
+- [ ] All TODOs related to this PR have been closed
+- [ ] There are automated tests for newly written code and bug fixes
+- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
+- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
+- [ ] CHANGELOG.md has been updated
 
 ## Screenshots or gifs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ A PR is only ready for merge once all the following acceptance criteria are fulf
 -[ ] All TODOs related to this PR have been closed
 -[ ] There are automated tests for newly written code and bug fixes
 -[ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
--[ ] Documentation (GH-pages, analysis/visualisation READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
+-[ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
 -[ ] CHANGELOG.md has been updated
 
 ## Screenshots or gifs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Fix the csv-exporter so that it exports multiple projects instead of just one when multiple projects are specified [#3414](https://github.com/MaibornWolff/codecharta/pull/3414)
 -   Fix file extensions of output files for merged projects [#3421](https://github.com/MaibornWolff/codecharta/pull/3421)
 -   Fix the ability for users to accidentally pass invalid metrics to the RawTextParser without it crashing [#3424](https://github.com/MaibornWolff/codecharta/pull/3424)
+-   Fix deselected buildings with green/red roof in delta mode do not reset their color roof [#3426](https://github.com/MaibornWolff/codecharta/pull/3426)
 
 ### Chore ‍👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/ui/codeMap/arrow/__snapshots__/codeMap.arrow.service.spec.ts.snap
+++ b/visualization/app/codeCharta/ui/codeMap/arrow/__snapshots__/codeMap.arrow.service.spec.ts.snap
@@ -149,7 +149,7 @@ CodeMapBuilding {
   },
   "_color": "#EB8319",
   "_defaultColor": "#ddcc00",
-  "_defaultDeltaColor": "#EB8319",
+  "_defaultDeltaColor": "#000000",
   "_deltaColor": "#EB8319",
   "_id": 1,
   "_node": {

--- a/visualization/app/codeCharta/ui/codeMap/arrow/__snapshots__/codeMap.arrow.service.spec.ts.snap
+++ b/visualization/app/codeCharta/ui/codeMap/arrow/__snapshots__/codeMap.arrow.service.spec.ts.snap
@@ -199,3 +199,137 @@ CodeMapBuilding {
   },
 }
 `;
+
+exports[`CodeMapArrowService Arrow Behaviour when selecting and hovering a building should restore to previous color if another building is selected in delta mode 1`] = `
+CodeMapBuilding {
+  "_boundingBox": Box3 {
+    "max": Vector3 {
+      "x": -Infinity,
+      "y": -Infinity,
+      "z": -Infinity,
+    },
+    "min": Vector3 {
+      "x": Infinity,
+      "y": Infinity,
+      "z": Infinity,
+    },
+  },
+  "_color": "#EB8319",
+  "_defaultColor": "#ddcc00",
+  "_defaultDeltaColor": "#000000",
+  "_deltaColor": "#EB8319",
+  "_id": 2,
+  "_node": {
+    "attributes": {
+      "a": 20,
+      "b": 15,
+      "mcc": 100,
+    },
+    "color": "#820E0E",
+    "deltas": {
+      "a": 1,
+      "b": 2,
+    },
+    "depth": 4,
+    "edgeAttributes": {
+      "a": {
+        "incoming": 2,
+        "outgoing": 666,
+      },
+    },
+    "flat": false,
+    "height": 2,
+    "heightDelta": 20,
+    "id": 2,
+    "incomingEdgePoint": Vector3 {
+      "x": 1,
+      "y": 2,
+      "z": 3,
+    },
+    "isLeaf": true,
+    "length": 3,
+    "link": "NO_LINK",
+    "mapNodeDepth": 2,
+    "markingColor": "0xFFFFFF",
+    "name": "root/small leaf",
+    "outgoingEdgePoint": Vector3 {
+      "x": 1,
+      "y": 2,
+      "z": 3,
+    },
+    "path": "/root/Parent Leaf/small leaf",
+    "visible": true,
+    "width": 1,
+    "x0": 5,
+    "y0": 7,
+    "z0": 6,
+  },
+}
+`;
+
+exports[`CodeMapArrowService Arrow Behaviour when selecting and hovering a building should restore to previous color if another building is selected in delta mode 2`] = `
+CodeMapBuilding {
+  "_boundingBox": Box3 {
+    "max": Vector3 {
+      "x": 6,
+      "y": 8,
+      "z": 10,
+    },
+    "min": Vector3 {
+      "x": 5,
+      "y": 6,
+      "z": 7,
+    },
+  },
+  "_color": "#6987A5",
+  "_defaultColor": "#AABBCC",
+  "_defaultDeltaColor": "#000000",
+  "_deltaColor": "#1A1A1A",
+  "_id": 0,
+  "_node": {
+    "attributes": {
+      "a": 20,
+      "b": 15,
+      "mcc": 14,
+    },
+    "color": "#AABBCC",
+    "deltas": {
+      "a": 1,
+      "b": 2,
+    },
+    "depth": 4,
+    "edgeAttributes": {
+      "a": {
+        "incoming": 2,
+        "outgoing": 666,
+      },
+    },
+    "flat": false,
+    "height": 2,
+    "heightDelta": 20,
+    "id": 1,
+    "incomingEdgePoint": Vector3 {
+      "x": 1,
+      "y": 2,
+      "z": 3,
+    },
+    "isLeaf": true,
+    "length": 3,
+    "link": "NO_LINK",
+    "mapNodeDepth": 2,
+    "markingColor": "0xFFFFFF",
+    "name": "root/big leaf",
+    "outgoingEdgePoint": Vector3 {
+      "x": 1,
+      "y": 2,
+      "z": 3,
+    },
+    "path": "/root/big leaf",
+    "visible": true,
+    "width": 1,
+    "x0": 5,
+    "y0": 7,
+    "z0": 6,
+  },
+}
+`;

--- a/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.spec.ts
@@ -100,6 +100,22 @@ describe("CodeMapArrowService", () => {
 			expect(threeSceneService["highlighted"]).toMatchSnapshot()
 			expect(threeSceneService["selected"]).toMatchSnapshot()
 		})
+		it("should restore to previous color if another building is selected in delta mode", async () => {
+			const nodes: Node[] = [
+				CODE_MAP_BUILDING_WITH_OUTGOING_EDGE_NODE.node,
+				CODE_MAP_BUILDING_WITH_INCOMING_EDGE_NODE.node,
+				DIFFERENT_NODE
+			]
+			threeSceneService["mapMesh"] = new CodeMapMesh(nodes, state.getValue(), true)
+
+			store.dispatch(setHeightMetric({ value: "mcc" }))
+
+			threeSceneService.selectBuilding(CODE_MAP_BUILDING_WITH_OUTGOING_EDGE_NODE)
+			threeSceneService.selectBuilding(CODE_MAP_BUILDING_WITH_INCOMING_EDGE_NODE)
+
+			expect(threeSceneService["selected"]).toMatchSnapshot()
+			expect(threeSceneService["mapMesh"].getBuildingByPath(CODE_MAP_BUILDING_WITH_OUTGOING_EDGE_NODE.node.path)).toMatchSnapshot()
+		})
 		it("should debounce the edge reset of buildings to improve performance", async () => {
 			const resetEdgesOfBuildingMock = jest.fn()
 			codeMapArrowService["resetEdgesOfBuildings"] = resetEdgesOfBuildingMock

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
@@ -20,7 +20,6 @@ export class CodeMapBuilding {
 		this._defaultColor = color
 		this._deltaColor = "#000000"
 		this._defaultDeltaColor = "#000000"
-		this._deltaColorStorage = "#000000"
 		this._node = node
 	}
 
@@ -37,7 +36,6 @@ export class CodeMapBuilding {
 
 		if (this._node.deltas) {
 			this._deltaColor = this._decreaseLightnessForColor(this._defaultDeltaColor, value)
-			this._defaultDeltaColor = this._deltaColorStorage
 		}
 	}
 
@@ -70,8 +68,7 @@ export class CodeMapBuilding {
 
 	resetColor() {
 		this._color = this._defaultColor
-		this._deltaColor = "#000000"
-		this._defaultDeltaColor = this._deltaColorStorage
+		this._deltaColor = this._defaultDeltaColor
 	}
 
 	equals(building: CodeMapBuilding) {
@@ -113,12 +110,9 @@ export class CodeMapBuilding {
 	setDeltaColor(color: string) {
 		this._defaultDeltaColor = color
 		this._deltaColor = color
-		this._deltaColorStorage = color
 	}
 
-	// Both color need to be set, deltaColor = lower part, defaultDeltaColor = upperPart (where defined?)
-	setClickDeltaColor(color: string) {
+	setOnclickDeltaColor(color: string) {
 		this._deltaColor = color
-		this._defaultDeltaColor = color
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
@@ -9,6 +9,7 @@ export class CodeMapBuilding {
 	private _defaultColor: string
 	private _deltaColor: string
 	private _defaultDeltaColor: string
+	private _deltaColorStorage: string
 	private _node: Node
 	parent: CodeMapBuilding
 
@@ -19,6 +20,7 @@ export class CodeMapBuilding {
 		this._defaultColor = color
 		this._deltaColor = "#000000"
 		this._defaultDeltaColor = "#000000"
+		this._deltaColorStorage = "#000000"
 		this._node = node
 	}
 
@@ -31,25 +33,23 @@ export class CodeMapBuilding {
 	}
 
 	decreaseLightness(value: number) {
-		const defaultColorHSL = ColorConverter.hexToHSL(this._defaultColor)
-		defaultColorHSL.decreaseLightness(value)
-		if (defaultColorHSL.getLightness() < 10) {
-			defaultColorHSL.setLightness(10)
-		} else {
-			defaultColorHSL.setLightness(defaultColorHSL.getLightness())
-		}
-		this._color = defaultColorHSL.toHex()
+		this._color = this._decreaseLightnessForColor(this._defaultColor, value)
 
 		if (this._node.deltas) {
-			const deltaColorHSL = ColorConverter.hexToHSL(this._defaultDeltaColor)
-			deltaColorHSL.decreaseLightness(value)
-			if (deltaColorHSL.getLightness() < 10) {
-				deltaColorHSL.setLightness(10)
-			} else {
-				deltaColorHSL.setLightness(deltaColorHSL.getLightness())
-			}
-			this._deltaColor = deltaColorHSL.toHex()
+			this._deltaColor = this._decreaseLightnessForColor(this._defaultDeltaColor, value)
+			this._defaultDeltaColor = this._deltaColorStorage
 		}
+	}
+
+	_decreaseLightnessForColor(color: string, value: number) {
+		const colorHSL = ColorConverter.hexToHSL(color)
+		colorHSL.decreaseLightness(value)
+		if (colorHSL.getLightness() < 10) {
+			colorHSL.setLightness(10)
+		} else {
+			colorHSL.setLightness(colorHSL.getLightness())
+		}
+		return colorHSL.toHex()
 	}
 
 	getColorVector() {
@@ -70,7 +70,8 @@ export class CodeMapBuilding {
 
 	resetColor() {
 		this._color = this._defaultColor
-		this._deltaColor = this._defaultDeltaColor
+		this._deltaColor = "#000000"
+		this._defaultDeltaColor = this._deltaColorStorage
 	}
 
 	equals(building: CodeMapBuilding) {
@@ -112,5 +113,12 @@ export class CodeMapBuilding {
 	setDeltaColor(color: string) {
 		this._defaultDeltaColor = color
 		this._deltaColor = color
+		this._deltaColorStorage = color
+	}
+
+	// Both color need to be set, deltaColor = lower part, defaultDeltaColor = upperPart (where defined?)
+	setClickDeltaColor(color: string) {
+		this._deltaColor = color
+		this._defaultDeltaColor = color
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
@@ -9,7 +9,6 @@ export class CodeMapBuilding {
 	private _defaultColor: string
 	private _deltaColor: string
 	private _defaultDeltaColor: string
-	private _deltaColorStorage: string
 	private _node: Node
 	parent: CodeMapBuilding
 

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapBuilding.ts
@@ -38,7 +38,7 @@ export class CodeMapBuilding {
 		}
 	}
 
-	_decreaseLightnessForColor(color: string, value: number) {
+	private _decreaseLightnessForColor(color: string, value: number) {
 		const colorHSL = ColorConverter.hexToHSL(color)
 		colorHSL.decreaseLightness(value)
 		if (colorHSL.getLightness() < 10) {
@@ -106,12 +106,12 @@ export class CodeMapBuilding {
 		this._node = node
 	}
 
-	setDeltaColor(color: string) {
+	setInitialDeltaColor(color: string) {
 		this._defaultDeltaColor = color
 		this._deltaColor = color
 	}
 
-	setOnclickDeltaColor(color: string) {
+	setDeltaColor(color: string) {
 		this._deltaColor = color
 	}
 }

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
@@ -47,7 +47,7 @@ export class CodeMapMesh {
 
 	selectBuilding(building: CodeMapBuilding, color: string) {
 		building.setColor(color)
-		building.setOnclickDeltaColor(color)
+		building.setDeltaColor(color)
 		this.setVertexColor(building.id, building.getColorVector(), building.getDeltaColorVector())
 		this.updateVertices()
 	}
@@ -135,16 +135,16 @@ export class CodeMapMesh {
 		const { node } = building
 
 		if (node.flat) {
-			building.setDeltaColor(mapColors.flat)
+			building.setInitialDeltaColor(mapColors.flat)
 		} else if (node.deltas) {
 			const deltaValue = node.deltas[heightMetric]
 
 			if (deltaValue > 0) {
-				building.setDeltaColor(mapColors.positiveDelta)
+				building.setInitialDeltaColor(mapColors.positiveDelta)
 			}
 
 			if (deltaValue < 0) {
-				building.setDeltaColor(mapColors.negativeDelta)
+				building.setInitialDeltaColor(mapColors.negativeDelta)
 			}
 		}
 	}

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
@@ -47,7 +47,7 @@ export class CodeMapMesh {
 
 	selectBuilding(building: CodeMapBuilding, color: string) {
 		building.setColor(color)
-		building.setDeltaColor(color)
+		building.setClickDeltaColor(color)
 		this.setVertexColor(building.id, building.getColorVector(), building.getDefaultDeltaColorVector())
 		this.updateVertices()
 	}

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
@@ -47,8 +47,8 @@ export class CodeMapMesh {
 
 	selectBuilding(building: CodeMapBuilding, color: string) {
 		building.setColor(color)
-		building.setClickDeltaColor(color)
-		this.setVertexColor(building.id, building.getColorVector(), building.getDefaultDeltaColorVector())
+		building.setOnclickDeltaColor(color)
+		this.setVertexColor(building.id, building.getColorVector(), building.getDeltaColorVector())
 		this.updateVertices()
 	}
 


### PR DESCRIPTION
# Fix select color not correctly resetting on unselect in delta mode

Closes: #3348 

## Description

- Change `defaultDeltaColor` to be the true default / backup color for select/unselect (like it is handled in non-delta mode) 
- Add `onclick` method to `CodeMapBuilding` for selection process (avoid override of default value)
- - This is necessary because the delta colors get set on existing buildings and not while being constructed (like in non-delta mode)


## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualisation READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
