### PR TITLE
Fix sync flag using inconsistent characters #3406

### DIFF
--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/ProjectInputReader.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/ProjectInputReader.kt
@@ -5,7 +5,6 @@ import java.io.BufferedInputStream
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.nio.charset.StandardCharsets
 import java.util.Scanner
 
 object ProjectInputReader {
@@ -21,7 +20,6 @@ object ProjectInputReader {
     fun extractProjectString(input: InputStream): String {
         Thread.sleep(100)
         val availableBytes = input.available()
-
         if (availableBytes <= 0) {
             return ""
         }
@@ -29,8 +27,7 @@ object ProjectInputReader {
             return extractProjectString(BufferedInputStream(input))
         }
 
-        val isSyncSignalContained = isSyncSignalContained(input, availableBytes)
-
+        val isSyncSignalContained = containsSyncSignal(input)
         if (isSyncSignalContained) {
             val scanner = Scanner(input)
             val stringBuilder = StringBuilder()
@@ -43,7 +40,7 @@ object ProjectInputReader {
         }
 
         val charBuffer = CharArray(1024)
-        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
+        val reader = BufferedReader(InputStreamReader(input))
         val stringBuilder = StringBuilder()
         while (reader.ready()) {
             val bytesRead = reader.read(charBuffer)
@@ -53,9 +50,8 @@ object ProjectInputReader {
         return content.replace(Regex("[\\n\\r]"), "")
     }
 
-    private fun isSyncSignalContained(input: InputStream, availableBytes: Int): Boolean {
-
-        val bufferSize = minOf(availableBytes, 1024)
+    private fun containsSyncSignal(input: InputStream): Boolean {
+        val bufferSize = 1024
         val buffer = ByteArray(bufferSize)
         input.mark(bufferSize)
         input.read(buffer, 0, bufferSize)

--- a/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/ProjectInputReaderTest.kt
+++ b/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/ProjectInputReaderTest.kt
@@ -59,14 +59,12 @@ class ProjectInputReaderTest {
     @Test
     fun `Should discard newline characters when input contains newline characters`() {
         // given
-        val syncFlag = PipeableParserSyncFlag.SYNC_FLAG.value
         val line1 = "line1"
         val line2 = "line2"
         val newLine = "\n"
 
         val inputStream = PipedInputStream()
         val outputStream = PipedOutputStream(inputStream)
-        outputStream.write(syncFlag.toByteArray(StandardCharsets.UTF_8))
         outputStream.write(line1.toByteArray(StandardCharsets.UTF_8))
         outputStream.write(newLine.toByteArray(StandardCharsets.UTF_8))
         outputStream.write(line2.toByteArray(StandardCharsets.UTF_8))
@@ -104,12 +102,10 @@ class ProjectInputReaderTest {
     @Test
     fun `Should return stream content when no valid project at end of stream`() {
         // given
-        val syncFlag = PipeableParserSyncFlag.SYNC_FLAG.value
         val invalidProjectData = "data\":\"data\"}"
 
         val inputStream = PipedInputStream()
         val outputStream = PipedOutputStream(inputStream)
-        outputStream.write(syncFlag.toByteArray(StandardCharsets.UTF_8))
         outputStream.write(invalidProjectData.toByteArray(StandardCharsets.UTF_8))
         outputStream.close()
 

--- a/analysis/tools/PipeableParser/src/main/kotlin/de/maibornwolff/codecharta/tools/pipeableparser/PipeableParserSyncFlag.kt
+++ b/analysis/tools/PipeableParser/src/main/kotlin/de/maibornwolff/codecharta/tools/pipeableparser/PipeableParserSyncFlag.kt
@@ -1,5 +1,5 @@
 package de.maibornwolff.codecharta.tools.pipeableparser
 
 enum class PipeableParserSyncFlag(val value: String) {
-    SYNC_FLAG("\r\r\r\r\r")
+    SYNC_FLAG("\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E")
 }


### PR DESCRIPTION
# Fix/3406/fix rawtextparser input handling

Issue: #3406

## Description

**Descriptive pull request text**, answering:
  - As part of [#3422](https://github.com/MaibornWolff/codecharta/pull/3422) a sync flag was introduced which clarifies the synchronization process between pipeable parsers
  - The sync flag consisted of carriage return characters - which get written to stdout inconsistently accross shells
  - Carriage returns get substitutued by out-tabs which are not visible to user and get printed consitently

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated