### PR TITLE
Fix/2866/ccsh modify behavior 1 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix parsers crashing after printing output to stdout [#3442](https://github.com/MaibornWolff/codecharta/pull/3442)
+-   Fix removal of nodes in `modify` [#3446](https://github.com/MaibornWolff/codecharta/pull/3446)
 
 ## [1.121.1] - 2023-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 -   Fix parsers crashing after printing output to stdout [#3442](https://github.com/MaibornWolff/codecharta/pull/3442)
--   Fix removal of nodes in `modify` [#3446](https://github.com/MaibornWolff/codecharta/pull/3446)
+-   Fix removal of nodes with identical names in `modify` [#3446](https://github.com/MaibornWolff/codecharta/pull/3446)
 
 ## [1.121.1] - 2023-12-08
 

--- a/analysis/filter/StructureModifier/build.gradle
+++ b/analysis/filter/StructureModifier/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     implementation project(':model')
     implementation project(':tools:InteractiveParser')
-    implementation project(':tools:PipeableParser')
 
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version

--- a/analysis/filter/StructureModifier/build.gradle
+++ b/analysis/filter/StructureModifier/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
     implementation group: 'com.github.kotlin-inquirer', name: 'kotlin-inquirer', version: kotlin_inquirer_version
+    implementation project(path: ':tools:PipeableParser')
+    implementation project(path: ':tools:PipeableParser')
+    implementation project(path: ':tools:PipeableParser')
 
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation project(path: ':model', configuration: 'testOutput')

--- a/analysis/filter/StructureModifier/build.gradle
+++ b/analysis/filter/StructureModifier/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
     implementation group: 'com.github.kotlin-inquirer', name: 'kotlin-inquirer', version: kotlin_inquirer_version
     implementation project(path: ':tools:PipeableParser')
-    implementation project(path: ':tools:PipeableParser')
-    implementation project(path: ':tools:PipeableParser')
 
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation project(path: ':model', configuration: 'testOutput')

--- a/analysis/filter/StructureModifier/build.gradle
+++ b/analysis/filter/StructureModifier/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
     implementation project(':model')
     implementation project(':tools:InteractiveParser')
+    implementation project(':tools:PipeableParser')
 
     implementation group: 'info.picocli', name: 'picocli', version: picocli_version
     implementation group: 'io.github.microutils', name: 'kotlin-logging', version: kotlin_logging_version
     implementation group: 'com.github.kotlin-inquirer', name: 'kotlin-inquirer', version: kotlin_inquirer_version
-    implementation project(path: ':tools:PipeableParser')
 
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version
     testImplementation project(path: ':model', configuration: 'testOutput')

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -31,17 +31,26 @@ class NodeRemover(private val project: Project) {
 
     private fun removeNodes(paths: List<List<String>>): List<MutableNode> {
         val rootNode = project.rootNode.toMutableNode()
-
         for (path in paths) {
             var currentNode = rootNode
-            val rootElementIndex = path.indexOfFirst { it == "root" }
-            val pathSegmentsWithoutRoot = path.subList(rootElementIndex + 1, path.size)
-            for ((index, pathSegment) in pathSegmentsWithoutRoot.withIndex()) {
-                val isLastSegment = index == pathSegmentsWithoutRoot.lastIndex
+            if (path[0] != "root") {
+                logger.warn("Path to node has to start with root: ${path.joinToString("/")}")
+                continue
+            }
+
+            val pathWithoutRoot = path.drop(1)
+            for ((index, pathSegment) in pathWithoutRoot.withIndex()) {
+                val isLastSegment = index == pathWithoutRoot.lastIndex
                 if (isLastSegment) {
                     currentNode.children.removeIf { it.name == pathSegment }
                 } else {
-                    currentNode = currentNode.children.find { it.name == pathSegment } ?: break
+                    val childNode: MutableNode? = currentNode.children.find { it.name == pathSegment }
+                    if (childNode != null) {
+                        currentNode = childNode
+                    } else {
+                        logger.warn("Path to node not found: ${path.joinToString("/")}")
+                        break
+                    }
                 }
             }
         }

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -49,7 +49,6 @@ class NodeRemover(private val project: Project) {
         return listOf(rootNode)
     }
 
-
     private fun removeEdges(removePatterns: Array<String>): MutableList<Edge> {
         var edges = project.edges
         removePatterns.forEach { path -> edges = edges.filter { !it.fromNodeName.contains(path) && !it.toNodeName.contains(path) } }

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -34,8 +34,7 @@ class NodeRemover(private val project: Project) {
 
         for (path in paths) {
             var currentNode = rootNode
-            val pathUntilRoot = path.dropWhile { it != "root" }
-            val pathWithoutRoot = pathUntilRoot.dropWhile { it == "root" }
+            val pathWithoutRoot = path.takeLastWhile { it != "root" }
             for ((index, pathElement) in pathWithoutRoot.withIndex()) {
                 val isLastElement = index == pathWithoutRoot.lastIndex
                 if (isLastElement) {

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -40,7 +40,7 @@ class NodeRemover(private val project: Project) {
 
             val pathWithoutRoot = path.drop(1)
             for ((index, pathSegment) in pathWithoutRoot.withIndex()) {
-                val isLastSegment = index == pathWithoutRoot.lastIndex
+                val isLastSegment = pathWithoutRoot.lastIndex == index
                 if (isLastSegment) {
                     currentNode.children.removeIf { it.name == pathSegment }
                 } else {

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemover.kt
@@ -34,13 +34,14 @@ class NodeRemover(private val project: Project) {
 
         for (path in paths) {
             var currentNode = rootNode
-            val pathWithoutRoot = path.takeLastWhile { it != "root" }
-            for ((index, pathElement) in pathWithoutRoot.withIndex()) {
-                val isLastElement = index == pathWithoutRoot.lastIndex
-                if (isLastElement) {
-                    currentNode.children.removeIf { it.name == pathElement }
+            val rootElementIndex = path.indexOfFirst { it == "root" }
+            val pathSegmentsWithoutRoot = path.subList(rootElementIndex + 1, path.size)
+            for ((index, pathSegment) in pathSegmentsWithoutRoot.withIndex()) {
+                val isLastSegment = index == pathSegmentsWithoutRoot.lastIndex
+                if (isLastSegment) {
+                    currentNode.children.removeIf { it.name == pathSegment }
                 } else {
-                    currentNode = currentNode.children.find { it.name == pathElement } ?: break
+                    currentNode = currentNode.children.find { it.name == pathSegment } ?: break
                 }
             }
         }

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
@@ -6,6 +6,8 @@ import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.tools.interactiveparser.util.CodeChartaConstants
+import de.maibornwolff.codecharta.tools.pipeableparser.PipeableParser
+import de.maibornwolff.codecharta.tools.pipeableparser.PipeableParserSyncFlag
 import de.maibornwolff.codecharta.util.CommaSeparatedParameterPreprocessor
 import de.maibornwolff.codecharta.util.CommaSeparatedStringToListConverter
 import de.maibornwolff.codecharta.util.InputHelper
@@ -25,7 +27,7 @@ class StructureModifier(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : Callable<Unit?>, InteractiveParser {
+) : Callable<Unit?>, InteractiveParser, PipeableParser {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
@@ -76,7 +78,7 @@ class StructureModifier(
     }
 
     override fun call(): Unit? {
-
+        logPipeableParserSyncSignal(PipeableParserSyncFlag.SYNC_FLAG)
         project = readProject() ?: return null
 
         when {

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
@@ -6,8 +6,6 @@ import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import de.maibornwolff.codecharta.tools.interactiveparser.InteractiveParser
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.tools.interactiveparser.util.CodeChartaConstants
-import de.maibornwolff.codecharta.tools.pipeableparser.PipeableParser
-import de.maibornwolff.codecharta.tools.pipeableparser.PipeableParserSyncFlag
 import de.maibornwolff.codecharta.util.CommaSeparatedParameterPreprocessor
 import de.maibornwolff.codecharta.util.CommaSeparatedStringToListConverter
 import de.maibornwolff.codecharta.util.InputHelper
@@ -27,7 +25,7 @@ class StructureModifier(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : Callable<Unit?>, InteractiveParser, PipeableParser {
+) : Callable<Unit?>, InteractiveParser {
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
@@ -78,7 +76,6 @@ class StructureModifier(
     }
 
     override fun call(): Unit? {
-        logPipeableParserSyncSignal(PipeableParserSyncFlag.SYNC_FLAG)
         project = readProject() ?: return null
 
         when {

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -138,13 +138,54 @@ class NodeRemoverTest {
         val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
         val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
         val subProjectExtractor = NodeRemover(mergedProject)
+        val pathToRemove = "/root/src/test/java/io"
 
         // when
-        val result = subProjectExtractor.remove(arrayOf("/root/src/test/java/io"))
+        val result = subProjectExtractor.remove(arrayOf(pathToRemove))
         val testFolder = result.rootNode.children.find { it.name == "src" }
                                         ?.children?.find { it.name == "main" }
                                         ?.children?.find { it.name == "java" }
                                         ?.children?.find { it.name == "io" }
+
+        // then
+        Assertions.assertThat(testFolder).isNotNull()
+    }
+
+    @Test
+    fun `Should correctly remove node when arguments starting with a forward slash get converted to absolute paths (git-bash)`() {
+        // given
+        val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
+        val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
+        val subProjectExtractor = NodeRemover(mergedProject)
+        val pathToRemove = "/root/src/test/java/io"
+        val pathToRemoveAbsolute = "C:/Users/User/AppData/Local/Programs/Git$pathToRemove"
+
+        // when
+        val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
+        val testFolder = result.rootNode.children.find { it.name == "src" }
+                ?.children?.find { it.name == "main" }
+                ?.children?.find { it.name == "java" }
+                ?.children?.find { it.name == "io" }
+
+        // then
+        Assertions.assertThat(testFolder).isNotNull()
+    }
+
+    @Test
+    fun `Should correctly remove node when remove value is absolute path and contains an additional "root" path element`() {
+        // given
+        val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
+        val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
+        val subProjectExtractor = NodeRemover(mergedProject)
+        val pathToRemove = "/root/src/test/java/io"
+        val pathToRemoveAbsolute = "C:/Users/root/AppData/Local/Programs/Git$pathToRemove"
+
+        // when
+        val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
+        val testFolder = result.rootNode.children.find { it.name == "src" }
+                ?.children?.find { it.name == "main" }
+                ?.children?.find { it.name == "java" }
+                ?.children?.find { it.name == "io" }
 
         // then
         Assertions.assertThat(testFolder).isNotNull()

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -182,7 +182,7 @@ class NodeRemoverTest {
         val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
         val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
         val subProjectExtractor = NodeRemover(mergedProject)
-        val pathToRemove = "/root/src/test/java/io"
+        val pathToRemove = "/root/src/test/java/io/root"
         val pathToRemoveAbsolute = "C:/Users/root/AppData/Local/Programs/Git$pathToRemove"
 
         // when
@@ -191,6 +191,7 @@ class NodeRemoverTest {
                 ?.children?.find { it.name == "test" }
                 ?.children?.find { it.name == "java" }
                 ?.children?.find { it.name == "io" }
+                ?.children?.find { it.name == "root" }
 
         // then
         Assertions.assertThat(folderToRemove).isNull()

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -142,13 +142,18 @@ class NodeRemoverTest {
 
         // when
         val result = subProjectExtractor.remove(arrayOf(pathToRemove))
-        val testFolder = result.rootNode.children.find { it.name == "src" }
+        val folderToKeep = result.rootNode.children.find { it.name == "src" }
                                         ?.children?.find { it.name == "main" }
                                         ?.children?.find { it.name == "java" }
                                         ?.children?.find { it.name == "io" }
+        val folderToRemove = result.rootNode.children.find { it.name == "src" }
+                ?.children?.find { it.name == "test" }
+                ?.children?.find { it.name == "java" }
+                ?.children?.find { it.name == "io" }
 
         // then
-        Assertions.assertThat(testFolder).isNotNull()
+        Assertions.assertThat(folderToKeep).isNotNull()
+        Assertions.assertThat(folderToRemove).isNull()
     }
 
     @Test
@@ -162,17 +167,17 @@ class NodeRemoverTest {
 
         // when
         val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
-        val testFolder = result.rootNode.children.find { it.name == "src" }
-                ?.children?.find { it.name == "main" }
+        val folderToRemove = result.rootNode.children.find { it.name == "src" }
+                ?.children?.find { it.name == "test" }
                 ?.children?.find { it.name == "java" }
                 ?.children?.find { it.name == "io" }
 
         // then
-        Assertions.assertThat(testFolder).isNotNull()
+        Assertions.assertThat(folderToRemove).isNull()
     }
 
     @Test
-    fun `Should correctly remove node when remove value is absolute path and contains an additional "root" path element`() {
+    fun `Should correctly remove node when remove value is absolute path and contains an additional 'root' path element`() {
         // given
         val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
         val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
@@ -182,12 +187,12 @@ class NodeRemoverTest {
 
         // when
         val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
-        val testFolder = result.rootNode.children.find { it.name == "src" }
-                ?.children?.find { it.name == "main" }
+        val folderToRemove = result.rootNode.children.find { it.name == "src" }
+                ?.children?.find { it.name == "test" }
                 ?.children?.find { it.name == "java" }
                 ?.children?.find { it.name == "io" }
 
         // then
-        Assertions.assertThat(testFolder).isNotNull()
+        Assertions.assertThat(folderToRemove).isNull()
     }
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -155,45 +155,4 @@ class NodeRemoverTest {
         Assertions.assertThat(folderToKeep).isNotNull()
         Assertions.assertThat(folderToRemove).isNull()
     }
-
-    @Test
-    fun `Should correctly remove node when arguments starting with a forward slash get converted to absolute paths (git-bash)`() {
-        // given
-        val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
-        val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
-        val subProjectExtractor = NodeRemover(mergedProject)
-        val pathToRemove = "/root/src/test/java/io"
-        val pathToRemoveAbsolute = "C:/Users/User/AppData/Local/Programs/Git$pathToRemove"
-
-        // when
-        val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
-        val folderToRemove = result.rootNode.children.find { it.name == "src" }
-                ?.children?.find { it.name == "test" }
-                ?.children?.find { it.name == "java" }
-                ?.children?.find { it.name == "io" }
-
-        // then
-        Assertions.assertThat(folderToRemove).isNull()
-    }
-
-    @Test
-    fun `Should correctly remove node when remove value is absolute path and contains an additional 'root' path element`() {
-        // given
-        val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
-        val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
-        val subProjectExtractor = NodeRemover(mergedProject)
-        val pathToRemove = "/root/src/test/java/io/root"
-        val pathToRemoveAbsolute = "C:/Users/root/AppData/Local/Programs/Git$pathToRemove"
-
-        // when
-        val result = subProjectExtractor.remove(arrayOf(pathToRemoveAbsolute))
-        val folderToRemove = result.rootNode.children.find { it.name == "src" }
-                ?.children?.find { it.name == "test" }
-                ?.children?.find { it.name == "java" }
-                ?.children?.find { it.name == "io" }
-                ?.children?.find { it.name == "root" }
-
-        // then
-        Assertions.assertThat(folderToRemove).isNull()
-    }
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -66,7 +66,7 @@ class NodeRemoverTest {
     }
 
     @Test
-    fun `Should remove affected edges when removal are specified`() {
+    fun `Should remove affected edges when removal is specified`() {
         // when
         val subProjectExtractor = NodeRemover(sampleProject)
         val result = subProjectExtractor.remove(arrayOf("/root/foo"))

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -124,7 +124,7 @@ class NodeRemoverTest {
         // when
         val result = subProjectExtractor.remove(arrayOf("/root/src/test/java/io"))
         val testFolder = result.rootNode.children.find { it.name == "src" }
-                                        ?.children?.find { it.name == "test" }
+                                        ?.children?.find { it.name == "main" }
                                         ?.children?.find { it.name == "java" }
                                         ?.children?.find { it.name == "io" }
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -1,5 +1,6 @@
 package de.maibornwolff.codecharta.filter.structuremodifier
 
+import de.maibornwolff.codecharta.model.Path
 import de.maibornwolff.codecharta.model.Project
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import org.assertj.core.api.Assertions
@@ -111,5 +112,23 @@ class NodeRemoverTest {
         assertEquals(resultProject.attributeDescriptors.size, 3)
         assertEquals(resultProject.attributeDescriptors["rloc"]!!.description, "1")
         assertEquals(resultProject.attributeDescriptors["yrloc"], null)
+    }
+
+    @Test
+    fun `Should correctly remove node when another node in a different subfolder has the same name`() {
+        // given
+        val bufferedReader = File("src/test/resources/merged_project.cc.json").bufferedReader()
+        val mergedProject = ProjectDeserializer.deserializeProject(bufferedReader)
+        val subProjectExtractor = NodeRemover(mergedProject)
+
+        // when
+        val result = subProjectExtractor.remove(arrayOf("/root/src/test/java/io"))
+        val testFolder = result.rootNode.children.find { it.name == "src" }
+                                        ?.children?.find { it.name == "test" }
+                                        ?.children?.find { it.name == "java" }
+                                        ?.children?.find { it.name == "io" }
+
+        // then
+        Assertions.assertThat(testFolder).isNotNull()
     }
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -1,6 +1,5 @@
 package de.maibornwolff.codecharta.filter.structuremodifier
 
-import de.maibornwolff.codecharta.model.Path
 import de.maibornwolff.codecharta.model.Project
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import org.assertj.core.api.Assertions
@@ -21,53 +20,58 @@ class NodeRemoverTest {
     }
 
     @Test
-    fun `Non existent path leads to replication of the project`() {
+    fun `Should replicate project when non existent path specified`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/somethig"))
 
+        // then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(sampleProject)
     }
 
     @Test
-    fun `Non affected nodes are kept`() {
+    fun `Should keep non affected nodes when removal is specified`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/src/main"))
-
         val testFolder = result.rootNode.children.first().children.first()
+
+        // then
         Assertions.assertThat(testFolder.name).isEqualTo("test")
     }
 
     @Test
-    fun `specified nodes are removed`() {
+    fun `Should remove correct nodes when single node is specified for removal`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/src/main"))
-
         val srcContent = result.rootNode.children.first().children
+
+        // then
         Assertions.assertThat(srcContent.size).isEqualTo(2)
         Assertions.assertThat(srcContent.map { it.name }).doesNotContain("main")
     }
 
     @Test
-    fun `multiple nodes are removed`() {
+    fun `Should remove correct nodes when multiple nodes are specified for removal`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/src/main/file1.java", "root/src/folder3/"))
-
         val srcContent = result.rootNode.children.first().children
         val mainContent = srcContent.first().children
+
+        // then
         Assertions.assertThat(srcContent.map { it.name }).doesNotContain("folder3")
         Assertions.assertThat(mainContent.map { it.name }).containsOnly("file2.java")
     }
 
     @Test
-    fun `Affected edges are removed`() {
+    fun `Should remove affected edges when removal are specified`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/foo"))
 
+        // then
         Assertions.assertThat(result.edges.size).isEqualTo(1)
         Assertions.assertThat(result.edges.first()).usingRecursiveComparison().isEqualTo(sampleProject.edges.last())
         Assertions.assertThat(result.edges.map { it.fromNodeName }).doesNotContain("/root/foo")
@@ -75,40 +79,54 @@ class NodeRemoverTest {
     }
 
     @Test
-    fun `Affected edges are removed for multiple removals`() {
-        val subProjectExtractor = NodeRemover(sampleProject)
+    fun `Should remove affected edges when multiple removals are specified`() {
+        // given
         val toExclude = arrayOf("/root/foo/file1", "root/else/")
+        val shouldBeExcluded = listOf("/root/foo/file1", "root/else/file1", "root/else")
 
+        // when
+        val subProjectExtractor = NodeRemover(sampleProject)
         val result = subProjectExtractor.remove(toExclude)
 
-        val shouldBeExcluded = listOf("/root/foo/file1", "root/else/file1", "root/else")
+        // then
         Assertions.assertThat(result.edges.size).isEqualTo(2)
         Assertions.assertThat(result.edges.map { it.fromNodeName }).doesNotContainAnyElementsOf(shouldBeExcluded)
         Assertions.assertThat(result.edges.map { it.toNodeName }).doesNotContainAnyElementsOf(shouldBeExcluded)
     }
 
     @Test
-    fun `Affected blacklist items are removed`() {
+    fun `Should remove correct blacklist items when node removal specified`() {
+        // when
         val subProjectExtractor = NodeRemover(sampleProject)
-
         val result = subProjectExtractor.remove(arrayOf("/root/foo"))
 
+        // then
         Assertions.assertThat(result.blacklist.map { it.path }).doesNotContainSubsequence("/root/foo")
     }
 
     @Test
-    fun `given a remove action attributeDescriptors should get copied if attributes don't change`() {
+    fun `Should keep attributes when only node removal specified`() {
+        // given
         val input = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(DESCRIPTOR_TEST_PATH)!!)
         val attributeProject = ProjectDeserializer.deserializeProject(input)
+
+        // when
         val resultProject = NodeRemover(attributeProject).remove(arrayOf("/root/bigLeaf.ts"))
+
+        // then
         assertEquals(attributeProject.attributeDescriptors.size, resultProject.attributeDescriptors.size)
     }
 
     @Test
-    fun `should remove unused attributeDescriptors if nodes are removed`() {
+    fun `Should remove unused attributeDescriptors when nodes are removed`() {
+        // given
         val input = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(DESCRIPTOR_TEST_PATH)!!)
         val attributeProject = ProjectDeserializer.deserializeProject(input)
+
+        // when
         val resultProject = NodeRemover(attributeProject).remove(arrayOf("/root/AnotherParentLeaf"))
+
+        // then
         assertEquals(resultProject.attributeDescriptors.size, 3)
         assertEquals(resultProject.attributeDescriptors["rloc"]!!.description, "1")
         assertEquals(resultProject.attributeDescriptors["yrloc"], null)

--- a/analysis/filter/StructureModifier/src/test/resources/merged_project.cc.json
+++ b/analysis/filter/StructureModifier/src/test/resources/merged_project.cc.json
@@ -1,0 +1,2156 @@
+{
+  "checksum": "2dfbe70e155d9ab2d490482b94c018f7",
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "children": [
+          {
+            "name": "src",
+            "type": "Folder",
+            "attributes": {},
+            "children": [
+              {
+                "name": "main",
+                "type": "Folder",
+                "attributes": {},
+                "children": [
+                  {
+                    "name": "java",
+                    "type": "Folder",
+                    "attributes": {},
+                    "children": [
+                      {
+                        "name": "io",
+                        "type": "Folder",
+                        "attributes": {},
+                        "link": "",
+                        "children": [
+                          {
+                            "name": "airlift",
+                            "type": "Folder",
+                            "attributes": {},
+                            "link": "",
+                            "children": [
+                              {
+                                "name": "airline",
+                                "type": "Folder",
+                                "attributes": {},
+                                "link": "",
+                                "children": [
+                                  {
+                                    "name": "Accessor.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 227.0,
+                                      "classes": 1.0,
+                                      "functions": 15.0,
+                                      "statements": 109.0,
+                                      "comment_lines": 3.0,
+                                      "mcc": 47.0,
+                                      "cognitive_complexity": 63.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 6.0,
+                                      "code_smell": 12.0,
+                                      "security_hotspot": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Arguments.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 14.0,
+                                      "classes": 1.0,
+                                      "functions": 4.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 4.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Cli.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 264.0,
+                                      "classes": 3.0,
+                                      "functions": 25.0,
+                                      "statements": 97.0,
+                                      "comment_lines": 13.0,
+                                      "mcc": 42.0,
+                                      "cognitive_complexity": 22.0,
+                                      "commented_out_code_blocks": 2.0,
+                                      "max_nesting_level": 2.0,
+                                      "code_smell": 11.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Command.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 15.0,
+                                      "classes": 1.0,
+                                      "functions": 3.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 4.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "CommandFactory.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 5.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "CommandGroupUsage.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 140.0,
+                                      "classes": 1.0,
+                                      "functions": 8.0,
+                                      "statements": 70.0,
+                                      "comment_lines": 8.0,
+                                      "mcc": 29.0,
+                                      "cognitive_complexity": 37.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 4.0,
+                                      "code_smell": 3.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "CommandSuggester.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 23.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 4.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 1.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "CommandUsage.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 106.0,
+                                      "classes": 1.0,
+                                      "functions": 7.0,
+                                      "statements": 52.0,
+                                      "comment_lines": 13.0,
+                                      "mcc": 16.0,
+                                      "cognitive_complexity": 13.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 3.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Context.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 5.0,
+                                      "classes": 1.0,
+                                      "functions": 0.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "DefaultCommandFactory.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 11.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 1.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 1.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "GlobalSuggester.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 22.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 1.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 1.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "GlobalUsage.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 93.0,
+                                      "classes": 1.0,
+                                      "functions": 7.0,
+                                      "statements": 41.0,
+                                      "comment_lines": 8.0,
+                                      "mcc": 15.0,
+                                      "cognitive_complexity": 11.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 2.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "GlobalUsageSummary.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 64.0,
+                                      "classes": 1.0,
+                                      "functions": 5.0,
+                                      "statements": 23.0,
+                                      "comment_lines": 5.0,
+                                      "mcc": 10.0,
+                                      "cognitive_complexity": 4.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 2.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "GroupSuggester.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 20.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 1.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 1.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Help.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 81.0,
+                                      "classes": 1.0,
+                                      "functions": 6.0,
+                                      "statements": 36.0,
+                                      "comment_lines": 4.0,
+                                      "mcc": 15.0,
+                                      "cognitive_complexity": 21.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 5.0,
+                                      "code_smell": 5.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "HelpOption.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 17.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 1.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "code_smell": 1.0,
+                                      "max_nesting_level": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "model",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "ArgumentsMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 119.0,
+                                          "classes": 1.0,
+                                          "functions": 12.0,
+                                          "statements": 56.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 25.0,
+                                          "cognitive_complexity": 13.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 2.0,
+                                          "code_smell": 2.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandGroupMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 52.0,
+                                          "classes": 1.0,
+                                          "functions": 7.0,
+                                          "statements": 19.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 7.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "bug": 0.0,
+                                          "vulnerability": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 91.0,
+                                          "classes": 1.0,
+                                          "functions": 12.0,
+                                          "statements": 31.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 12.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 1.0,
+                                          "security_hotspot": 0.0,
+                                          "bug": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "GlobalMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 64.0,
+                                          "classes": 1.0,
+                                          "functions": 8.0,
+                                          "statements": 22.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 8.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "code_smell": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "MetadataLoader.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 222.0,
+                                          "classes": 2.0,
+                                          "functions": 11.0,
+                                          "statements": 109.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 43.0,
+                                          "cognitive_complexity": 67.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 5.0,
+                                          "code_smell": 4.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 1.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "OptionMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 188.0,
+                                          "classes": 1.0,
+                                          "functions": 16.0,
+                                          "statements": 90.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 36.0,
+                                          "cognitive_complexity": 22.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "code_smell": 3.0,
+                                          "max_nesting_level": 2.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "SuggesterMetadata.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 23.0,
+                                          "classes": 1.0,
+                                          "functions": 3.0,
+                                          "statements": 4.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 3.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "Option.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 18.0,
+                                      "classes": 1.0,
+                                      "functions": 8.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 8.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "OptionType.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 5.0,
+                                      "classes": 1.0,
+                                      "functions": 0.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseArgumentsMissingException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 15.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseArgumentsUnexpectedException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 17.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseCommandMissingException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 9.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 1.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 1.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseCommandUnrecognizedException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 17.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 13.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 2.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseOptionConversionException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 31.0,
+                                      "classes": 1.0,
+                                      "functions": 5.0,
+                                      "statements": 8.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 5.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseOptionMissingException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 15.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseOptionMissingValueException.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 15.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 3.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Parser.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 208.0,
+                                      "classes": 1.0,
+                                      "functions": 10.0,
+                                      "statements": 119.0,
+                                      "comment_lines": 21.0,
+                                      "mcc": 45.0,
+                                      "cognitive_complexity": 60.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 4.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 2.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParserUtil.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 68.0,
+                                      "classes": 1.0,
+                                      "functions": 4.0,
+                                      "statements": 26.0,
+                                      "comment_lines": 4.0,
+                                      "mcc": 17.0,
+                                      "cognitive_complexity": 20.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 3.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ParseState.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 129.0,
+                                      "classes": 1.0,
+                                      "functions": 18.0,
+                                      "statements": 29.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 18.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "SingleCommand.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 75.0,
+                                      "classes": 1.0,
+                                      "functions": 6.0,
+                                      "statements": 28.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 16.0,
+                                      "cognitive_complexity": 12.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 2.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "SuggestCommand.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 72.0,
+                                      "classes": 1.0,
+                                      "functions": 3.0,
+                                      "statements": 17.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 7.0,
+                                      "cognitive_complexity": 9.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 3.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Suggester.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 5.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "code_smell": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TypeConverter.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 78.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 36.0,
+                                      "comment_lines": 3.0,
+                                      "mcc": 19.0,
+                                      "cognitive_complexity": 24.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 9.0,
+                                      "code_smell": 5.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "UsageHelper.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 114.0,
+                                      "classes": 1.0,
+                                      "functions": 7.0,
+                                      "statements": 45.0,
+                                      "comment_lines": 2.0,
+                                      "mcc": 23.0,
+                                      "cognitive_complexity": 13.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 2.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "UsagePrinter.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 109.0,
+                                      "classes": 1.0,
+                                      "functions": 10.0,
+                                      "statements": 58.0,
+                                      "comment_lines": 3.0,
+                                      "mcc": 22.0,
+                                      "cognitive_complexity": 18.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 3.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "com",
+                        "type": "Folder",
+                        "attributes": {},
+                        "link": "",
+                        "children": [
+                          {
+                            "name": "mindflow",
+                            "type": "Folder",
+                            "attributes": {},
+                            "link": "",
+                            "children": [
+                              {
+                                "name": "py4j",
+                                "type": "Folder",
+                                "attributes": {},
+                                "link": "",
+                                "children": [
+                                  {
+                                    "name": "Converter.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 6.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 1.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "exception",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "IllegalPinyinException.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 15.0,
+                                          "classes": 1.0,
+                                          "functions": 4.0,
+                                          "statements": 3.0,
+                                          "comment_lines": 1.0,
+                                          "mcc": 4.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "PinyinConverter.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 115.0,
+                                      "classes": 1.0,
+                                      "functions": 4.0,
+                                      "statements": 68.0,
+                                      "comment_lines": 8.0,
+                                      "mcc": 38.0,
+                                      "cognitive_complexity": 84.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 6.0,
+                                      "code_smell": 6.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "util",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "ArrayUtils.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 15.0,
+                                          "classes": 1.0,
+                                          "functions": 2.0,
+                                          "statements": 7.0,
+                                          "comment_lines": 1.0,
+                                          "mcc": 5.0,
+                                          "cognitive_complexity": 3.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 1.0,
+                                          "code_smell": 1.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "IoUtils.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 44.0,
+                                          "classes": 1.0,
+                                          "functions": 7.0,
+                                          "statements": 19.0,
+                                          "comment_lines": 1.0,
+                                          "mcc": 10.0,
+                                          "cognitive_complexity": 4.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 2.0,
+                                          "code_smell": 1.0,
+                                          "security_hotspot": 1.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "StringUtils.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 57.0,
+                                          "classes": 1.0,
+                                          "functions": 8.0,
+                                          "statements": 30.0,
+                                          "comment_lines": 10.0,
+                                          "mcc": 22.0,
+                                          "cognitive_complexity": 16.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 2.0,
+                                          "code_smell": 2.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "voc",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "Py4jDictionary.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 100.0,
+                                          "classes": 2.0,
+                                          "functions": 9.0,
+                                          "statements": 45.0,
+                                          "comment_lines": 1.0,
+                                          "mcc": 18.0,
+                                          "cognitive_complexity": 18.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 5.0,
+                                          "code_smell": 6.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "test",
+                "type": "Folder",
+                "attributes": {},
+                "children": [
+                  {
+                    "name": "java",
+                    "type": "Folder",
+                    "attributes": {},
+                    "children": [
+                      {
+                        "name": "io",
+                        "type": "Folder",
+                        "attributes": {},
+                        "link": "",
+                        "children": [
+                          {
+                            "name": "airlift",
+                            "type": "Folder",
+                            "attributes": {},
+                            "link": "",
+                            "children": [
+                              {
+                                "name": "airline",
+                                "type": "Folder",
+                                "attributes": {},
+                                "link": "",
+                                "children": [
+                                  {
+                                    "name": "args",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "Args1.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 30.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "Args2.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 20.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "code_smell": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "Args3.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 14.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsArityString.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 13.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 2.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsBooleanArity.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 9.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsBooleanArity0.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 9.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsDefault.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 18.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsEnum.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 13.0,
+                                          "classes": 2.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 2.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "code_smell": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsInherited.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 10.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsMultipleUnparsed.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 11.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 2.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsOutOfMemory.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 12.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "code_smell": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsPrivate.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 13.0,
+                                          "classes": 1.0,
+                                          "functions": 1.0,
+                                          "statements": 1.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 1.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsRequired.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 11.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "ArgsSingleChar.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 32.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "Arity1.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 9.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandHidden.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 11.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "vulnerability": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandLineArgs.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 72.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 1.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "OptionsHidden.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 11.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "OptionsRequired.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 11.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "ArgsRequiredWrongMain.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 7.0,
+                                      "classes": 1.0,
+                                      "functions": 0.0,
+                                      "statements": 0.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 0.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ArgumentConversion.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 87.0,
+                                      "classes": 5.0,
+                                      "functions": 11.0,
+                                      "statements": 20.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 14.0,
+                                      "cognitive_complexity": 3.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 6.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "command",
+                                    "type": "Folder",
+                                    "attributes": {},
+                                    "link": "",
+                                    "children": [
+                                      {
+                                        "name": "CommandAdd.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 16.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0,
+                                          "sonar_issue_other": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandCommit.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 18.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "vulnerability": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandMain.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 8.0,
+                                          "classes": 1.0,
+                                          "functions": 0.0,
+                                          "statements": 0.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 0.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 0.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      },
+                                      {
+                                        "name": "CommandTest.java",
+                                        "type": "File",
+                                        "attributes": {
+                                          "rloc": 47.0,
+                                          "classes": 1.0,
+                                          "functions": 3.0,
+                                          "statements": 18.0,
+                                          "comment_lines": 0.0,
+                                          "mcc": 3.0,
+                                          "cognitive_complexity": 0.0,
+                                          "commented_out_code_blocks": 0.0,
+                                          "max_nesting_level": 0.0,
+                                          "code_smell": 3.0,
+                                          "security_hotspot": 0.0,
+                                          "vulnerability": 0.0,
+                                          "sonar_issue_other": 0.0,
+                                          "bug": 0.0
+                                        },
+                                        "link": "",
+                                        "children": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "Git.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 60.0,
+                                      "classes": 5.0,
+                                      "functions": 3.0,
+                                      "statements": 5.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 3.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "Ping.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 22.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 5.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 3.0,
+                                      "cognitive_complexity": 1.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestArgumentConversion.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 56.0,
+                                      "classes": 1.0,
+                                      "functions": 7.0,
+                                      "statements": 12.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 13.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 5.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestCli.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 23.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 6.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0,
+                                      "vulnerability": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestCommand.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 346.0,
+                                      "classes": 2.0,
+                                      "functions": 42.0,
+                                      "statements": 110.0,
+                                      "comment_lines": 5.0,
+                                      "mcc": 44.0,
+                                      "cognitive_complexity": 2.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 7.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestGalaxyCommandLineParser.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 360.0,
+                                      "classes": 18.0,
+                                      "functions": 20.0,
+                                      "statements": 54.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 20.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 8.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestGit.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 25.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 12.0,
+                                      "comment_lines": 2.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 3.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestHelp.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 441.0,
+                                      "classes": 1.0,
+                                      "functions": 11.0,
+                                      "statements": 64.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 11.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 17.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestingUtil.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 11.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 1.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 0.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestParametersDelegate.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 212.0,
+                                      "classes": 21.0,
+                                      "functions": 8.0,
+                                      "statements": 27.0,
+                                      "comment_lines": 9.0,
+                                      "mcc": 8.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 4.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestPing.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 21.0,
+                                      "classes": 1.0,
+                                      "functions": 2.0,
+                                      "statements": 8.0,
+                                      "comment_lines": 2.0,
+                                      "mcc": 2.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 2.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestSingleCommand.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 326.0,
+                                      "classes": 3.0,
+                                      "functions": 38.0,
+                                      "statements": 101.0,
+                                      "comment_lines": 3.0,
+                                      "mcc": 40.0,
+                                      "cognitive_complexity": 2.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 4.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "sonar_issue_other": 0.0,
+                                      "bug": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "TestTypeConverter.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 342.0,
+                                      "classes": 1.0,
+                                      "functions": 63.0,
+                                      "statements": 80.0,
+                                      "comment_lines": 0.0,
+                                      "mcc": 63.0,
+                                      "cognitive_complexity": 0.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 0.0,
+                                      "code_smell": 1.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "com",
+                        "type": "Folder",
+                        "attributes": {},
+                        "link": "",
+                        "children": [
+                          {
+                            "name": "mindflow",
+                            "type": "Folder",
+                            "attributes": {},
+                            "link": "",
+                            "children": [
+                              {
+                                "name": "py4j",
+                                "type": "Folder",
+                                "attributes": {},
+                                "link": "",
+                                "children": [
+                                  {
+                                    "name": "PinyinConverterTest.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 31.0,
+                                      "classes": 1.0,
+                                      "functions": 4.0,
+                                      "statements": 12.0,
+                                      "comment_lines": 1.0,
+                                      "mcc": 6.0,
+                                      "cognitive_complexity": 2.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 3.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  },
+                                  {
+                                    "name": "ThreadSafeTest.java",
+                                    "type": "File",
+                                    "attributes": {
+                                      "rloc": 26.0,
+                                      "classes": 1.0,
+                                      "functions": 1.0,
+                                      "statements": 12.0,
+                                      "comment_lines": 3.0,
+                                      "mcc": 4.0,
+                                      "cognitive_complexity": 4.0,
+                                      "commented_out_code_blocks": 0.0,
+                                      "max_nesting_level": 1.0,
+                                      "code_smell": 3.0,
+                                      "security_hotspot": 0.0,
+                                      "vulnerability": 0.0,
+                                      "bug": 0.0,
+                                      "sonar_issue_other": 0.0
+                                    },
+                                    "link": "",
+                                    "children": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.3",
+    "edges": [],
+    "attributeTypes": {},
+    "attributeDescriptors": {},
+    "blacklist": []
+  }
+}

--- a/analysis/filter/StructureModifier/src/test/resources/merged_project.cc.json
+++ b/analysis/filter/StructureModifier/src/test/resources/merged_project.cc.json
@@ -2067,6 +2067,36 @@
                                 ]
                               }
                             ]
+                          },
+                          {
+                            "name": "root",
+                            "type": "Folder",
+                            "attributes": {},
+                            "link": "",
+                            "children": [
+                              {
+                                "name": "TestTypeConverter.java",
+                                "type": "File",
+                                "attributes": {
+                                  "rloc": 342.0,
+                                  "classes": 1.0,
+                                  "functions": 63.0,
+                                  "statements": 80.0,
+                                  "comment_lines": 0.0,
+                                  "mcc": 63.0,
+                                  "cognitive_complexity": 0.0,
+                                  "commented_out_code_blocks": 0.0,
+                                  "max_nesting_level": 0.0,
+                                  "code_smell": 1.0,
+                                  "security_hotspot": 0.0,
+                                  "vulnerability": 0.0,
+                                  "bug": 0.0,
+                                  "sonar_issue_other": 0.0
+                                },
+                                "link": "",
+                                "children": []
+                              }
+                            ]
                           }
                         ]
                       },

--- a/analysis/filter/StructureModifier/src/test/resources/test_attributeDescriptors.json
+++ b/analysis/filter/StructureModifier/src/test/resources/test_attributeDescriptors.json
@@ -1,144 +1,144 @@
 {
-	"data": {
-		"projectName": "",
-		"nodes": [
-			{
-				"name": "root",
-				"type": "Folder",
-				"attributes": {},
-				"children": [
-					{
-						"name": "AnotherParentLeaf",
-						"type": "Folder",
-						"attributes": {},
-						"children": [
-							{
-								"name": "smallLeafies.html",
-								"type": "File",
-								"attributes": {
-									"yrloc": 30.0,
-									"yfunctions": 100.0,
-									"ymcc": 100.0,
-									"ypairingRate": 60.0,
-									"yavgCommits": 51.0
-								},
-								"children": []
-							},
-							{
-								"name": "otherSmallLeafies.ts",
-								"type": "File",
-								"attributes": {
-									"yrloc": 70.0,
-									"yfunctions": 1000.0,
-									"ymcc": 10.0,
-									"ypairingRate": 65.0,
-									"yavgCommits": 22.0
-								},
-								"children": []
-							}
-						]
-					},
-					{
-						"name": "bigLeaf.ts",
-						"type": "File",
-						"attributes": {
-							"rloc": 120.0,
-							"functions": 10.0,
-							"mcc": 1.0
-						},
-						"link": "http://www.google.de",
-						"children": []
-					},
-					{
-						"name": "ParentLeaf",
-						"type": "Folder",
-						"attributes": {},
-						"children": [
-							{
-								"name": "smallLeaf.html",
-								"type": "File",
-								"attributes": {
-									"rloc": 30.0,
-									"functions": 101.0,
-									"mcc": 80.0
-								},
-								"children": []
-							},
-							{
-								"name": "otherSmallLeaf.ts",
-								"type": "File",
-								"attributes": {
-									"rloc": 70.0,
-									"functions": 10.0,
-									"mcc": 100.0
-								},
-								"children": []
-							},
-							{
-								"name": "sample2LeafMergedIn.kt",
-								"type": "File",
-								"attributes": {
-									"rloc": 600.0,
-									"functions": 10.0,
-									"mcc": 1.0
-								},
-								"link": "http://www.google.de",
-								"children": []
-							}
-						]
-					}
-				]
-			}
-		],
-		"apiVersion": "1.3",
-		"edges": [],
-		"attributeTypes": {
-			"nodes": {
-				"rloc": "absolute",
-				"functions": "absolute",
-				"mcc": "absolute",
-				"pairingRate": "relative"
-			}
-		},
-		"attributeDescriptors": {
-			"yrloc": {
-				"description": "a",
-				"hintLowValue": "aa",
-				"hintHighValue": "aaa",
-				"link": "aaaa"
-			},
-			"yfunctions": {
-				"description": "b",
-				"hintLowValue": "bb",
-				"hintHighValue": "bbb",
-				"link": "bbbb"
-			},
-			"ymcc": {
-				"description": "c",
-				"hintLowValue": "cc",
-				"hintHighValue": "ccc",
-				"link": "cccc"
-			},
-			"rloc": {
-				"description": "1",
-				"hintLowValue": "1",
-				"hintHighValue": "1",
-				"link": "1"
-			},
-			"functions": {
-				"description": "2",
-				"hintLowValue": "2",
-				"hintHighValue": "2",
-				"link": "2"
-			},
-			"mcc": {
-				"description": "3",
-				"hintLowValue": "3",
-				"hintHighValue": "3",
-				"link": "3"
-			}
-		},
-		"blacklist": []
-	},
-	"checksum": "c3adfbb789ada1b6b7455de0b7d9d220"
+  "checksum": "c3adfbb789ada1b6b7455de0b7d9d220",
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "children": [
+          {
+            "name": "AnotherParentLeaf",
+            "type": "Folder",
+            "attributes": {},
+            "children": [
+              {
+                "name": "smallLeafies.html",
+                "type": "File",
+                "attributes": {
+                  "yrloc": 30.0,
+                  "yfunctions": 100.0,
+                  "ymcc": 100.0,
+                  "ypairingRate": 60.0,
+                  "yavgCommits": 51.0
+                },
+                "children": []
+              },
+              {
+                "name": "otherSmallLeafies.ts",
+                "type": "File",
+                "attributes": {
+                  "yrloc": 70.0,
+                  "yfunctions": 1000.0,
+                  "ymcc": 10.0,
+                  "ypairingRate": 65.0,
+                  "yavgCommits": 22.0
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "name": "bigLeaf.ts",
+            "type": "File",
+            "attributes": {
+              "rloc": 120.0,
+              "functions": 10.0,
+              "mcc": 1.0
+            },
+            "link": "http://www.google.de",
+            "children": []
+          },
+          {
+            "name": "ParentLeaf",
+            "type": "Folder",
+            "attributes": {},
+            "children": [
+              {
+                "name": "smallLeaf.html",
+                "type": "File",
+                "attributes": {
+                  "rloc": 30.0,
+                  "functions": 101.0,
+                  "mcc": 80.0
+                },
+                "children": []
+              },
+              {
+                "name": "otherSmallLeaf.ts",
+                "type": "File",
+                "attributes": {
+                  "rloc": 70.0,
+                  "functions": 10.0,
+                  "mcc": 100.0
+                },
+                "children": []
+              },
+              {
+                "name": "sample2LeafMergedIn.kt",
+                "type": "File",
+                "attributes": {
+                  "rloc": 600.0,
+                  "functions": 10.0,
+                  "mcc": 1.0
+                },
+                "link": "http://www.google.de",
+                "children": []
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.3",
+    "edges": [],
+    "attributeTypes": {
+      "nodes": {
+        "rloc": "absolute",
+        "functions": "absolute",
+        "mcc": "absolute",
+        "pairingRate": "relative"
+      }
+    },
+    "attributeDescriptors": {
+      "yrloc": {
+        "description": "a",
+        "hintLowValue": "aa",
+        "hintHighValue": "aaa",
+        "link": "aaaa"
+      },
+      "yfunctions": {
+        "description": "b",
+        "hintLowValue": "bb",
+        "hintHighValue": "bbb",
+        "link": "bbbb"
+      },
+      "ymcc": {
+        "description": "c",
+        "hintLowValue": "cc",
+        "hintHighValue": "ccc",
+        "link": "cccc"
+      },
+      "rloc": {
+        "description": "1",
+        "hintLowValue": "1",
+        "hintHighValue": "1",
+        "link": "1"
+      },
+      "functions": {
+        "description": "2",
+        "hintLowValue": "2",
+        "hintHighValue": "2",
+        "link": "2"
+      },
+      "mcc": {
+        "description": "3",
+        "hintLowValue": "3",
+        "hintHighValue": "3",
+        "link": "3"
+      }
+    },
+    "blacklist": []
+  }
 }


### PR DESCRIPTION
# Fix/2866/ccsh modify behavior 1 and 3

Issue: #2866

## Description

**Descriptive pull request text**, answering:
  - The path specified to remove a node can now begin with a slash across shells
  - Nodes with the same name in different subfolders get handled correctly in the removal process

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated