### PR TITLE
Set correct options for very high risk metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Fix parsers crashing after printing output to stdout [#3442](https://github.com/MaibornWolff/codecharta/pull/3442)
 -   Fix removal of nodes with identical names in `modify` [#3446](https://github.com/MaibornWolff/codecharta/pull/3446)
+-   Fix the highlighting of very high risk metrics to highlight only matching files [#3454](https://github.com/MaibornWolff/codecharta/pull/3454)
 
 ## [1.121.1] - 2023-12-08
 

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/artificialIntelligence.selector.spec.ts
@@ -16,8 +16,8 @@ describe("ArtificialIntelligenceSelector", () => {
 			analyzedProgrammingLanguage: "java",
 			riskProfile: { highRisk: 37, lowRisk: 46, moderateRisk: 17, veryHighRisk: 0 },
 			suspiciousMetricSuggestionLinks: [
-				{ from: 365, isOutlier: true, metric: "loc", to: 554 },
-				{ from: 29, isOutlier: true, metric: "functions", to: 44 },
+				{ from: 365, isOutlier: true, metric: "loc", to: 554, outlierThreshold: 1001 },
+				{ from: 29, isOutlier: true, metric: "functions", to: 44, outlierThreshold: 75 },
 				{ from: 48, metric: "mcc", to: 71 }
 			],
 			unsuspiciousMetrics: ["rloc (Real Lines of Code)"],
@@ -35,8 +35,8 @@ describe("ArtificialIntelligenceSelector", () => {
 			analyzedProgrammingLanguage: "java",
 			riskProfile: { highRisk: 37, lowRisk: 46, moderateRisk: 17, veryHighRisk: 0 },
 			suspiciousMetricSuggestionLinks: [
-				{ from: 365, isOutlier: true, metric: "loc", to: 554 },
-				{ from: 29, isOutlier: true, metric: "functions", to: 44 },
+				{ from: 365, isOutlier: true, metric: "loc", to: 554, outlierThreshold: 1001 },
+				{ from: 29, isOutlier: true, metric: "functions", to: 44, outlierThreshold: 75 },
 				{ from: 48, metric: "mcc", to: 71 }
 			],
 			unsuspiciousMetrics: ["rloc (Real Lines of Code)"],

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/util/suspiciousMetricsHelper.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/util/suspiciousMetricsHelper.spec.ts
@@ -160,6 +160,7 @@ describe("suspiciousMetricsHelper", () => {
 			{
 				from: 1,
 				isOutlier: true,
+				outlierThreshold: 1000,
 				metric: "mcc",
 				to: 10
 			}

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/util/suspiciousMetricsHelper.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/selectors/util/suspiciousMetricsHelper.ts
@@ -22,6 +22,7 @@ export interface MetricSuggestionParameters {
 	from: number
 	to: number
 	isOutlier?: boolean
+	outlierThreshold?: number
 }
 
 export function calculateSuspiciousMetrics(metricAssessmentResults: MetricAssessmentResults): MetricSuggestionParameters[] {
@@ -35,6 +36,7 @@ export function calculateSuspiciousMetrics(metricAssessmentResults: MetricAssess
 
 		if (metricAssessmentResults.outliersThresholds.has(metricName)) {
 			noticeableMetricSuggestionLinks.get(metricName).isOutlier = true
+			noticeableMetricSuggestionLinks.get(metricName).outlierThreshold = metricAssessmentResults.outliersThresholds.get(metricName)
 		}
 	}
 

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -51,7 +51,12 @@
 			Suspicious {{ item.metric | uppercase }} Files
 		</button>
 
-		<button *ngIf="item.isOutlier" class="risk-button" (click)="applySuspiciousMetric(item, true)" title="Show very high risk files">
+		<button
+			*ngIf="item.isOutlier"
+			class="risk-button"
+			(click)="applySuspiciousMetric(item, true)"
+			title="Show very high risk files (90th percentile)"
+		>
 			<i class="fa fa-exclamation-triangle"></i>
 		</button>
 	</div>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
@@ -138,4 +138,26 @@ describe("SuspiciousMetricsComponent", () => {
 			expect(store.dispatch).toHaveBeenCalledWith(setColorRange({ value: { from: 10, to: 22 } }))
 		})
 	})
+
+	describe("risk-button", () => {
+		it("should set the color range to the correct percentile when very high risk files available", async () => {
+			await render(SuspiciousMetricComponent, {
+				excludeComponentDeclaration: true,
+				componentProperties: {
+					data: {
+						analyzedProgrammingLanguage: "ts",
+						unsuspiciousMetrics: ["rloc"],
+						suspiciousMetricSuggestionLinks: [{ metric: "mcc", from: 10, to: 22, isOutlier: true, outlierThreshold: 120 }],
+						untrackedMetrics: []
+					}
+				}
+			})
+			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
+			await userEvent.click(screen.getByTitle("Show very high risk files"), undefined)
+			const store = TestBed.inject(Store)
+			expect(store.dispatch).toHaveBeenCalledWith(setHeightMetric({ value: "mcc" }))
+			expect(store.dispatch).toHaveBeenCalledWith(setColorMetric({ value: "mcc" }))
+			expect(store.dispatch).toHaveBeenCalledWith(setColorRange({ value: { from: 10, to: 120 } }))
+		})
+	})
 })

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
@@ -153,7 +153,7 @@ describe("SuspiciousMetricsComponent", () => {
 				}
 			})
 			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
-			await userEvent.click(screen.getByTitle("Show very high risk files"), undefined)
+			await userEvent.click(screen.getByTitle("Show very high risk files (90th percentile)"), undefined)
 			const store = TestBed.inject(Store)
 			expect(store.dispatch).toHaveBeenCalledWith(setHeightMetric({ value: "mcc" }))
 			expect(store.dispatch).toHaveBeenCalledWith(setColorMetric({ value: "mcc" }))

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -37,7 +37,10 @@ export class SuspiciousMetricComponent implements OnChanges {
 		this.store.dispatch(setColorMetric({ value: metric.metric }))
 		this.store.dispatch(
 			setColorRange({
-				value: { from: metric.from, to: metric.to }
+				value: {
+					from: metric.from,
+					to: markOutlier ? metric.outlierThreshold : metric.to
+				}
 			})
 		)
 		this.store.dispatch(


### PR DESCRIPTION
# Set correct options for very high risk metrics

Closes: #3450

## Description

**Descriptive pull request text**, answering:
- Highlighting files with very high risk will now exclusively highlight buildings with very high risk metrics, rather than both high risk and very high risk

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated