### PR TITLE
Validate input-file during interactive configuration #3334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   File explorer can be pinned while analyzing the code-map [#3459](https://github.com/MaibornWolff/codecharta/pull/3459)
+-   Validate input file during interactive parser configuration [#3460](https://github.com/MaibornWolff/codecharta/pull/3460)
 
 ### Changed
 

--- a/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/ParserDialog.kt
+++ b/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/ParserDialog.kt
@@ -4,6 +4,7 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.math.BigDecimal
 import java.nio.file.Paths
@@ -11,10 +12,10 @@ import java.nio.file.Paths
 class ParserDialog {
     companion object : ParserDialogInterface {
         override fun collectParserArgs(): List<String> {
-            val inputFileName = KInquirer.promptInput(
-                message = "What is the cc.json file that has to be parsed?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json"
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(
@@ -31,6 +32,12 @@ class ParserDialog {
                 "--output-file=$outputFileName",
                 "--depth-of-hierarchy=$maxHierarchy"
             )
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(
+                    message = "What is the cc.json file that has to be parsed?",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json")
         }
     }
 }

--- a/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/ParserDialog.kt
+++ b/analysis/export/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/exporter/csv/ParserDialog.kt
@@ -7,15 +7,14 @@ import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.math.BigDecimal
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName("cc.json", false)
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(
@@ -32,12 +31,6 @@ class ParserDialog {
                 "--output-file=$outputFileName",
                 "--depth-of-hierarchy=$maxHierarchy"
             )
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(
-                    message = "What is the cc.json file that has to be parsed?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json")
         }
     }
 }

--- a/analysis/export/CSVExporter/src/test/kotlin/de/maibornwolff/codecharta/exporter/csvexporter/ParserDialogTest.kt
+++ b/analysis/export/CSVExporter/src/test/kotlin/de/maibornwolff/codecharta/exporter/csvexporter/ParserDialogTest.kt
@@ -5,10 +5,12 @@ import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import de.maibornwolff.codecharta.exporter.csv.CSVExporter
 import de.maibornwolff.codecharta.exporter.csv.ParserDialog
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -25,7 +27,11 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output arguments that are parsed correctly`() {
+    fun `should output correct arguments when provided with valid input`() {
+        // given
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
+
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
             KInquirer.promptInput(any(), any(), any())
@@ -34,12 +40,37 @@ class ParserDialogTest {
             KInquirer.promptInputNumber(any(), any(), any())
         } returns BigDecimal(5)
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
         val commandLine = CommandLine(CSVExporter())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
 
-        assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().first().name).isEqualTo("sampleFile.cc.json")
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo("sampleOutputFile")
-        assertThat(parseResult.matchedOption("depth-of-hierarchy").getValue<Int>()).isEqualTo(5)
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().first().name).isEqualTo("sampleFile.cc.json")
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo("sampleOutputFile")
+        Assertions.assertThat(parseResult.matchedOption("depth-of-hierarchy").getValue<Int>()).isEqualTo(5)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns "" andThen "sampleFile.cc.json" andThen "sampleOutputFile"
+        every {
+            KInquirer.promptInputNumber(any(), any(), any())
+        } returns BigDecimal(5)
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val commandLine = CommandLine(CSVExporter())
+        val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().first().name).isEqualTo("sampleFile.cc.json")
     }
 }

--- a/analysis/export/CSVExporter/src/test/kotlin/de/maibornwolff/codecharta/exporter/csvexporter/ParserDialogTest.kt
+++ b/analysis/export/CSVExporter/src/test/kotlin/de/maibornwolff/codecharta/exporter/csvexporter/ParserDialogTest.kt
@@ -11,7 +11,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -21,7 +21,7 @@ import java.math.BigDecimal
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
@@ -6,19 +6,16 @@ import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import mu.KotlinLogging
 import java.io.File
-import java.nio.file.Paths
 
 private val logger = KotlinLogging.logger {}
 
 class ParserDialog {
     companion object : ParserDialogInterface {
-        private const val EXTENSION = "cc.json"
-
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName("cc.json", false)
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             logger.info { "File path: $inputFileName" }
 
@@ -37,10 +34,6 @@ class ParserDialog {
             )
 
             return listOf(inputFileName, "--output-file=$outputFileName", "--path-separator=$pathSeparator")
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(message = "What is the $EXTENSION file that has to be parsed?", hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput." + EXTENSION)
         }
     }
 }

--- a/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
+++ b/analysis/filter/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialog.kt
@@ -3,6 +3,7 @@ package de.maibornwolff.codecharta.filter.edgefilter
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import mu.KotlinLogging
 import java.io.File
 import java.nio.file.Paths
@@ -14,11 +15,11 @@ class ParserDialog {
         private const val EXTENSION = "cc.json"
 
         override fun collectParserArgs(): List<String> {
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
-            val inputFileName = KInquirer.promptInput(
-                    message = "What is the $EXTENSION file that has to be parsed?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput." + EXTENSION
-                                                     )
             logger.info { "File path: $inputFileName" }
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
@@ -36,6 +37,10 @@ class ParserDialog {
             )
 
             return listOf(inputFileName, "--output-file=$outputFileName", "--path-separator=$pathSeparator")
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(message = "What is the $EXTENSION file that has to be parsed?", hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput." + EXTENSION)
         }
     }
 }

--- a/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialogTest.kt
+++ b/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialogTest.kt
@@ -8,7 +8,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -17,7 +17,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialogTest.kt
+++ b/analysis/filter/EdgeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/edgefilter/ParserDialogTest.kt
@@ -2,10 +2,12 @@ package de.maibornwolff.codecharta.filter.edgefilter
 
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -21,30 +23,44 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when provided with valid input`() {
+        // given
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
+
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
             KInquirer.promptInput(any(), any(), any())
         } returns "sampleFile.cc.json" andThen "sampleOutputFile" andThen "/"
 
-        val parserArguments = ParserDialog.collectParserArgs()
-
-        assertThat(parserArguments)
-            .isEqualTo(listOf("sampleFile.cc.json", "--output-file=sampleOutputFile", "--path-separator=/"))
-    }
-
-    @Test
-    fun `should output arguments that are parsed correctly`() {
-        mockkStatic("com.github.kinquirer.components.InputKt")
-        every {
-            KInquirer.promptInput(any(), any(), any())
-        } returns "sampleFile.cc.json" andThen "sampleOutputFile" andThen "/"
-
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
         val cmdLine = CommandLine(EdgeFilter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo("sampleOutputFile")
-        assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo('/')
-        assertThat(parseResult.matchedPositional(0).getValue<File>()).isEqualTo(File("sampleFile.cc.json"))
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo("sampleOutputFile")
+        Assertions.assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo('/')
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>()).isEqualTo(File("sampleFile.cc.json"))
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns "" andThen "sampleFile.cc.json" andThen "sampleOutputFile" andThen "/"
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(EdgeFilter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>()).isEqualTo(File("sampleFile.cc.json"))
     }
 }

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
@@ -4,6 +4,8 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
+import java.io.File
 import java.nio.file.Paths
 
 class ParserDialog {
@@ -11,10 +13,10 @@ class ParserDialog {
 
         override fun collectParserArgs(): List<String> {
 
-            val inputFolderName =
-                KInquirer.promptInput(
-                        message = "What is the folder of cc.json files that has to be merged?",
-                        default = Paths.get("").toAbsolutePath().toString())
+            var inputFolderName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFolderName)), canInputContainFolders = true)) {
+                inputFolderName = collectInputFileName()
+            }
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file?"
@@ -49,6 +51,10 @@ class ParserDialog {
                 "--leaf=$leaf",
                 "--ignore-case=$ignoreCase"
             )
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(message = "What is the folder of cc.json files that has to be merged?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
@@ -6,17 +6,15 @@ import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-
-            var inputFolderName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFolderName)), canInputContainFolders = true)) {
-                inputFolderName = collectInputFileName()
-            }
+            var inputFolderName: String
+            do {
+                inputFolderName = getInputFileName("cc.json", true)
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFolderName)), canInputContainFolders = true))
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file?"
@@ -51,10 +49,6 @@ class ParserDialog {
                 "--leaf=$leaf",
                 "--ignore-case=$ignoreCase"
             )
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(message = "What is the folder of cc.json files that has to be merged?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialogTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialogTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialogTest.kt
@@ -3,10 +3,12 @@ package de.maibornwolff.codecharta.filter.mergefilter
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -22,7 +24,8 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when provided with valid input`() {
+        // given
         val inputFolderName = "folder"
         val outputFileName = "sampleOutputFile"
         val compress = false
@@ -30,6 +33,9 @@ class ParserDialogTest {
         val recursive = false
         val leaf = false
         val ignoreCase = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -40,20 +46,51 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns compress andThen addMissing andThen recursive andThen leaf andThen ignoreCase
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val commandLine = CommandLine(MergeFilter())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().map { it.name }).isEqualTo(
-            listOf(
-                inputFolderName
-            )
-        )
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(compress)
-        assertThat(parseResult.matchedOption("add-missing").getValue<Boolean>()).isEqualTo(addMissing)
-        assertThat(parseResult.matchedOption("recursive").getValue<Boolean>()).isEqualTo(recursive)
-        assertThat(parseResult.matchedOption("leaf").getValue<Boolean>()).isEqualTo(leaf)
-        assertThat(parseResult.matchedOption("ignore-case").getValue<Boolean>()).isEqualTo(ignoreCase)
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().map { it.name }).isEqualTo(listOf(inputFolderName))
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(compress)
+        Assertions.assertThat(parseResult.matchedOption("add-missing").getValue<Boolean>()).isEqualTo(addMissing)
+        Assertions.assertThat(parseResult.matchedOption("recursive").getValue<Boolean>()).isEqualTo(recursive)
+        Assertions.assertThat(parseResult.matchedOption("leaf").getValue<Boolean>()).isEqualTo(leaf)
+        Assertions.assertThat(parseResult.matchedOption("ignore-case").getValue<Boolean>()).isEqualTo(ignoreCase)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidInputFolderName = ""
+        val validInputFolderName = "folder"
+        val outputFileName = "sampleOutputFile"
+        val compress = false
+        val addMissing = false
+        val recursive = false
+        val leaf = false
+        val ignoreCase = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns invalidInputFolderName andThen validInputFolderName andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns compress andThen addMissing andThen recursive andThen leaf andThen ignoreCase
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val commandLine = CommandLine(MergeFilter())
+        val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<Array<File>>().map { it.name }).isEqualTo(listOf(validInputFolderName))
     }
 }

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
@@ -14,10 +14,13 @@ class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = KInquirer.promptInput(
+                    message = "What is the cc.json file that has to be modified?",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json"
+                )
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             val selectedAction: String = KInquirer.promptList(
                     message = "Which action do you want to perform?",
@@ -36,10 +39,6 @@ class ParserDialog {
                 StructureModifierAction.REMOVE_NODES.descripton -> listOf(inputFileName, *collectRemoveNodesArguments())
                 else -> listOf()
             }
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(message = "What is the cc.json file that has to be modified?", hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json")
         }
 
         private fun collectPrintArguments(): Array<String> {

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
@@ -5,6 +5,7 @@ import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import com.github.kinquirer.components.promptList
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.math.BigDecimal
 import java.nio.file.Paths
@@ -13,10 +14,10 @@ class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            val inputFolderName =
-                    KInquirer.promptInput(
-                            message = "What is the cc.json file that has to be modified?",
-                            hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json")
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
             val selectedAction: String = KInquirer.promptList(
                     message = "Which action do you want to perform?",
@@ -29,12 +30,16 @@ class ParserDialog {
             )
 
             return when (selectedAction) {
-                StructureModifierAction.PRINT_STRUCTURE.descripton -> listOf(inputFolderName, *collectPrintArguments())
-                StructureModifierAction.SET_ROOT.descripton -> listOf(inputFolderName, *collectSetRootArguments())
-                StructureModifierAction.MOVE_NODES.descripton -> listOf(inputFolderName, *collectMoveNodesArguments())
-                StructureModifierAction.REMOVE_NODES.descripton -> listOf(inputFolderName, *collectRemoveNodesArguments())
+                StructureModifierAction.PRINT_STRUCTURE.descripton -> listOf(inputFileName, *collectPrintArguments())
+                StructureModifierAction.SET_ROOT.descripton -> listOf(inputFileName, *collectSetRootArguments())
+                StructureModifierAction.MOVE_NODES.descripton -> listOf(inputFileName, *collectMoveNodesArguments())
+                StructureModifierAction.REMOVE_NODES.descripton -> listOf(inputFileName, *collectRemoveNodesArguments())
                 else -> listOf()
             }
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(message = "What is the cc.json file that has to be modified?", hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.cc.json")
         }
 
         private fun collectPrintArguments(): Array<String> {

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialogTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialogTest.kt
@@ -10,7 +10,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -20,7 +20,7 @@ import java.math.BigDecimal
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/util/ParserDialogHelper.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/util/ParserDialogHelper.kt
@@ -11,11 +11,11 @@ class ParserDialogHelper {
     companion object {
         fun getInputFiles(isSourceMonitor: Boolean): MutableList<String> {
             val inputFileNames = mutableListOf<String>()
+            var firstFile: String
+            do {
+                firstFile = getInputFileName(isSourceMonitor)
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(firstFile)), canInputContainFolders = false))
 
-            var firstFile = collectFirstFile(isSourceMonitor)
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(firstFile)), canInputContainFolders = false)) {
-                firstFile = collectFirstFile(isSourceMonitor)
-            }
             inputFileNames.add(firstFile)
 
             while (true) {
@@ -30,7 +30,7 @@ class ParserDialogHelper {
             return inputFileNames
         }
 
-        private fun collectFirstFile(isSourceMonitor: Boolean): String {
+        private fun getInputFileName(isSourceMonitor: Boolean): String {
             return KInquirer.promptInput(
                     message = if (isSourceMonitor) "What is the SourceMonitor CSV file that has to be parsed?" else "Please specify the name of the first CSV file to be parsed.",
                     hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.csv"

--- a/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/util/ParserDialogHelper.kt
+++ b/analysis/import/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/util/ParserDialogHelper.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.codecharta.importer.util
 
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -9,22 +10,35 @@ class ParserDialogHelper {
 
     companion object {
         fun getInputFiles(isSourceMonitor: Boolean): MutableList<String> {
-            val inputFileNames = mutableListOf(KInquirer.promptInput(
-                    message = if (isSourceMonitor) { "What is the SourceMonitor CSV file that has to be parsed?" } else { "Please specify the name of the first CSV file to be parsed." },
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.csv"))
+            val inputFileNames = mutableListOf<String>()
+
+            var firstFile = collectFirstFile(isSourceMonitor)
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(firstFile)), canInputContainFolders = false)) {
+                firstFile = collectFirstFile(isSourceMonitor)
+            }
+            inputFileNames.add(firstFile)
 
             while (true) {
-                val additionalFile = KInquirer.promptInput(
-                        message = "If you want to parse additional CSV files, specify the name of the next file. Otherwise, leave this field empty to skip.",
-                                                          )
-                if (additionalFile.isNotBlank()) {
-                    inputFileNames.add(additionalFile)
-                } else {
-                    break
+                var additionalFile = collectAdditionalFile()
+                if (additionalFile.isBlank()) break
+                while (!InputHelper.isInputValidAndNotNull(arrayOf(File(additionalFile)), canInputContainFolders = false)) {
+                    additionalFile = collectAdditionalFile()
                 }
+                inputFileNames.add(additionalFile)
             }
 
             return inputFileNames
+        }
+
+        private fun collectFirstFile(isSourceMonitor: Boolean): String {
+            return KInquirer.promptInput(
+                    message = if (isSourceMonitor) "What is the SourceMonitor CSV file that has to be parsed?" else "Please specify the name of the first CSV file to be parsed.",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.csv"
+            )
+        }
+
+        private fun collectAdditionalFile(): String {
+            return KInquirer.promptInput(message = "If you want to parse additional CSV files, specify the name of the next file. Otherwise, leave this field empty to skip.")
         }
     }
 }

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/csv/ParserDialogTest.kt
@@ -3,12 +3,13 @@ package de.maibornwolff.codecharta.importer.csv
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -23,13 +24,17 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val fileName = "in.csv"
         val outputFileName = "out.cc.json"
         val pathColumnName = "path"
         val delimiter = ";"
         val pathSeparator = "/"
         val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -40,20 +45,23 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(CSVImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("path-column-name").getValue<String>()).isEqualTo(pathColumnName)
-        assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
-        assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
-        assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("path-column-name").getValue<String>()).isEqualTo(pathColumnName)
+        Assertions.assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
+        Assertions.assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
     }
 
     @Test
-    fun `should accept multiple file names`() {
+    fun `should output correct arguments when multiple files are provided`() {
+        // given
         val fileName = "in.csv"
         val fileName2 = "in2.csv"
         val fileName3 = "in3.csv"
@@ -62,6 +70,9 @@ class ParserDialogTest {
         val delimiter = ";"
         val pathSeparator = "/"
         val isCompressed = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true andThen true andThen true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -72,17 +83,56 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(CSVImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("path-column-name").getValue<String>()).isEqualTo(pathColumnName)
-        assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
-        assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
-        assertNull(parseResult.matchedOption("not-compressed"))
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(fileName2)
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[2].name).isEqualTo(fileName3)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("path-column-name").getValue<String>()).isEqualTo(pathColumnName)
+        Assertions.assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
+        Assertions.assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
+        Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(fileName2)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[2].name).isEqualTo(fileName3)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidFileName1 = "invalidFileName"
+        val invalidFileName2 = "invalidFileName2"
+        val validFileName1 = "in.csv"
+        val validFileName2 = "in2.csv"
+        val validFileName3 = "in3.csv"
+        val outputFileName = "out.cc.json"
+        val pathColumnName = "path"
+        val delimiter = ";"
+        val pathSeparator = "/"
+        val isCompressed = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true andThen false andThen true andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any(), any(), any(), any())
+        } returns invalidFileName1 andThen validFileName1 andThen invalidFileName2 andThen validFileName2 andThen validFileName3 andThen "" andThen outputFileName andThen pathColumnName andThen delimiter andThen pathSeparator
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(CSVImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(validFileName1)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(validFileName2)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[2].name).isEqualTo(validFileName3)
     }
 }

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialogTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialogTest.kt
+++ b/analysis/import/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcemonitor/ParserDialogTest.kt
@@ -3,10 +3,12 @@ package de.maibornwolff.codecharta.importer.sourcemonitor
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,10 +25,14 @@ class ParserDialogTest {
 
     @Test
     fun `should output correct arguments`() {
+        // given
         val fileName = "in.csv"
         val outputFileName = "out.cc.json"
         val isCompressed = true
 
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
+
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
             KInquirer.promptInput(any(), any(), any(), any())
@@ -36,20 +42,26 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(SourceMonitorImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("not-compressed")).isNull()
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
     }
 
     @Test
     fun `should output correct arguments not compressed`() {
+        // given
         val fileName = "in.csv"
         val outputFileName = "out.cc.json"
         val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -60,12 +72,46 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(SourceMonitorImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
-        assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val validFileName1 = "in1.csv"
+        val validFileName2 = "in2.csv"
+        val invalidFileName1 = "invalidFileName1"
+        val invalidFileName2 = "invalidFileName2"
+        val outputFileName = "out.cc.json"
+        val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true andThen false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any(), any())
+        } returns invalidFileName1 andThen validFileName1 andThen invalidFileName2 andThen validFileName2 andThen "" andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(SourceMonitorImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(validFileName1)
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(validFileName2)
     }
 }

--- a/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
+++ b/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
@@ -13,10 +13,10 @@ class ParserDialog {
         private const val EXTENSION = "csv"
 
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName()
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(
@@ -37,7 +37,7 @@ class ParserDialog {
             )
         }
 
-        private fun collectInputFileName(): String {
+        private fun getInputFileName(): String {
             val defaultInputFileName = "edges.$EXTENSION"
             val defaultInputFilePath = Paths.get("").toAbsolutePath().toString() + File.separator + defaultInputFileName
             return KInquirer.promptInput(

--- a/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
+++ b/analysis/import/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialog.kt
@@ -4,6 +4,7 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -12,13 +13,10 @@ class ParserDialog {
         private const val EXTENSION = "csv"
 
         override fun collectParserArgs(): List<String> {
-            val defaultInputFileName = "edges.$EXTENSION"
-            val defaultInputFilePath = Paths.get("").toAbsolutePath().toString() + File.separator + defaultInputFileName
-            val inputFileName = KInquirer.promptInput(
-                message = "What is the $EXTENSION file that has to be parsed?",
-                hint = defaultInputFilePath,
-                default = defaultInputFilePath
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(
@@ -36,6 +34,16 @@ class ParserDialog {
                 inputFileName,
                 "--output-file=$outputFileName",
                 if (isCompressed) null else "--not-compressed",
+            )
+        }
+
+        private fun collectInputFileName(): String {
+            val defaultInputFileName = "edges.$EXTENSION"
+            val defaultInputFilePath = Paths.get("").toAbsolutePath().toString() + File.separator + defaultInputFileName
+            return KInquirer.promptInput(
+                    message = "What is the $EXTENSION file that has to be parsed?",
+                    hint = defaultInputFilePath,
+                    default = defaultInputFilePath
             )
         }
     }

--- a/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialogTest.kt
+++ b/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialogTest.kt
@@ -3,7 +3,9 @@ package de.maibornwolff.codecharta.importer.codemaat
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
@@ -23,10 +25,14 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val fileName = "cmi"
         val outputFileName = "cmi.cc.json"
         val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -37,20 +43,26 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(CodeMaatImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<List<File>>()[0].name).isEqualTo(fileName)
     }
 
     @Test
-    fun `should output correct arguments compressed`() {
+    fun `should output correct arguments when compress flag is set`() {
+        // given
         val fileName = "cmi"
         val outputFileName = "cmi.cc.json"
         val isCompressed = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -61,12 +73,43 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(CodeMaatImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         assertNull(parseResult.matchedOption("not-compressed"))
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<List<File>>()[0].name).isEqualTo(fileName)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidFileName = ""
+        val validFileName = "cmi"
+        val outputFileName = "cmi.cc.json"
+        val isCompressed = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns invalidFileName andThen validFileName andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(CodeMaatImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<List<File>>()[0].name).isEqualTo(validFileName)
     }
 }

--- a/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialogTest.kt
+++ b/analysis/import/CodeMaatImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/codemaat/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -19,7 +19,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanParserDialog.kt
+++ b/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanParserDialog.kt
@@ -1,11 +1,8 @@
 package de.maibornwolff.codecharta.importer.gitlogparser.subcommands
 
-import com.github.kinquirer.KInquirer
-import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
-import java.nio.file.Paths
 
 class LogScanParserDialog {
     companion object : ParserDialogInterface {
@@ -13,34 +10,20 @@ class LogScanParserDialog {
         override fun collectParserArgs(): List<String> {
 
             print("You can generate this file with: git log --numstat --raw --topo-order --reverse -m > git.log")
-            var gitLogFile = collectGitLogFile()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLogFile)), canInputContainFolders = false)) {
-                gitLogFile = collectGitLogFile()
-            }
+            var gitLogFile: String
+            do {
+                gitLogFile = getInputFileName("What is the git.log file that has to be parsed?", "git.log")
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLogFile)), canInputContainFolders = false))
 
             print("You can generate this file with: git ls-files > file-name-list.txt")
-            var gitLsFile = collectGitLsFile()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLsFile)), canInputContainFolders = false)) {
-                gitLsFile = collectGitLsFile()
-            }
+            var gitLsFile: String
+            do {
+                gitLsFile = getInputFileName("What is the path to the file name list?", "file-name-list.txt")
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLsFile)), canInputContainFolders = false))
 
             return listOfNotNull(
                 "--git-log=$gitLogFile",
                 "--repo-files=$gitLsFile"
-            )
-        }
-
-        private fun collectGitLogFile(): String {
-            return KInquirer.promptInput(
-                    message = "What is the git.log file that has to be parsed?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "git.log"
-            )
-        }
-
-        private fun collectGitLsFile(): String {
-            return KInquirer.promptInput(
-                    message = "What is the path to the file name list?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "file-name-list.txt"
             )
         }
     }

--- a/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanParserDialog.kt
+++ b/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanParserDialog.kt
@@ -3,6 +3,7 @@ package de.maibornwolff.codecharta.importer.gitlogparser.subcommands
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -12,20 +13,34 @@ class LogScanParserDialog {
         override fun collectParserArgs(): List<String> {
 
             print("You can generate this file with: git log --numstat --raw --topo-order --reverse -m > git.log")
-            val gitLogFile = KInquirer.promptInput(
-                message = "What is the git.log file that has to be parsed?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "git.log"
-            )
+            var gitLogFile = collectGitLogFile()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLogFile)), canInputContainFolders = false)) {
+                gitLogFile = collectGitLogFile()
+            }
 
             print("You can generate this file with: git ls-files > file-name-list.txt")
-            val gitLsFile = KInquirer.promptInput(
-                message = "What is the path to the file name list?",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "file-name-list.txt"
-            )
+            var gitLsFile = collectGitLsFile()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(gitLsFile)), canInputContainFolders = false)) {
+                gitLsFile = collectGitLsFile()
+            }
 
             return listOfNotNull(
                 "--git-log=$gitLogFile",
                 "--repo-files=$gitLsFile"
+            )
+        }
+
+        private fun collectGitLogFile(): String {
+            return KInquirer.promptInput(
+                    message = "What is the git.log file that has to be parsed?",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "git.log"
+            )
+        }
+
+        private fun collectGitLsFile(): String {
+            return KInquirer.promptInput(
+                    message = "What is the path to the file name list?",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "file-name-list.txt"
             )
         }
     }

--- a/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanParserDialog.kt
+++ b/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanParserDialog.kt
@@ -11,11 +11,10 @@ class RepoScanParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-
-            var repoPath = collectRepoPath()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(repoPath)), canInputContainFolders = true)) {
+            var repoPath: String
+            do {
                 repoPath = collectRepoPath()
-            }
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(repoPath)), canInputContainFolders = true))
 
             return listOfNotNull(
                 if (repoPath.isBlank()) null else "--repo-path=$repoPath"

--- a/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanParserDialog.kt
+++ b/analysis/import/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanParserDialog.kt
@@ -3,6 +3,8 @@ package de.maibornwolff.codecharta.importer.gitlogparser.subcommands
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
+import java.io.File
 import java.nio.file.Paths
 
 class RepoScanParserDialog {
@@ -10,13 +12,20 @@ class RepoScanParserDialog {
 
         override fun collectParserArgs(): List<String> {
 
-            val repoPath = KInquirer.promptInput(
-                message = "What is the root directory of the git project you want to parse?",
-                default = Paths.get("").normalize().toAbsolutePath().toString()
-            )
+            var repoPath = collectRepoPath()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(repoPath)), canInputContainFolders = true)) {
+                repoPath = collectRepoPath()
+            }
 
             return listOfNotNull(
                 if (repoPath.isBlank()) null else "--repo-path=$repoPath"
+            )
+        }
+
+        private fun collectRepoPath(): String {
+            return KInquirer.promptInput(
+                    message = "What is the root directory of the git project you want to parse?",
+                    default = Paths.get("").normalize().toAbsolutePath().toString()
             )
         }
     }

--- a/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialogTest.kt
+++ b/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialogTest.kt
@@ -11,7 +11,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -22,7 +22,7 @@ class ParserDialogTest {
 
     private val FIRST_ELEMENT = 1
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialogTest.kt
+++ b/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/ParserDialogTest.kt
@@ -5,12 +5,13 @@ import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.importer.gitlogparser.subcommands.LogScanCommand
 import de.maibornwolff.codecharta.importer.gitlogparser.subcommands.RepoScanCommand
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -27,13 +28,17 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments for repo-scan`() {
+    fun `should output correct arguments when repo-scan is selected`() {
+        // given
         val isLogScan = false
         val pathName = "path/to/repo"
         val outputFileName = "codecharta.cc.json"
         val isCompressed = false
         val isSilent = false
         val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -44,26 +49,31 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
-
         val cmdLine = CommandLine(RepoScanCommand())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.originalArgs()[0].equals("repo-scan"))
-        assertThat(parseResult.matchedOption("repo-path").getValue<String>()).isEqualTo(pathName)
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
-        assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
-        assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("repo-path").getValue<String>()).isEqualTo(pathName)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
+        Assertions.assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
     }
 
     @Test
-    fun `should output correct arguments for repo-scan compressed`() {
+    fun `should output correct arguments when repo-scan is selected and compress-flag is set`() {
+        // given
         val isLogScan = false
         val pathName = "path/to/repo"
         val outputFileName = "codecharta.cc.json"
         val isCompressed = true
         val isSilent = false
         val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -74,20 +84,22 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
-
         val cmdLine = CommandLine(RepoScanCommand())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.originalArgs()[0].equals("repo-scan"))
-        assertThat(parseResult.matchedOption("repo-path").getValue<String>()).isEqualTo(pathName)
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertNull(parseResult.matchedOption("not-compressed"))
-        assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
-        assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("repo-path").getValue<String>()).isEqualTo(pathName)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
+        Assertions.assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
+        Assertions.assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
     }
 
     @Test
-    fun `should output correct arguments for log-scan`() {
+    fun `should output correct arguments when log-scan is selected`() {
+        // given
         val isLogScan = true
         val gitLogFileName = "git.log"
         val fileNameList = "file-name-list.txt"
@@ -96,6 +108,9 @@ class ParserDialogTest {
         val isSilent = false
         val addAuthor = false
 
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true andThen true
+
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
             KInquirer.promptInput(any(), any(), any())
@@ -105,21 +120,23 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
-
         val cmdLine = CommandLine(LogScanCommand())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.originalArgs()[0].equals("log-scan"))
-        assertThat(parseResult.matchedOption("git-log").getValue<File>().name).isEqualTo(gitLogFileName)
-        assertThat(parseResult.matchedOption("repo-files").getValue<File>().name).isEqualTo(fileNameList)
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
-        assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
-        assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("git-log").getValue<File>().name).isEqualTo(gitLogFileName)
+        Assertions.assertThat(parseResult.matchedOption("repo-files").getValue<File>().name).isEqualTo(fileNameList)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
+        Assertions.assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
+        Assertions.assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
     }
 
     @Test
-    fun `should output correct arguments for log-scan compressed`() {
+    fun `should output correct arguments when log-scan is selected and compress-flag is set`() {
+        // given
         val isLogScan = true
         val gitLogFileName = "git.log"
         val fileNameList = "file-name-list.txt"
@@ -128,6 +145,9 @@ class ParserDialogTest {
         val isSilent = false
         val addAuthor = false
 
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true andThen true
+
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
             KInquirer.promptInput(any(), any(), any())
@@ -137,16 +157,84 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
-
         val cmdLine = CommandLine(LogScanCommand())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        assertThat(parseResult.originalArgs()[0].equals("log-scan"))
-        assertThat(parseResult.matchedOption("git-log").getValue<File>().name).isEqualTo(gitLogFileName)
-        assertThat(parseResult.matchedOption("repo-files").getValue<File>().name).isEqualTo(fileNameList)
-        assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
-        assertNull(parseResult.matchedOption("not-compressed"))
-        assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
-        assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("git-log").getValue<File>().name).isEqualTo(gitLogFileName)
+        Assertions.assertThat(parseResult.matchedOption("repo-files").getValue<File>().name).isEqualTo(fileNameList)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
+        Assertions.assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
+        Assertions.assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
+    }
+
+    @Test
+    fun `should prompt user twice for repo-path when first repo-path is invalid`() {
+        // given
+        val isLogScan = false
+        val repoPathNameEmpty = ""
+        val repoPathName = "path/to/repo"
+        val outputFileName = "codecharta.cc.json"
+        val isCompressed = false
+        val isSilent = false
+        val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns repoPathNameEmpty andThen repoPathName andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
+        val cmdLine = CommandLine(RepoScanCommand())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("repo-path").getValue<String>()).isEqualTo(repoPathName)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val isLogScan = true
+        val gitLogFileNameEmpty = ""
+        val gitLogFileName = "git.log"
+        val fileNameListEmpty = ""
+        val fileNameList = "file-name-list.txt"
+        val outputFileName = "codecharta.cc.json"
+        val isCompressed = true
+        val isSilent = false
+        val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true andThen false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns gitLogFileNameEmpty andThen gitLogFileName andThen fileNameListEmpty andThen fileNameList andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isLogScan andThen isCompressed andThen isSilent andThen addAuthor
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs().drop(FIRST_ELEMENT)
+        val cmdLine = CommandLine(LogScanCommand())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("git-log").getValue<File>().name).isEqualTo(gitLogFileName)
+        Assertions.assertThat(parseResult.matchedOption("repo-files").getValue<File>().name).isEqualTo(fileNameList)
     }
 }

--- a/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanCommandTest.kt
+++ b/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/LogScanCommandTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -14,10 +14,10 @@ import java.io.PrintStream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LogScanCommandTest {
-    val errContent = ByteArrayOutputStream()
-    val originalErr = System.err
+    private val errContent = ByteArrayOutputStream()
+    private val originalErr = System.err
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanCommandTest.kt
+++ b/analysis/import/GitLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/gitlogparser/subcommands/RepoScanCommandTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -14,10 +14,10 @@ import java.io.PrintStream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RepoScanCommandTest {
-    val errContent = ByteArrayOutputStream()
-    val originalErr = System.err
+    private val errContent = ByteArrayOutputStream()
+    private val originalErr = System.err
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
@@ -4,6 +4,7 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -17,11 +18,10 @@ class ParserDialog {
                     default = false
                 )
 
-            val inputFile = KInquirer.promptInput(
-                message = if (isJsonFile) "Which MetricGardener json-File do you want to import?"
-                else "What Project do you want to parse?",
-                hint = if (isJsonFile) { Paths.get("").toAbsolutePath().toString() + File.separator + "file.json" } else Paths.get("").toAbsolutePath().toString()
-            )
+            var inputFile = collectInputFileName(isJsonFile)
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFile)), canInputContainFolders = true)) {
+                inputFile = collectInputFileName(isJsonFile)
+            }
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file? If empty, the result will be returned in the terminal",
@@ -38,6 +38,13 @@ class ParserDialog {
                 "--output-file=$outputFileName",
                 if (isCompressed) null else "--not-compressed",
                 if (isJsonFile) "--is-json-file" else null
+            )
+        }
+
+        private fun collectInputFileName(isJsonFile: Boolean): String {
+            return KInquirer.promptInput(
+                    message = if (isJsonFile) "Which MetricGardener json-File do you want to import?" else "What Project do you want to parse?",
+                    hint = if (isJsonFile) { Paths.get("").toAbsolutePath().toString() + File.separator + "file.json" } else Paths.get("").toAbsolutePath().toString()
             )
         }
     }

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialog.kt
@@ -6,7 +6,6 @@ import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
@@ -18,10 +17,10 @@ class ParserDialog {
                     default = false
                 )
 
-            var inputFile = collectInputFileName(isJsonFile)
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFile)), canInputContainFolders = true)) {
+            var inputFile: String
+            do {
                 inputFile = collectInputFileName(isJsonFile)
-            }
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFile)), canInputContainFolders = true))
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file? If empty, the result will be returned in the terminal",
@@ -42,10 +41,9 @@ class ParserDialog {
         }
 
         private fun collectInputFileName(isJsonFile: Boolean): String {
-            return KInquirer.promptInput(
-                    message = if (isJsonFile) "Which MetricGardener json-File do you want to import?" else "What Project do you want to parse?",
-                    hint = if (isJsonFile) { Paths.get("").toAbsolutePath().toString() + File.separator + "file.json" } else Paths.get("").toAbsolutePath().toString()
-            )
+            return if (isJsonFile) {
+                getInputFileName("Which MetricGardener json-File do you want to import?", "yourFile.json")
+            } else getInputFileName("What Project do you want to parse?", "")
         }
     }
 }

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/ParserDialogTest.kt
@@ -3,12 +3,13 @@ package de.maibornwolff.codecharta.importer.metricgardenerimporter
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -23,11 +24,15 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments non compressed`() {
+    fun `should output correct arguments when compress-flag is not set`() {
+        // given
         val fileName = "metricGardenIn.json"
         val outputFileName = "out.cc.json"
         val isCompressed = false
         val isJsonFile = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -38,10 +43,12 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isJsonFile andThen isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(MetricGardenerImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
@@ -49,11 +56,15 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments compressed`() {
+    fun `should output correct arguments when compress-flag is set`() {
+        // given
         val fileName = "metricGardenIn.json"
         val outputFileName = "out.cc.json"
         val isCompressed = true
         val isJsonFile = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -64,13 +75,45 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isJsonFile andThen isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(MetricGardenerImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
-        assertNull(parseResult.matchedOption("not-compressed"))
-        assertNull(parseResult.matchedOption("is-json-file"))
+        Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
+        Assertions.assertThat(parseResult.matchedOption("is-json-file")).isNull()
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidFileName = "invalidFileName"
+        val validFileName = "metricGardenIn.json"
+        val outputFileName = "out.cc.json"
+        val isCompressed = true
+        val isJsonFile = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any(), any())
+        } returns invalidFileName andThen validFileName andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isJsonFile andThen isCompressed
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(MetricGardenerImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(validFileName)
     }
 }

--- a/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
+++ b/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
@@ -15,10 +15,10 @@ class ParserDialog {
 
         override fun collectParserArgs(): List<String> {
             print("You can generate this file with: svn log --verbose > svn.log")
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+            var inputFileName: String
+            do {
                 inputFileName = collectInputFileName()
-            }
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(

--- a/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
+++ b/analysis/import/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialog.kt
@@ -4,6 +4,7 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -14,13 +15,10 @@ class ParserDialog {
 
         override fun collectParserArgs(): List<String> {
             print("You can generate this file with: svn log --verbose > svn.log")
-            val defaultInputFileName = "svn.$EXTENSION"
-            val defaultInputFilePath = Paths.get("").toAbsolutePath().toString() + File.separator + defaultInputFileName
-            val inputFileName = KInquirer.promptInput(
-                message = "What is the $EXTENSION file that has to be parsed?",
-                hint = defaultInputFilePath,
-                default = defaultInputFilePath
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
             val defaultOutputFileName = getOutputFileName(inputFileName)
             val outputFileName: String = KInquirer.promptInput(
@@ -46,6 +44,16 @@ class ParserDialog {
                 "--not-compressed=$isCompressed",
                 "--silent=$isSilent",
                 "--add-author=$addAuthor"
+            )
+        }
+
+        private fun collectInputFileName(): String {
+            val defaultInputFileName = "svn.$EXTENSION"
+            val defaultInputFilePath = Paths.get("").toAbsolutePath().toString() + File.separator + defaultInputFileName
+            return KInquirer.promptInput(
+                    message = "What is the $EXTENSION file that has to be parsed?",
+                    hint = defaultInputFilePath,
+                    default = defaultInputFilePath
             )
         }
     }

--- a/analysis/import/SVNLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialogTest.kt
+++ b/analysis/import/SVNLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/SVNLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialogTest.kt
+++ b/analysis/import/SVNLogParser/src/test/kotlin/de/maibornwolff/codecharta/importer/svnlogparser/ParserDialogTest.kt
@@ -3,7 +3,9 @@ package de.maibornwolff.codecharta.importer.svnlogparser
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
@@ -22,12 +24,16 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments that can be parsed`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val fileName = "svn.log"
         val outputFileName = "codecharta.cc.json"
         val isCompressed = false
         val isSilent = false
         val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -38,15 +44,47 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed andThen isSilent andThen addAuthor
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(SVNLogParser())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
-        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>())
-                .isEqualTo(outputFileName)
+
+        // then
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
         Assertions.assertThat(parseResult.matchedOption("silent").getValue<Boolean>()).isEqualTo(isSilent)
         Assertions.assertThat(parseResult.matchedOption("add-author").getValue<Boolean>()).isEqualTo(addAuthor)
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidInputFileName = ""
+        val validInputFileName = "svn.log"
+        val outputFileName = "codecharta.cc.json"
+        val isCompressed = false
+        val isSilent = false
+        val addAuthor = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns invalidInputFileName andThen validInputFileName andThen outputFileName
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed andThen isSilent andThen addAuthor
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(SVNLogParser())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(validInputFileName)
     }
 }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
@@ -4,25 +4,29 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import mu.KotlinLogging
 
 class ParserDialog {
     companion object : ParserDialogInterface {
+    private val logger = KotlinLogging.logger {}
 
         override fun collectParserArgs(): List<String> {
-            val hostUrl = KInquirer.promptInput(
-                message = "What is the sonar.host.url of your project?",
-                hint = "https://sonar.foo"
-            )
+            var hostUrl = collectHostUrl()
+            while (hostUrl.isEmpty()) {
+                logger.error("Empty hostUrl is not allowed!")
+                hostUrl = collectHostUrl()
+            }
 
-            val projectKey = KInquirer.promptInput(
-                message = "What is the sonar.projectKey?",
-                hint = "de.foo:bar"
-            )
+            var projectKey = collectProjectKey()
+            while (projectKey.isEmpty()) {
+                logger.error("Empty projectKey is not allowed!")
+                projectKey = collectProjectKey()
+            }
 
             val userToken: String = KInquirer.promptInput(
                 message = "What is the sonar user token (sonar.login) required to connect to the remote Sonar instance?",
                 hint = "sqp_0a81f6490875e062f79ccdeace23ac3c68dac6e"
-                                                         )
+            )
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file?",
@@ -38,11 +42,10 @@ class ParserDialog {
                 default = true
             )
 
-            val mergeModules: Boolean =
-                KInquirer.promptConfirm(
+            val mergeModules: Boolean = KInquirer.promptConfirm(
                     message = "Do you want to merge modules in multi-module projects?",
                     default = false
-                )
+            )
 
             return listOfNotNull(
                 hostUrl,
@@ -52,9 +55,17 @@ class ParserDialog {
                 if (metrics.isEmpty()) null else "--metrics=${eraseWhitespace(metrics)}",
                 if (isCompressed) null else "--not-compressed",
                 "--merge-modules=$mergeModules",
-                                )
+            )
         }
 
         private fun eraseWhitespace(input: String) = input.replace(" ", "")
+
+        private fun collectHostUrl(): String {
+            return KInquirer.promptInput(message = "What is the sonar.host.url of your project?", hint = "https://sonar.foo")
+        }
+
+        private fun collectProjectKey(): String {
+            return KInquirer.promptInput(message = "What is the sonar.projectKey?", hint = "de.foo:bar")
+        }
     }
 }

--- a/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
+++ b/analysis/import/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialog.kt
@@ -65,7 +65,7 @@ class ParserDialog {
         }
 
         private fun collectProjectKey(): String {
-            return KInquirer.promptInput(message = "What is the sonar.projectKey?", hint = "de.foo:bar")
+            return KInquirer.promptInput(message = "What is the sonar.projectKey?", hint = "Unique identifier of your project")
         }
     }
 }

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialogTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialogTest.kt
@@ -7,7 +7,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -15,7 +15,7 @@ import picocli.CommandLine
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialogTest.kt
+++ b/analysis/import/SonarImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/sonar/ParserDialogTest.kt
@@ -6,9 +6,8 @@ import com.github.kinquirer.components.promptInput
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -22,7 +21,8 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val hostUrl = "https://sonar.foo"
         val projectKey = "de.foo:bar"
         val userToken = "c123d456"
@@ -40,24 +40,24 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns compress andThen mergeModules
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val commandLine = CommandLine(SonarImporterMain())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
-        assertEquals(parseResult.matchedPositional(0).getValue<String>(), hostUrl)
-        assertEquals(parseResult.matchedPositional(1).getValue<String>(), projectKey)
-        assertEquals(parseResult.matchedOption("user-token").getValue<String>(), userToken)
-        assertEquals(parseResult.matchedOption("output-file").getValue<String>(), outputFileName)
-        assertEquals(
-            parseResult.matchedOption("metrics").getValue<ArrayList<String>>(),
-            listOf("metric1", "metric2")
-        )
-        assertEquals(parseResult.matchedOption("not-compressed").getValue<Boolean>(), compress)
-        assertEquals(parseResult.matchedOption("merge-modules").getValue<Boolean>(), mergeModules)
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<String>()).isEqualTo(hostUrl)
+        Assertions.assertThat(parseResult.matchedPositional(1).getValue<String>()).isEqualTo(projectKey)
+        Assertions.assertThat(parseResult.matchedOption("user-token").getValue<String>()).isEqualTo(userToken)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("metrics").getValue<ArrayList<String>>()).isEqualTo(listOf("metric1", "metric2"))
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(compress)
+        Assertions.assertThat(parseResult.matchedOption("merge-modules").getValue<Boolean>()).isEqualTo(mergeModules)
     }
 
     @Test
-    fun `should omit the metrics flag if the metrics are empty`() {
+    fun `should omit the metrics flag when metrics are empty`() {
+        // given
         val hostUrl = "https://sonar.foo"
         val projectKey = "de.foo:bar"
         val userToken = "c123d456"
@@ -75,21 +75,24 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns compress andThen mergeModules
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val commandLine = CommandLine(SonarImporterMain())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
-        assertEquals(parseResult.matchedPositional(0).getValue<String>(), hostUrl)
-        assertEquals(parseResult.matchedPositional(1).getValue<String>(), projectKey)
-        assertEquals(parseResult.matchedOption("user-token").getValue<String>(), userToken)
-        assertEquals(parseResult.matchedOption("output-file").getValue<String>(), outputFileName)
-        assertNull(parseResult.matchedOption("metrics"))
-        assertEquals(parseResult.matchedOption("not-compressed").getValue<Boolean>(), compress)
-        assertEquals(parseResult.matchedOption("merge-modules").getValue<Boolean>(), mergeModules)
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<String>()).isEqualTo(hostUrl)
+        Assertions.assertThat(parseResult.matchedPositional(1).getValue<String>()).isEqualTo(projectKey)
+        Assertions.assertThat(parseResult.matchedOption("user-token").getValue<String>()).isEqualTo(userToken)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("metrics")).isNull()
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(compress)
+        Assertions.assertThat(parseResult.matchedOption("merge-modules").getValue<Boolean>()).isEqualTo(mergeModules)
     }
 
     @Test
-    fun `should omit the user-tooen flag if user-token is empty`() {
+    fun `should omit the user-token flag when user-token is empty`() {
+        // given
         val hostUrl = "https://sonar.foo"
         val projectKey = "de.foo:bar"
         val userToken = ""
@@ -107,19 +110,78 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns compress andThen mergeModules
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val commandLine = CommandLine(SonarImporterMain())
         val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
-        assertEquals(parseResult.matchedPositional(0).getValue<String>(), hostUrl)
-        assertEquals(parseResult.matchedPositional(1).getValue<String>(), projectKey)
-        assertNull(parseResult.matchedOption("user-token"))
-        assertEquals(parseResult.matchedOption("output-file").getValue<String>(), outputFileName)
-        assertEquals(
-            parseResult.matchedOption("metrics").getValue<ArrayList<String>>(),
-            listOf("metric1", "metric2")
-        )
-        assertEquals(parseResult.matchedOption("not-compressed").getValue<Boolean>(), compress)
-        assertEquals(parseResult.matchedOption("merge-modules").getValue<Boolean>(), mergeModules)
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<String>()).isEqualTo(hostUrl)
+        Assertions.assertThat(parseResult.matchedPositional(1).getValue<String>()).isEqualTo(projectKey)
+        Assertions.assertThat(parseResult.matchedOption("user-token")).isNull()
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("metrics").getValue<ArrayList<String>>()).isEqualTo(listOf("metric1", "metric2"))
+        Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(compress)
+        Assertions.assertThat(parseResult.matchedOption("merge-modules").getValue<Boolean>()).isEqualTo(mergeModules)
+    }
+
+    @Test
+    fun `should prompt user twice for host-url when first host-url is empty`() {
+        // given
+        val emptyHostUrl = ""
+        val hostUrl = "https://sonar.foo"
+        val projectKey = "de.foo:bar"
+        val userToken = "c123d456"
+        val outputFileName = "codecharta.cc.json"
+        val metrics = "metric1, metric2"
+        val compress = false
+        val mergeModules = false
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns emptyHostUrl andThen hostUrl andThen projectKey andThen userToken andThen outputFileName andThen metrics
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns compress andThen mergeModules
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val commandLine = CommandLine(SonarImporterMain())
+        val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<String>()).isEqualTo(hostUrl)
+    }
+
+    @Test
+    fun `should prompt user twice for project-key when first project-key is empty`() {
+        // given
+        val hostUrl = "https://sonar.foo"
+        val emptyProjectKey = ""
+        val projectKey = "de.foo:bar"
+        val userToken = "c123d456"
+        val outputFileName = "codecharta.cc.json"
+        val metrics = "metric1, metric2"
+        val compress = false
+        val mergeModules = false
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any())
+        } returns hostUrl andThen emptyProjectKey andThen projectKey andThen userToken andThen outputFileName andThen metrics
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns compress andThen mergeModules
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val commandLine = CommandLine(SonarImporterMain())
+        val parseResult = commandLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(1).getValue<String>()).isEqualTo(projectKey)
     }
 }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
@@ -6,16 +6,18 @@ import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptListObject
 import com.github.kinquirer.core.Choice
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
+import java.io.File
 import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            val inputFileName = KInquirer.promptInput(
-                    message = "Which project folder or code file should be parsed?",
-                    default = Paths.get("").toAbsolutePath().toString()
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true)) {
+                inputFileName = collectInputFileName()
+            }
 
             val outputFormat = KInquirer.promptListObject(
                     message = "Which output format should be generated?",
@@ -68,6 +70,10 @@ class ParserDialog {
                     if (defaultExcludes) "--default-excludes" else null,
                     if (isVerbose) "--verbose" else null,
             ) + exclude
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(message = "Which project folder or code file should be parsed?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
+++ b/analysis/import/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialog.kt
@@ -8,16 +8,15 @@ import com.github.kinquirer.core.Choice
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName("Which project folder or code file should be parsed?", "")
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true))
 
             val outputFormat = KInquirer.promptListObject(
                     message = "Which output format should be generated?",
@@ -47,7 +46,7 @@ class ParserDialog {
                     message = "Exclude file/folder according to regex pattern? Leave empty to skip.",
                 )
                 if (additionalExclude.isNotBlank()) {
-                    exclude.add("--exclude=" + additionalExclude)
+                    exclude.add("--exclude=$additionalExclude")
                 } else {
                     break
                 }
@@ -70,10 +69,6 @@ class ParserDialog {
                     if (defaultExcludes) "--default-excludes" else null,
                     if (isVerbose) "--verbose" else null,
             ) + exclude
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(message = "Which project folder or code file should be parsed?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialogTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialogTest.kt
@@ -5,7 +5,9 @@ import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptListObject
 import com.github.kinquirer.core.Choice
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
@@ -24,7 +26,8 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val fileName = "in.java"
         val outputFormat = OutputFormat.JSON
         val outputFileName = "out.cc.json"
@@ -32,6 +35,9 @@ class ParserDialogTest {
         val defaultExcludes = true
         val isCompressed = false
         val isVerbose = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -46,14 +52,15 @@ class ParserDialogTest {
             KInquirer.promptListObject(any(), any<List<Choice<OutputFormat>>>(), any(), any(), any())
         } returns outputFormat
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(SourceCodeParserMain())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("format").getValue<OutputFormat>()).isEqualTo(outputFormat)
-        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<File>().name)
-                .isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<File>().name).isEqualTo(outputFileName)
         Assertions.assertThat(parseResult.matchedOption("exclude")).isNull()
         Assertions.assertThat(parseResult.matchedOption("no-issues")).isNull()
         Assertions.assertThat(parseResult.matchedOption("default-excludes").getValue<Boolean>()).isEqualTo(defaultExcludes)
@@ -62,7 +69,8 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should accept multiple exclude patterns`() {
+    fun `should output correct arguments when multiple exclude patterns are specified`() {
+        // given
         val fileName = "in.java"
         val outputFormat = OutputFormat.CSV
         val outputFileName = "out.csv"
@@ -71,6 +79,9 @@ class ParserDialogTest {
         val defaultExcludes = false
         val isCompressed = true
         val isVerbose = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -85,18 +96,56 @@ class ParserDialogTest {
             KInquirer.promptListObject(any(), any<List<Choice<OutputFormat>>>(), any(), any(), any())
         } returns outputFormat
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(SourceCodeParserMain())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("format").getValue<OutputFormat>()).isEqualTo(outputFormat)
-        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<File>().name)
-                .isEqualTo(outputFileName)
+        Assertions.assertThat(parseResult.matchedOption("output-file").getValue<File>().name).isEqualTo(outputFileName)
         Assertions.assertThat(parseResult.matchedOption("exclude").getValue<Array<String>>()).containsExactly(*excludes)
         Assertions.assertThat(parseResult.matchedOption("no-issues").getValue<Boolean>()).isEqualTo(!findIssues)
         Assertions.assertThat(parseResult.matchedOption("default-excludes")).isNull()
         Assertions.assertThat(parseResult.matchedOption("not-compressed")).isNull()
         Assertions.assertThat(parseResult.matchedOption("verbose")).isNull()
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidInputFileName = ""
+        val validInputFileName = "in.java"
+        val outputFormat = OutputFormat.JSON
+        val outputFileName = "out.cc.json"
+        val findIssues = true
+        val defaultExcludes = true
+        val isCompressed = false
+        val isVerbose = true
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any(), any())
+        } returns invalidInputFileName andThen validInputFileName andThen outputFileName andThen ""
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns findIssues andThen defaultExcludes andThen isCompressed andThen isVerbose
+        mockkStatic("com.github.kinquirer.components.ListKt")
+        every {
+            KInquirer.promptListObject(any(), any<List<Choice<OutputFormat>>>(), any(), any(), any())
+        } returns outputFormat
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(SourceCodeParserMain())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(validInputFileName)
     }
 }

--- a/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialogTest.kt
+++ b/analysis/import/SourceCodeParser/src/test/kotlin/de/maibornwolff/codecharta/importer/sourcecodeparser/ParserDialogTest.kt
@@ -11,7 +11,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -20,7 +20,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
+++ b/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
@@ -6,16 +6,15 @@ import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName("what is the Tokei JSON file that should be parsed?", "yourInput.json")
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false))
 
             val outputFileName: String = KInquirer.promptInput(
                     message = "What is the name of the output file?",
@@ -45,13 +44,6 @@ class ParserDialog {
                 "--root-name=$rootName",
                 "--path-separator=$pathSeparator",
                 if (isCompressed) null else "--not-compressed",
-            )
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(
-                    message = "Please specify the name of the Tokei JSON file to be parsed:",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.json"
             )
         }
     }

--- a/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
+++ b/analysis/import/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialog.kt
@@ -4,6 +4,7 @@ import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.nio.file.Paths
 
@@ -11,10 +12,10 @@ class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            val inputFileName = KInquirer.promptInput(
-                    message = "Please specify the name of the Tokei JSON file to be parsed:",
-                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.json"
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = false)) {
+                inputFileName = collectInputFileName()
+            }
 
             val outputFileName: String = KInquirer.promptInput(
                     message = "What is the name of the output file?",
@@ -44,6 +45,13 @@ class ParserDialog {
                 "--root-name=$rootName",
                 "--path-separator=$pathSeparator",
                 if (isCompressed) null else "--not-compressed",
+            )
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(
+                    message = "Please specify the name of the Tokei JSON file to be parsed:",
+                    hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput.json"
             )
         }
     }

--- a/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialogTest.kt
+++ b/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialogTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import picocli.CommandLine
@@ -18,7 +18,7 @@ import java.io.File
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialogTest.kt
+++ b/analysis/import/TokeiImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/tokeiimporter/ParserDialogTest.kt
@@ -3,7 +3,9 @@ package de.maibornwolff.codecharta.importer.tokeiimporter
 import com.github.kinquirer.KInquirer
 import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
+import de.maibornwolff.codecharta.util.InputHelper
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
@@ -22,12 +24,16 @@ class ParserDialogTest {
     }
 
     @Test
-    fun `should output correct arguments`() {
+    fun `should output correct arguments when valid input is provided`() {
+        // given
         val fileName = "in.json"
         val outputFileName = "out.cc.json"
         val rootFolder = "/foo/bar"
         val pathSeparator = "/"
         val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns true
 
         mockkStatic("com.github.kinquirer.components.InputKt")
         every {
@@ -38,14 +44,47 @@ class ParserDialogTest {
             KInquirer.promptConfirm(any(), any())
         } returns isCompressed
 
+        // when
         val parserArguments = ParserDialog.collectParserArgs()
-
         val cmdLine = CommandLine(TokeiImporter())
         val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
         Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(fileName)
         Assertions.assertThat(parseResult.matchedOption("output-file").getValue<String>().equals(outputFileName))
         Assertions.assertThat(parseResult.matchedOption("not-compressed").getValue<Boolean>()).isEqualTo(isCompressed)
         Assertions.assertThat(parseResult.matchedOption("root-name").getValue<String>()).isEqualTo(rootFolder)
         Assertions.assertThat(parseResult.matchedOption("path-separator").getValue<String>()).isEqualTo(pathSeparator)
+    }
+
+    @Test
+    fun `should prompt user twice for input file when first input file is invalid`() {
+        // given
+        val invalidInputFileName = ""
+        val validInputFileName = "in.json"
+        val outputFileName = "out.cc.json"
+        val rootFolder = "/foo/bar"
+        val pathSeparator = "/"
+        val isCompressed = false
+
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValidAndNotNull(any(), any()) } returns false andThen true
+
+        mockkStatic("com.github.kinquirer.components.InputKt")
+        every {
+            KInquirer.promptInput(any(), any(), any(), any())
+        } returns invalidInputFileName andThen validInputFileName andThen outputFileName andThen rootFolder andThen pathSeparator
+        mockkStatic("com.github.kinquirer.components.ConfirmKt")
+        every {
+            KInquirer.promptConfirm(any(), any())
+        } returns isCompressed
+
+        // when
+        val parserArguments = ParserDialog.collectParserArgs()
+        val cmdLine = CommandLine(TokeiImporter())
+        val parseResult = cmdLine.parseArgs(*parserArguments.toTypedArray())
+
+        // then
+        Assertions.assertThat(parseResult.matchedPositional(0).getValue<File>().name).isEqualTo(validInputFileName)
     }
 }

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -5,6 +5,8 @@ import com.github.kinquirer.components.promptConfirm
 import com.github.kinquirer.components.promptInput
 import com.github.kinquirer.components.promptInputNumber
 import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
+import de.maibornwolff.codecharta.util.InputHelper
+import java.io.File
 import java.math.BigDecimal
 import java.nio.file.Paths
 
@@ -12,10 +14,10 @@ class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            val inputFileName = KInquirer.promptInput(
-                message = "What is the file (.txt) or folder that has to be parsed?",
-                default = Paths.get("").toAbsolutePath().toString()
-            )
+            var inputFileName = collectInputFileName()
+            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true)) {
+                inputFileName = collectInputFileName()
+            }
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file (leave empty to print to stdout)?",
@@ -61,6 +63,10 @@ class ParserDialog {
                 "--file-extensions=$fileExtensions",
                 "--without-default-excludes=$withoutDefaultExcludes",
             )
+        }
+
+        private fun collectInputFileName(): String {
+            return KInquirer.promptInput(message = "What is the file (.txt) or folder that has to be parsed?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
+++ b/analysis/parser/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/parser/rawtextparser/ParserDialog.kt
@@ -8,16 +8,15 @@ import de.maibornwolff.codecharta.tools.interactiveparser.ParserDialogInterface
 import de.maibornwolff.codecharta.util.InputHelper
 import java.io.File
 import java.math.BigDecimal
-import java.nio.file.Paths
 
 class ParserDialog {
     companion object : ParserDialogInterface {
 
         override fun collectParserArgs(): List<String> {
-            var inputFileName = collectInputFileName()
-            while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true)) {
-                inputFileName = collectInputFileName()
-            }
+            var inputFileName: String
+            do {
+                inputFileName = getInputFileName("What is the file (.txt) or folder that has to be parsed?", "")
+            } while (!InputHelper.isInputValidAndNotNull(arrayOf(File(inputFileName)), canInputContainFolders = true))
 
             val outputFileName: String = KInquirer.promptInput(
                 message = "What is the name of the output file (leave empty to print to stdout)?",
@@ -63,10 +62,6 @@ class ParserDialog {
                 "--file-extensions=$fileExtensions",
                 "--without-default-excludes=$withoutDefaultExcludes",
             )
-        }
-
-        private fun collectInputFileName(): String {
-            return KInquirer.promptInput(message = "What is the file (.txt) or folder that has to be parsed?", default = Paths.get("").toAbsolutePath().toString())
         }
     }
 }

--- a/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
+++ b/analysis/parser/RawTextParser/src/test/kotlin/de/maibornwolff/codecharta/rawtextparser/ParserDialogTest.kt
@@ -12,7 +12,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -25,7 +25,7 @@ import java.math.BigDecimal
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/tools/InteractiveParser/build.gradle
+++ b/analysis/tools/InteractiveParser/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-
+    implementation group: 'com.github.kotlin-inquirer', name: 'kotlin-inquirer', version: kotlin_inquirer_version
 }

--- a/analysis/tools/InteractiveParser/src/main/kotlin/de/maibornwolff/codecharta/tools/interactiveparser/ParserDialogInterface.kt
+++ b/analysis/tools/InteractiveParser/src/main/kotlin/de/maibornwolff/codecharta/tools/interactiveparser/ParserDialogInterface.kt
@@ -1,7 +1,27 @@
 package de.maibornwolff.codecharta.tools.interactiveparser
 
+import com.github.kinquirer.KInquirer
+import com.github.kinquirer.components.promptInput
+import java.io.File
+import java.nio.file.Paths
+
 interface ParserDialogInterface {
     fun collectParserArgs(): List<String>
+
+    fun getInputFileName(inputType: String, isFolder: Boolean): String {
+        val fileOrFolder = if (isFolder) "folder of $inputType files" else "$inputType file"
+        return KInquirer.promptInput(
+                message = "What is the $fileOrFolder that should be parsed?",
+                hint = Paths.get("").toAbsolutePath().toString() + File.separator + "yourInput$inputType"
+        )
+    }
+
+    fun getInputFileName(customMessage: String, customHint: String): String {
+        return KInquirer.promptInput(
+                message = customMessage,
+                hint = Paths.get("").toAbsolutePath().toString() + if (customHint.isBlank()) "" else File.separator + customHint
+        )
+    }
 
     fun getOutputFileName(fullFileName: String): String {
         return fullFileName.substringAfterLast("/").substringAfterLast("\\").substringBefore(".")

--- a/analysis/tools/ValidationTool/src/test/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialogTest.kt
+++ b/analysis/tools/ValidationTool/src/test/kotlin/de/maibornwolff/codecharta/tools/validation/ParserDialogTest.kt
@@ -6,14 +6,14 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ParserDialogTest {
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }

--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/parser/InteractiveParserSuggestionDialogTest.kt
@@ -13,6 +13,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -40,7 +41,7 @@ class InteractiveParserSuggestionDialogTest {
         System.setErr(originalErrorOut)
     }
 
-    @AfterAll
+    @AfterEach
     fun afterTest() {
         unmockkAll()
     }


### PR DESCRIPTION
# Validate input-file during interactive configuration #3334

Closes: #3334

## Description

**Descriptive pull request text**, answering:
  - Invalid files get detected immediately during interactive parsing

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated