### PR TITLE
feature/1234/keep-label-on-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Clarify sonar user token question [#3445](https://github.com/MaibornWolff/codecharta/pull/3445)
 -   Changed the `--user` flag to `--user-token` in SonarImporter [#3445](https://github.com/MaibornWolff/codecharta/pull/3445)
 -   Changed the interactive dialog of `modify` to prompt user for single action to perform [#3448](https://github.com/MaibornWolff/codecharta/pull/3448)
--   Selected buildings now keep their label untul they are unselected [#3465](https://github.com/MaibornWolff/codecharta/pull/3465)
+-   Selected buildings now keep their label until they are unselected [#3465](https://github.com/MaibornWolff/codecharta/pull/3465)
 
 ### Fixed 🐞
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 -   Clarify sonar user token question [#3445](https://github.com/MaibornWolff/codecharta/pull/3445)
 -   Changed the `--user` flag to `--user-token` in SonarImporter [#3445](https://github.com/MaibornWolff/codecharta/pull/3445)
 -   Changed the interactive dialog of `modify` to prompt user for single action to perform [#3448](https://github.com/MaibornWolff/codecharta/pull/3448)
+-   Selected buildings now keep their label untul they are unselected [#3465](https://github.com/MaibornWolff/codecharta/pull/3465)
 
 ### Fixed 🐞
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -5,7 +5,6 @@ import { ThreeSceneService } from "./threeViewer/threeSceneService"
 import { ThreeRendererService } from "./threeViewer/threeRenderer.service"
 import { ViewCubeMouseEventsService } from "../viewCube/viewCube.mouseEvents.service"
 import { CodeMapBuilding } from "./rendering/codeMapBuilding"
-import { CODE_MAP_BUILDING, CONSTANT_HIGHLIGHT, TEST_FILE_WITH_PATHS, TEST_NODES } from "../../util/dataMocks"
 import { BlacklistItem, CcState, CodeMapNode, Node } from "../../codeCharta.model"
 import { NodeDecorator } from "../../util/nodeDecorator"
 import { klona } from "klona"
@@ -19,6 +18,7 @@ import { setRightClickedNodeData } from "../../state/store/appStatus/rightClicke
 import { State, Store } from "@ngrx/store"
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
 import { defaultState } from "../../state/store/state.manager"
+import { CODE_MAP_BUILDING, CODE_MAP_BUILDING_TS_NODE, CONSTANT_HIGHLIGHT, TEST_FILE_WITH_PATHS, TEST_NODES } from "../../util/dataMocks"
 
 jest.mock("../../state/selectors/accumulatedData/idToNode.selector", () => ({
 	idToNodeSelector: jest.fn()
@@ -871,7 +871,25 @@ describe("codeMapMouseEventService", () => {
 		})
 
 		it("should remove the old and create the new label when selected building is changed", () => {
-			//TODO we need two buildings for this, check if we have two in the mocks
+			const oldSelection = codeMapBuilding
+			const newSelection = CODE_MAP_BUILDING_TS_NODE
+
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			threeSceneService.animateLabel = jest.fn()
+			codeMapLabelService.clearTemporaryLabel = jest.fn()
+			codeMapLabelService.addLeafLabel = jest.fn()
+
+			codeMapMouseEventService["drawLabelForSelected"](codeMapBuilding)
+
+			codeMapMouseEventService["intersectedBuilding"] = newSelection
+			codeMapMouseEventService["onLeftClick"]()
+
+			expect(codeMapMouseEventService["temporaryLabelForSelectedBuilding"]).not.toEqual(oldSelection.node)
+			expect(codeMapMouseEventService["temporaryLabelForSelectedBuilding"]).toEqual(newSelection.node)
+			expect(codeMapLabelService.clearTemporaryLabel).toHaveBeenCalledWith(codeMapBuilding.node)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(oldSelection.node, 0, true)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(newSelection.node, 0, true)
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledTimes(2)
 		})
 
 		it("should keep the label when clicking on the already selected building", () => {
@@ -882,8 +900,8 @@ describe("codeMapMouseEventService", () => {
 
 			codeMapMouseEventService["drawLabelForSelected"](codeMapBuilding)
 			const referenceLabel = codeMapMouseEventService["temporaryLabelForSelectedBuilding"]
-			codeMapMouseEventService["intersectedBuilding"] = codeMapBuilding
 
+			codeMapMouseEventService["intersectedBuilding"] = codeMapBuilding
 			codeMapMouseEventService["onLeftClick"]()
 
 			expect(codeMapMouseEventService["drawLabelForSelected"]).toHaveBeenCalledWith(codeMapBuilding)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -846,12 +846,50 @@ describe("codeMapMouseEventService", () => {
 	})
 
 	describe("labelForSelectedBuilding", () => {
-		it("should create a label when clicking on a building", () => {})
+		it("should create a label when selecting a building", () => {
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			threeSceneService.animateLabel = jest.fn()
+			codeMapLabelService.addLeafLabel = jest.fn()
 
-		it("should remove the label when the building is unselected", () => {})
+			codeMapMouseEventService["drawLabelForSelected"](codeMapBuilding)
 
-		it("should remove the old and create the new label when selected building is changed", () => {})
+			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
+			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
+			expect(codeMapMouseEventService["temporaryLabelForSelectedBuilding"]).toEqual(codeMapBuilding.node)
+		})
 
-		it("should keep the label when clicking on the already selected building", () => {})
+		it("should remove the label when a previously selected building is unselected", () => {
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			threeSceneService.animateLabel = jest.fn()
+			codeMapLabelService.clearTemporaryLabel = jest.fn()
+			codeMapMouseEventService["drawLabelForSelected"](codeMapBuilding)
+
+			codeMapMouseEventService["clearLabelForSelected"]()
+
+			expect(codeMapLabelService.clearTemporaryLabel).toHaveBeenCalledWith(codeMapBuilding.node)
+			expect(codeMapMouseEventService["temporaryLabelForSelectedBuilding"]).toBeNull()
+		})
+
+		it("should remove the old and create the new label when selected building is changed", () => {
+			//TODO we need two buildings for this, check if we have two in the mocks
+		})
+
+		it("should keep the label when clicking on the already selected building", () => {
+			threeSceneService.getLabelForHoveredNode = jest.fn()
+			threeSceneService.animateLabel = jest.fn()
+			codeMapMouseEventService["clearTemporaryLabel"] = jest.fn()
+			codeMapMouseEventService["drawLabelForSelected"] = jest.fn()
+
+			codeMapMouseEventService["drawLabelForSelected"](codeMapBuilding)
+			const referenceLabel = codeMapMouseEventService["temporaryLabelForSelectedBuilding"]
+			codeMapMouseEventService["intersectedBuilding"] = codeMapBuilding
+
+			codeMapMouseEventService["onLeftClick"]()
+
+			expect(codeMapMouseEventService["drawLabelForSelected"]).toHaveBeenCalledWith(codeMapBuilding)
+			expect(codeMapMouseEventService["drawLabelForSelected"]).toHaveBeenCalledTimes(2)
+			expect(codeMapMouseEventService["clearTemporaryLabel"]).not.toHaveBeenCalled()
+			expect(codeMapMouseEventService["temporaryLabelForSelectedBuilding"]).toEqual(referenceLabel)
+		})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -521,6 +521,9 @@ describe("codeMapMouseEventService", () => {
 
 			it("should call selectBuilding when no building is selected", () => {
 				threeSceneService.getSelectedBuilding = jest.fn()
+				threeSceneService.getLabelForHoveredNode = jest.fn()
+				threeSceneService.animateLabel = jest.fn()
+
 				codeMapMouseEventService["intersectedBuilding"] = codeMapBuilding
 
 				codeMapMouseEventService.onDocumentMouseUp(event)
@@ -530,6 +533,9 @@ describe("codeMapMouseEventService", () => {
 
 			it("should call selectBuilding when a new building is selected", () => {
 				threeSceneService.getSelectedBuilding = jest.fn().mockReturnValue(new CodeMapBuilding(200, null, null, null))
+				threeSceneService.getLabelForHoveredNode = jest.fn()
+				threeSceneService.animateLabel = jest.fn()
+
 				codeMapMouseEventService["intersectedBuilding"] = codeMapBuilding
 
 				codeMapMouseEventService.onDocumentMouseUp(event)
@@ -548,6 +554,9 @@ describe("codeMapMouseEventService", () => {
 			})
 
 			it("should not call clearSelection, when the mouse has moved less or exact 3 pixels but a building is currently being clicked upon", () => {
+				threeSceneService.getLabelForHoveredNode = jest.fn()
+				threeSceneService.animateLabel = jest.fn()
+
 				codeMapMouseEventService.onDocumentMouseMove(event)
 				codeMapMouseEventService.onDocumentMouseDown(event)
 				codeMapMouseEventService.onDocumentMouseMove({ clientX: 10, clientY: 17 } as MouseEvent)
@@ -817,7 +826,7 @@ describe("codeMapMouseEventService", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
 			codeMapLabelService.addLeafLabel = jest.fn()
 
-			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
+			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding)
 			const nodeHeight = codeMapBuilding.node.height + Math.abs(codeMapBuilding.node.heightDelta ?? 0)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
@@ -829,10 +838,20 @@ describe("codeMapMouseEventService", () => {
 			threeSceneService.getLabelForHoveredNode = jest.fn()
 			codeMapLabelService.addLeafLabel = jest.fn()
 
-			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding, null)
+			codeMapMouseEventService["drawTemporaryLabelFor"](codeMapBuilding)
 
 			expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
 			expect(codeMapLabelService.addLeafLabel).toHaveBeenCalledWith(codeMapBuilding.node, 0, true)
 		})
+	})
+
+	describe("labelForSelectedBuilding", () => {
+		it("should create a label when clicking on a building", () => {})
+
+		it("should remove the label when the building is unselected", () => {})
+
+		it("should remove the old and create the new label when selected building is changed", () => {})
+
+		it("should keep the label when clicking on the already selected building", () => {})
 	})
 })

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -364,8 +364,8 @@ export class CodeMapMouseEventService implements OnDestroy {
 	}
 
 	private drawLabelForSelected(codeMapBuilding: CodeMapBuilding) {
+		this.clearTemporaryLabel()
 		if (this.temporaryLabelForSelectedBuilding !== null) {
-			this.clearTemporaryLabel()
 			this.codeMapLabelService.clearTemporaryLabel(this.temporaryLabelForSelectedBuilding)
 		}
 		if (!codeMapBuilding.node.isLeaf) {


### PR DESCRIPTION
# Add label for the currently selected building

Issue: #1234

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

Makes the label that appears when hovering over a building stay while the building is selected

**We should not close the connected issue as it had some other ideas that could be implemented later**

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
