### PR TITLE
Rename screenshot button

### DIFF
--- a/visualization/app/codeCharta/ui/actionIcon/actionIcon.component.scss
+++ b/visualization/app/codeCharta/ui/actionIcon/actionIcon.component.scss
@@ -14,6 +14,10 @@ cc-action-icon {
 		background-color: theme.$cc-emphasized-color;
 	}
 
+	&.disabled {
+		opacity: 0.5;
+	}
+
 	i,
 	i.fa {
 		margin: auto;

--- a/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.spec.ts
@@ -17,7 +17,7 @@ jest.mock("html2canvas", () => {
 	}
 })
 
-describe("screenshotButtonComponent", () => {
+describe("legendScreenshotButtonComponent", () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			imports: [LegendPanelModule],
@@ -29,10 +29,6 @@ describe("screenshotButtonComponent", () => {
 		})
 	})
 
-	afterEach(() => {
-		jest.restoreAllMocks()
-	})
-
 	it("should copy to clipboard on click when screenshot to clipboard is enabled", async () => {
 		const user = userEvent.setup()
 		const { fixture } = await render(LegendScreenshotButtonComponent, {
@@ -40,12 +36,12 @@ describe("screenshotButtonComponent", () => {
 			componentProperties: { isLegendVisible: true }
 		})
 
-		const createClipboardItem = (global.ClipboardItem = jest.fn())
+		const clipboardItemMock = (global.ClipboardItem = jest.fn())
 		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
 
 		await user.click(screen.getByTitle("Copy screenshot of legend to clipboard"))
 
-		expect(createClipboardItem).toHaveBeenCalledTimes(1)
+		expect(clipboardItemMock).toHaveBeenCalledTimes(1)
 		expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
 	})
 

--- a/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.spec.ts
@@ -1,6 +1,6 @@
 import { State } from "@ngrx/store"
 import { TestBed } from "@angular/core/testing"
-import { render, screen } from "@testing-library/angular"
+import { render, screen, waitFor } from "@testing-library/angular"
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
 
 import { LegendPanelModule } from "../legendPanel.module"
@@ -41,8 +41,8 @@ describe("legendScreenshotButtonComponent", () => {
 
 		await user.click(screen.getByTitle("Copy screenshot of legend to clipboard"))
 
-		expect(clipboardItemMock).toHaveBeenCalledTimes(1)
 		expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
+		waitFor(() => expect(clipboardItemMock).toHaveBeenCalledTimes(1))
 	})
 
 	it("should save to file on click when screenshot to clipboard is disabled", async () => {
@@ -62,8 +62,8 @@ describe("legendScreenshotButtonComponent", () => {
 
 		await user.click(screen.getByTitle("Export screenshot of legend as file"))
 
-		expect(clickDownloadLinkSpy).toHaveBeenCalledTimes(1)
 		expect(makeScreenshotToFileSpy).toHaveBeenCalledTimes(1)
+		waitFor(() => expect(clickDownloadLinkSpy).toHaveBeenCalledTimes(1))
 	})
 
 	it("should open and close", async () => {
@@ -83,7 +83,7 @@ describe("legendScreenshotButtonComponent", () => {
 		expect(isScreenshotButtonVisible(container)).toBe(false)
 	})
 
-	it("should be disabled if write to console not available in browser", async () => {
+	it("should be disabled if write to console is not available in browser", async () => {
 		const { container } = await render(LegendScreenshotButtonComponent, {
 			excludeComponentDeclaration: true,
 			componentProperties: {
@@ -92,7 +92,7 @@ describe("legendScreenshotButtonComponent", () => {
 			}
 		})
 
-		expect(isScreenshotButtonDisabled(container)).toBe(true)
+		waitFor(() => expect(isScreenshotButtonDisabled(container)).toBe(true))
 	})
 
 	it("should add class 'isAttributeSideBarVisible' to screenshot button, when attribute sidebar is open", async () => {

--- a/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.ts
@@ -6,6 +6,7 @@ import { CcState } from "../../../codeCharta.model"
 import { IsAttributeSideBarVisibleService } from "../../../services/isAttributeSideBarVisible.service"
 import { screenshotToClipboardEnabledSelector } from "../../../state/store/appSettings/enableClipboard/screenshotToClipboardEnabled.selector"
 import { createPNGFileName } from "../../../model/files/files.helper"
+import { checkWriteToClipBoardAllowed, setToClipboard } from "../../../util/clipboard/clipboardWriter"
 
 @Component({
 	selector: "cc-legend-screenshot-button",
@@ -16,7 +17,7 @@ import { createPNGFileName } from "../../../model/files/files.helper"
 export class LegendScreenshotButtonComponent {
 	@Input() isLegendVisible: boolean
 	isRenderingScreenshot: boolean
-	isWriteToClipboardAllowed: boolean = this.checkWriteToClipBoardAllowed()
+	isWriteToClipboardAllowed: boolean = checkWriteToClipBoardAllowed()
 	isScreenshotToClipboardEnabled$ = this.store.select(screenshotToClipboardEnabledSelector)
 
 	constructor(
@@ -40,7 +41,7 @@ export class LegendScreenshotButtonComponent {
 		const element = this.getLegendPanelHTMLElement()
 		const canvas = await this.captureScreenshot(element)
 		const blob: Blob = await new Promise(resolve => canvas.toBlob(resolve))
-		await this.setToClipboard(blob)
+		await setToClipboard(blob)
 		this.isRenderingScreenshot = false
 	}
 
@@ -74,14 +75,5 @@ export class LegendScreenshotButtonComponent {
 		document.body.appendChild(downloadLink)
 		downloadLink.click()
 		downloadLink.remove()
-	}
-
-	private async setToClipboard(blob: Blob) {
-		const data = [new ClipboardItem({ [blob.type]: blob })]
-		await navigator.clipboard.write(data)
-	}
-
-	private checkWriteToClipBoardAllowed(): boolean {
-		return "clipboard" in navigator && "write" in navigator.clipboard
 	}
 }

--- a/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.ts
+++ b/visualization/app/codeCharta/ui/legendPanel/legendScreenshotButton/legendScreenshotButton.component.ts
@@ -6,7 +6,7 @@ import { CcState } from "../../../codeCharta.model"
 import { IsAttributeSideBarVisibleService } from "../../../services/isAttributeSideBarVisible.service"
 import { screenshotToClipboardEnabledSelector } from "../../../state/store/appSettings/enableClipboard/screenshotToClipboardEnabled.selector"
 import { createPNGFileName } from "../../../model/files/files.helper"
-import { checkWriteToClipBoardAllowed, setToClipboard } from "../../../util/clipboard/clipboardWriter"
+import { checkWriteToClipboardAllowed, setToClipboard } from "../../../util/clipboard/clipboardWriter"
 
 @Component({
 	selector: "cc-legend-screenshot-button",
@@ -17,7 +17,7 @@ import { checkWriteToClipBoardAllowed, setToClipboard } from "../../../util/clip
 export class LegendScreenshotButtonComponent {
 	@Input() isLegendVisible: boolean
 	isRenderingScreenshot: boolean
-	isWriteToClipboardAllowed: boolean = checkWriteToClipBoardAllowed()
+	isWriteToClipboardAllowed: boolean = checkWriteToClipboardAllowed()
 	isScreenshotToClipboardEnabled$ = this.store.select(screenshotToClipboardEnabledSelector)
 
 	constructor(

--- a/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.html
+++ b/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.html
@@ -1,14 +1,15 @@
 <cc-action-icon
 	*ngIf="isScreenshotToClipboardEnabled$ | async"
 	[icon]="'fa fa-camera'"
-	title="Copy screenshot to clipboard ({{ SCREENSHOT_HOTKEY_TO_CLIPBOARD }}), export it as a file by ({{ SCREENSHOT_HOTKEY_TO_FILE }})"
-	(click)="makeScreenshotToClipBoard()"
+	title="{{ TITLE_CLIPBOARD_BUTTON }}"
+	(click)="makeScreenshotToClipboard()"
+	[class.disabled]="!isWriteToClipboardAllowed"
 >
 </cc-action-icon>
 <cc-action-icon
 	*ngIf="!(isScreenshotToClipboardEnabled$ | async)"
 	[icon]="'fa fa-camera'"
-	title="Export screenshot as file ({{ SCREENSHOT_HOTKEY_TO_FILE }}), copy it to clipboard by ({{ SCREENSHOT_HOTKEY_TO_CLIPBOARD }})"
+	title="{{ TITLE_FILE_BUTTON }}"
 	(click)="makeScreenshotToFile()"
 >
 </cc-action-icon>

--- a/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
@@ -44,7 +44,7 @@ describe("screenshotButtonComponent", () => {
 			componentProperties: { isWriteToClipboardAllowed: true }
 		})
 
-		const mockClickboardItem = (global.ClipboardItem = jest.fn())
+		const mockClipboardItem = (global.ClipboardItem = jest.fn())
 		const mockToBlob = (HTMLCanvasElement.prototype.toBlob = jest.fn())
 		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
 
@@ -52,7 +52,7 @@ describe("screenshotButtonComponent", () => {
 
 		waitFor(() => {
 			expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
-			expect(mockClickboardItem).toHaveBeenCalledTimes(1)
+			expect(mockClipboardItem).toHaveBeenCalledTimes(1)
 			expect(mockToBlob).toHaveBeenCalledTimes(1)
 		})
 	})
@@ -86,7 +86,7 @@ describe("screenshotButtonComponent", () => {
 			componentProperties: { isWriteToClipboardAllowed: false }
 		})
 
-		const mockClickboardItem = (global.ClipboardItem = jest.fn())
+		const mockClipboardItem = (global.ClipboardItem = jest.fn())
 		const mockToBlob = (HTMLCanvasElement.prototype.toBlob = jest.fn())
 		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
 
@@ -94,7 +94,7 @@ describe("screenshotButtonComponent", () => {
 
 		waitFor(() => {
 			expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
-			expect(mockClickboardItem).not.toHaveBeenCalled()
+			expect(mockClipboardItem).not.toHaveBeenCalled()
 			expect(mockToBlob).not.toHaveBeenCalled()
 			expect(isScreenshotButtonDisabled(container)).toBe(true)
 		})

--- a/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
@@ -44,17 +44,16 @@ describe("screenshotButtonComponent", () => {
 			componentProperties: { isWriteToClipboardAllowed: true }
 		})
 
-		const clipboardItemMock = (global.ClipboardItem = jest.fn())
-		const toBlobMock = (HTMLCanvasElement.prototype.toBlob = jest.fn())
+		const mockClickboardItem = (global.ClipboardItem = jest.fn())
+		const mockToBlob = (HTMLCanvasElement.prototype.toBlob = jest.fn())
 		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
 
 		await user.click(screen.getByTitle("Take a screenshot of the map with Ctrl+Alt+F (copy to clipboard) or Ctrl+Alt+S (save as file)"))
 
-		expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
-
 		waitFor(() => {
-			expect(clipboardItemMock).toHaveBeenCalledTimes(1)
-			expect(toBlobMock).toHaveBeenCalledTimes(1)
+			expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
+			expect(mockClickboardItem).toHaveBeenCalledTimes(1)
+			expect(mockToBlob).toHaveBeenCalledTimes(1)
 		})
 	})
 
@@ -74,28 +73,29 @@ describe("screenshotButtonComponent", () => {
 
 		await user.click(screen.getByTitle("Take a screenshot of the map with Ctrl+Alt+S (save as file) or Ctrl+Alt+F (copy to clipboard)"))
 
-		expect(makeScreenshotToFileSpy).toHaveBeenCalledTimes(1)
-		waitFor(() => expect(clickDownloadLinkSpy).toHaveBeenCalledTimes(1))
+		await waitFor(() => {
+			expect(makeScreenshotToFileSpy).toHaveBeenCalledTimes(1)
+			expect(clickDownloadLinkSpy).toHaveBeenCalledTimes(1)
+		})
 	})
 
-	it("should be disabled when write to console is not available in browser", async () => {
+	it("should be disabled when write to clipoard is not available in browser", async () => {
 		const user = userEvent.setup()
-		const { fixture, container } = await render(ScreenshotButtonComponent, {
+		const { container, fixture } = await render(ScreenshotButtonComponent, {
 			excludeComponentDeclaration: true,
-			componentProperties: { isWriteToClipboardAllowed: true }
+			componentProperties: { isWriteToClipboardAllowed: false }
 		})
 
-		const clipboardItemMock = (global.ClipboardItem = jest.fn())
-		const toBlobMock = (HTMLCanvasElement.prototype.toBlob = jest.fn())
+		const mockClickboardItem = (global.ClipboardItem = jest.fn())
+		const mockToBlob = (HTMLCanvasElement.prototype.toBlob = jest.fn())
 		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
 
 		await user.click(screen.getByTitle("Take a screenshot of the map with Ctrl+Alt+F (copy to clipboard) or Ctrl+Alt+S (save as file)"))
 
-		expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
-
 		waitFor(() => {
-			expect(clipboardItemMock).not.toHaveBeenCalled()
-			expect(toBlobMock).not.toHaveBeenCalled()
+			expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
+			expect(mockClickboardItem).not.toHaveBeenCalled()
+			expect(mockToBlob).not.toHaveBeenCalled()
 			expect(isScreenshotButtonDisabled(container)).toBe(true)
 		})
 	})

--- a/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
+++ b/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.spec.ts
@@ -1,46 +1,90 @@
+import userEvent from "@testing-library/user-event"
 import { ScreenshotButtonComponent } from "./screenshotButton.component"
 import { TestBed } from "@angular/core/testing"
 import { render, screen } from "@testing-library/angular"
 import { ScreenshotButtonModule } from "./screenshotButton.module"
-import userEvent from "@testing-library/user-event"
 import { ThreeRendererService } from "../codeMap/threeViewer/threeRenderer.service"
 import { ThreeCameraService } from "../codeMap/threeViewer/threeCamera.service"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
 import { screenshotToClipboardEnabledSelector } from "../../state/store/appSettings/enableClipboard/screenshotToClipboardEnabled.selector"
 import { State } from "@ngrx/store"
+import { defaultState } from "../../state/store/state.manager"
 
 describe("screenshotButtonComponent", () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			imports: [ScreenshotButtonModule],
 			providers: [
+				provideMockStore({ selectors: [{ selector: screenshotToClipboardEnabledSelector, value: true }] }),
+				{ provide: State, useValue: { getValue: () => defaultState } },
 				{ provide: ThreeCameraService, useValue: {} },
 				{ provide: ThreeSceneService, useValue: {} },
-				{ provide: ThreeRendererService, useValue: {} },
-				{ provide: State, useValue: {} },
-				provideMockStore({ selectors: [{ selector: screenshotToClipboardEnabledSelector, value: true }] })
+				{
+					provide: ThreeRendererService,
+					useValue: {
+						renderer: {
+							getPixelRatio: jest.fn(),
+							setPixelRatio: jest.fn(),
+							getClearColor: jest.fn(),
+							setClearColor: jest.fn(),
+							render: jest.fn(),
+							domElement: document.createElement("canvas")
+						}
+					}
+				}
 			]
 		})
 	})
 
 	it("should copy to clipboard on click, when screenshot to clipboard is enabled", async () => {
-		const { fixture } = await render(ScreenshotButtonComponent, { excludeComponentDeclaration: true })
-		fixture.componentInstance.makeScreenshotToClipBoard = jest.fn()
+		const user = userEvent.setup()
+		const { fixture } = await render(ScreenshotButtonComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: { isWriteToClipboardAllowed: true }
+		})
 
-		await userEvent.click(screen.getByTitle("Copy screenshot to clipboard (Ctrl+Alt+F), export it as a file by (Ctrl+Alt+S)"))
-		expect(fixture.componentInstance.makeScreenshotToClipBoard).toHaveBeenCalled()
+		global.ClipboardItem = jest.fn()
+		HTMLCanvasElement.prototype.toBlob = jest.fn()
+		const makeScreenshotToClipboardSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToClipboard")
+
+		await user.click(screen.getByTitle("Take a screenshot of the map with Ctrl+Alt+F (copy to clipboard) or Ctrl+Alt+S (save as file)"))
+
+		expect(makeScreenshotToClipboardSpy).toHaveBeenCalledTimes(1)
 	})
 
 	it("should save to file on click, when screenshot to clipboard is not enabled", async () => {
-		const { fixture, detectChanges } = await render(ScreenshotButtonComponent, { excludeComponentDeclaration: true })
+		const user = userEvent.setup()
+		const { fixture, detectChanges } = await render(ScreenshotButtonComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: { isWriteToClipboardAllowed: true }
+		})
 		const store = TestBed.inject(MockStore)
 		store.overrideSelector(screenshotToClipboardEnabledSelector, false)
 		store.refreshState()
 		detectChanges()
-		fixture.componentInstance.makeScreenshotToFile = jest.fn()
 
-		await userEvent.click(screen.getByTitle("Export screenshot as file (Ctrl+Alt+S), copy it to clipboard by (Ctrl+Alt+F)"))
-		expect(fixture.componentInstance.makeScreenshotToFile).toHaveBeenCalled()
+		const clickDownloadLinkSpy = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation()
+		const makeScreenshotToFileSpy = jest.spyOn(fixture.componentInstance, "makeScreenshotToFile")
+
+		await user.click(screen.getByTitle("Take a screenshot of the map with Ctrl+Alt+S (save as file) or Ctrl+Alt+F (copy to clipboard)"))
+
+		expect(clickDownloadLinkSpy).toHaveBeenCalledTimes(1)
+		expect(makeScreenshotToFileSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it("should be disabled when write to console is not available in browser", async () => {
+		const { container } = await render(ScreenshotButtonComponent, {
+			excludeComponentDeclaration: true,
+			componentProperties: { isWriteToClipboardAllowed: false }
+		})
+
+		setTimeout(() => {
+			expect(isScreenshotButtonDisabled(container)).toBe(true)
+		})
 	})
 })
+
+function isScreenshotButtonDisabled(container: Element) {
+	return container.querySelector("cc-action-icon").classList.contains("disabled")
+}

--- a/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.ts
+++ b/visualization/app/codeCharta/ui/screenshotButton/screenshotButton.component.ts
@@ -99,7 +99,7 @@ export class ScreenshotButtonComponent {
 	private createTitleClipboardButton() {
 		return this.isWriteToClipboardAllowed
 			? `Take a screenshot of the map with ${this.SCREENSHOT_HOTKEY_TO_CLIPBOARD} (copy to clipboard) or ${this.SCREENSHOT_HOTKEY_TO_FILE} (save as file)`
-			: "Firefox does support copying to clipboard"
+			: "Firefox does not support copying to clipboard"
 	}
 
 	private createTitleFileButton() {

--- a/visualization/app/codeCharta/util/clipboard/clipBoardWriter.spec.ts
+++ b/visualization/app/codeCharta/util/clipboard/clipBoardWriter.spec.ts
@@ -1,0 +1,42 @@
+import userEvent from "@testing-library/user-event"
+import { setToClipboard, checkWriteToClipboardAllowed } from "./clipboardWriter"
+
+describe("clipboardWriter", () => {
+	describe("setToClipboard", () => {
+		it("writes to clipboard with correct data", async () => {
+			userEvent.setup()
+			const text = "sample-text"
+			const blobFromText = new Blob([text], { type: "text/plain" })
+			const clipboard = { write: jest.fn() } as any as Clipboard
+
+			global.ClipboardItem = jest.fn().mockReturnValue(blobFromText)
+			jest.spyOn(navigator, "clipboard", "get").mockReturnValue(clipboard)
+
+			await setToClipboard(blobFromText)
+
+			expect(navigator.clipboard.write).toHaveBeenCalledWith([blobFromText])
+		})
+	})
+
+	describe("checkWriteToClipboardAllowed", () => {
+		it("returns true if clipboard writing is supported", () => {
+			userEvent.setup()
+			const clipboard = { write: jest.fn() } as any as Clipboard
+			jest.spyOn(navigator, "clipboard", "get").mockReturnValue(clipboard)
+
+			const result = checkWriteToClipboardAllowed()
+
+			expect(result).toBe(true)
+		})
+
+		it("returns false if clipboard writing is not supported", () => {
+			userEvent.setup()
+			const clipboard = {} as any as Clipboard
+			jest.spyOn(navigator, "clipboard", "get").mockReturnValue(clipboard)
+
+			const result = checkWriteToClipboardAllowed()
+
+			expect(result).toBe(false)
+		})
+	})
+})

--- a/visualization/app/codeCharta/util/clipboard/clipBoardWriter.spec.ts
+++ b/visualization/app/codeCharta/util/clipboard/clipBoardWriter.spec.ts
@@ -3,7 +3,7 @@ import { setToClipboard, checkWriteToClipboardAllowed } from "./clipboardWriter"
 
 describe("clipboardWriter", () => {
 	describe("setToClipboard", () => {
-		it("writes to clipboard with correct data", async () => {
+		it("writes correct data to clipboard when write to clipboard is supported", async () => {
 			userEvent.setup()
 			const text = "sample-text"
 			const blobFromText = new Blob([text], { type: "text/plain" })
@@ -19,7 +19,7 @@ describe("clipboardWriter", () => {
 	})
 
 	describe("checkWriteToClipboardAllowed", () => {
-		it("returns true if clipboard writing is supported", () => {
+		it("returns true when write to clipboard is supported", () => {
 			userEvent.setup()
 			const clipboard = { write: jest.fn() } as any as Clipboard
 			jest.spyOn(navigator, "clipboard", "get").mockReturnValue(clipboard)
@@ -29,7 +29,7 @@ describe("clipboardWriter", () => {
 			expect(result).toBe(true)
 		})
 
-		it("returns false if clipboard writing is not supported", () => {
+		it("returns false when write to clipboard is not supported", () => {
 			userEvent.setup()
 			const clipboard = {} as any as Clipboard
 			jest.spyOn(navigator, "clipboard", "get").mockReturnValue(clipboard)

--- a/visualization/app/codeCharta/util/clipboard/clipboardWriter.ts
+++ b/visualization/app/codeCharta/util/clipboard/clipboardWriter.ts
@@ -3,6 +3,6 @@ export async function setToClipboard(blob: Blob) {
 	await navigator.clipboard.write(data)
 }
 
-export function checkWriteToClipBoardAllowed(): boolean {
+export function checkWriteToClipboardAllowed(): boolean {
 	return "clipboard" in navigator && "write" in navigator.clipboard
 }

--- a/visualization/app/codeCharta/util/clipboard/clipboardWriter.ts
+++ b/visualization/app/codeCharta/util/clipboard/clipboardWriter.ts
@@ -1,0 +1,8 @@
+export async function setToClipboard(blob: Blob) {
+	const data = [new ClipboardItem({ [blob.type]: blob })]
+	await navigator.clipboard.write(data)
+}
+
+export function checkWriteToClipBoardAllowed(): boolean {
+	return "clipboard" in navigator && "write" in navigator.clipboard
+}


### PR DESCRIPTION
# Rename screenshot button

Closes: #3427

## Description
  - Renames the screenshot button
  - Fixes previous UI problems with taking a screenshot

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated - changelog was updated with PR #3471