### PR TITLE
Adjust metric-gardener-importer for new JSON-Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+-   Fix metric-gardener-importer crashing on new metric-gardener-json-format [#3496](https://github.com/MaibornWolff/codecharta/pull/3496)
 -   Fix buildings inability to be completely red in delta mode [#3439](https://github.com/MaibornWolff/codecharta/pull/3439)
 -   Fix edge preview in visualization [#3439](https://github.com/MaibornWolff/codecharta/pull/3439)
 -   Fix edges start/end intersecting with building in delta mode [#3439](https://github.com/MaibornWolff/codecharta/pull/3439)

--- a/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerNodes.kt
+++ b/analysis/import/MetricGardenerImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerNodes.kt
@@ -3,11 +3,8 @@ package de.maibornwolff.codecharta.importer.metricgardenerimporter.model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
-@JsonIgnoreProperties("relationships")
-class MetricGardenerNodes(
-    @JsonProperty("nodes") var metricGardenerNodes: MutableList<MetricGardenerNode>
-                         ) {
-
+@JsonIgnoreProperties("relationships", "info")
+class MetricGardenerNodes(@JsonProperty("nodes") var metricGardenerNodes: MutableList<MetricGardenerNode>) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerNodesTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/model/MetricGardenerNodesTest.kt
@@ -2,54 +2,103 @@ package de.maibornwolff.codecharta.importer.metricgardenerimporter.model
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
-internal class MetricGardenerNodesTest {
-
+class MetricGardenerNodesTest {
     private val mapper = jacksonObjectMapper()
 
     @Test
-    fun whenDeserializeNodeList_thenSuccess() {
-        val json = """{
-            "nodes": [
+    fun `Should deserialize node-list when node-list contains valid properties only`() {
+        // given
+        val json = """
             {
-                "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt",
-                "type": "File",
-                "metrics": {
-                "mcc": 3,
-                "functions": 3,
-                "classes": 1,
-                "lines_of_code": 79,
-                "comment_lines": 32,
-                "real_lines_of_code": 40
-            },
-                "types": []
-            },
-            {
-                "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt",
-                "type": "File",
-                "metrics": {
-                "mcc": 34,
-                "functions": 8,
-                "classes": 1,
-                "lines_of_code": 188,
-                "comment_lines": 0,
-                "real_lines_of_code": 155
-            },
-                "types": []
+                "nodes": [
+                    {
+                        "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt",
+                        "type": "File",
+                        "metrics": {
+                            "mcc": 3,
+                            "functions": 3,
+                            "classes": 1,
+                            "lines_of_code": 79,
+                            "comment_lines": 32,
+                            "real_lines_of_code": 40
+                        },
+                        "types": []
+                    },
+                    {
+                        "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt",
+                        "type": "File",
+                        "metrics": {
+                            "mcc": 34,
+                            "functions": 8,
+                            "classes": 1,
+                            "lines_of_code": 188,
+                            "comment_lines": 0,
+                            "real_lines_of_code": 155
+                        },
+                        "types": []
+                    }
+                ]
             }
-             ],
-    "relationships": []
-}"""
-        val metricGardenerNodes: MetricGardenerNodes = mapper.readValue(json, MetricGardenerNodes::class.java)
-        val metricGardenerNode1 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt",
-                        "File", mapOf("mcc" to 3, "functions" to 3, "classes" to 1, "lines_of_code" to 79, "comment_lines" to 32, "real_lines_of_code" to 40))
-        val metricGardenerNode2 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt",
-                "File", mapOf("mcc" to 34, "functions" to 8, "classes" to 1, "lines_of_code" to 188, "comment_lines" to 0, "real_lines_of_code" to 155))
+        """
+
+        // when
+        val metricGardenerNodes = mapper.readValue(json, MetricGardenerNodes::class.java)
+        val metricGardenerNode1 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt", "File", mapOf("mcc" to 3, "functions" to 3, "classes" to 1, "lines_of_code" to 79, "comment_lines" to 32, "real_lines_of_code" to 40))
+        val metricGardenerNode2 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt", "File", mapOf("mcc" to 34, "functions" to 8, "classes" to 1, "lines_of_code" to 188, "comment_lines" to 0, "real_lines_of_code" to 155))
         val metricGardenerNodesA = MetricGardenerNodes(mutableListOf(metricGardenerNode1, metricGardenerNode2))
-        val metricGardenerNodesB = MetricGardenerNodes(mutableListOf(metricGardenerNode1))
-        assertNotEquals(metricGardenerNodes, metricGardenerNodesB)
+
+        // then
+        assertEquals(metricGardenerNodes, metricGardenerNodesA)
+        assertEquals(metricGardenerNodes.hashCode(), metricGardenerNodesA.hashCode())
+    }
+
+    @Test
+    fun `Should ignore non-required properties when node-list contains any of them`() {
+        // given
+        val json = """
+            {
+                "nodes": [
+                    {
+                        "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt",
+                        "type": "File",
+                        "metrics": {
+                            "mcc": 3,
+                            "functions": 3,
+                            "classes": 1,
+                            "lines_of_code": 79,
+                            "comment_lines": 32,
+                            "real_lines_of_code": 40
+                        },
+                        "types": []
+                    },
+                    {
+                        "name": "\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt",
+                        "type": "File",
+                        "metrics": {
+                            "mcc": 34,
+                            "functions": 8,
+                            "classes": 1,
+                            "lines_of_code": 188,
+                            "comment_lines": 0,
+                            "real_lines_of_code": 155
+                        },
+                        "types": []
+                    }
+                ],
+                "relationships": [],
+                "info": []
+            }
+        """
+
+        // when
+        val metricGardenerNodes = mapper.readValue(json, MetricGardenerNodes::class.java)
+        val metricGardenerNode1 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\TestService.kt", "File", mapOf("mcc" to 3, "functions" to 3, "classes" to 1, "lines_of_code" to 79, "comment_lines" to 32, "real_lines_of_code" to 40))
+        val metricGardenerNode2 = MetricGardenerNode("\\test-project\\path1\\test-project.path1.Logic\\Service\\UserLogonService.kt", "File", mapOf("mcc" to 34, "functions" to 8, "classes" to 1, "lines_of_code" to 188, "comment_lines" to 0, "real_lines_of_code" to 155))
+        val metricGardenerNodesA = MetricGardenerNodes(mutableListOf(metricGardenerNode1, metricGardenerNode2))
+
+        // then
         assertEquals(metricGardenerNodes, metricGardenerNodesA)
         assertEquals(metricGardenerNodes.hashCode(), metricGardenerNodesA.hashCode())
     }


### PR DESCRIPTION
# Adjust metric-gardener-importer for new JSON-Format

Closes: #3494

## Description
  - Adjusts the metric-gardener-importer to ignore the newly added field `info` of the metric-gardener JSON-format

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated