### PR TITLE
Deactivate metric-gardener in docker install

### DIFF
--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -25,7 +25,6 @@ RUN wget -qO codemaat.jar https://github.com/adamtornhill/code-maat/releases/dow
 RUN curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh; \
     bash /tmp/nodesource_setup.sh; \
     apt-get install nodejs make gcc build-essential -y; \
-    npm install -g --unsafe-perm metric-gardener
 
 RUN wget -qO /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip; \
     apt-get install unzip -y; \

--- a/gh-pages/_docs/01-04-docker-containers.md
+++ b/gh-pages/_docs/01-04-docker-containers.md
@@ -44,6 +44,8 @@ the analysis container, copy them over using `docker cp`
 
 See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/05-01-analysis.md %})
 
+> Attention: The direct execution of metric-gardener has been temporarily disabled. It is not included.
+
 Almost all tools the ccsh can import data from are included in the container, so you can get started immediately.
 Installed are:
 


### PR DESCRIPTION
# Deactivate metric-gardener in docker install

{Issue/Closes}: #3541

## Description

Remove metric-gardener from installation steps in `Dockerfile`

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] ~Changes have been manually tested~
- [x] All TODOs related to this PR have been closed
- [ ] ~There are automated tests for newly written code and bug fixes~
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

