### PR TITLE
Fix applying default scenarios #3369

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 -   Fix small style issues [#3544](https://github.com/MaibornWolff/codecharta/pull/3544)
 -   Fix key handling for selection metrics [#3546](https://github.com/MaibornWolff/codecharta/pull/3546)
+-   Fix applying default metric templates to ensure options reset correctly [#3560](https://github.com/MaibornWolff/codecharta/pull/3560)
 
 ### Chore 👨‍💻 👩‍💻
 

--- a/visualization/app/codeCharta/state/effects/resetSelectedEdgeMetricWhenItDoesntExistAnymore/resetSelectedEdgeMetricWhenItDoesntExistAnymore.effect.ts
+++ b/visualization/app/codeCharta/state/effects/resetSelectedEdgeMetricWhenItDoesntExistAnymore/resetSelectedEdgeMetricWhenItDoesntExistAnymore.effect.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core"
 import { createEffect } from "@ngrx/effects"
 import { Store } from "@ngrx/store"
-import { filter, withLatestFrom, map, distinctUntilChanged } from "rxjs"
+import { distinctUntilChanged, filter, map, withLatestFrom } from "rxjs"
 import { CcState } from "../../../codeCharta.model"
 import { metricDataSelector } from "../../selectors/accumulatedData/metricData/metricData.selector"
 import { setEdgeMetric } from "../../store/dynamicSettings/edgeMetric/edgeMetric.actions"

--- a/visualization/app/codeCharta/ui/ribbonBar/showScenariosButton/scenario.service.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/showScenariosButton/scenario.service.spec.ts
@@ -106,7 +106,7 @@ describe("scenarioService", () => {
 			expect(mockedThreeOrbitControlsService.setControlTarget).toHaveBeenCalledWith({ x: 2, y: 2, z: 2 })
 		})
 
-		it("should set properties to default if not defined in scenarion", () => {
+		it("should set properties to default if not defined in scenario", () => {
 			const dispatchSpy = jest.spyOn(mockedStore, "dispatch")
 			scenarioService.applyScenario("Scenario1")
 			expect(dispatchSpy).toHaveBeenCalledWith(setAmountOfTopLabels({ value: 1 }))


### PR DESCRIPTION
# Fix applying default scenarios #3369

Closes: #3369

## Description
- Fixes applying default metric templates, which didn't reset options properly or caused options to break

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated