### PR TITLE
Overhaul the Suspicious Metrics menu

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 -   Add search bar for custom configs [#3529](https://github.com/MaibornWolff/codecharta/pull/3529)
+-   Overhaul the Suspicious Metrics menu [#3493](https://github.com/MaibornWolff/codecharta/pull/3493)
 -   Automatically reverse the metric direction for those where higher values indicate better codequality, such as `branch_coverage` [#3518](https://github.com/MaibornWolff/codecharta/pull/3518)
 -   Display summary metrics for root node as default [#3525](https://github.com/MaibornWolff/codecharta/pull/3525)
 -   Remove whitespace on screenshots [#3527](https://github.com/MaibornWolff/codecharta/pull/3527)

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
@@ -22,6 +22,24 @@ cc-artificial-intelligence {
 		margin-bottom: 8px;
 		font-weight: bold;
 	}
+
+	.untracked-metrics-button {
+		background-color: white;
+		color: black;
+		cursor: pointer;
+		font-weight: bold;
+		padding: 8px;
+		width: 100%;
+		border: none;
+		text-align: left;
+		font-size: 16px;
+	}
+
+	.untracked-metrics-icon {
+		font-size: 18px;
+		padding: 4px;
+	}
+
 	.suspicious-metric-title {
 		font-weight: bold;
 

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
@@ -16,7 +16,7 @@ cc-artificial-intelligence {
 }
 .mat-mdc-menu-panel.mat-mdc-menu-panel.ai-drop-down {
 	padding: 8px 16px;
-	max-width: 33em;
+	max-width: 50em;
 
 	.title {
 		margin-bottom: 8px;
@@ -53,6 +53,9 @@ cc-artificial-intelligence {
 	.suspicious-metric-info-text {
 		margin-bottom: 8px;
 		font-size: 16px;
+		color: black;
+		line-height: 1.5rem;
+		padding-bottom: 0px;
 	}
 
 	.new-section {

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.component.scss
@@ -22,6 +22,20 @@ cc-artificial-intelligence {
 		margin-bottom: 8px;
 		font-weight: bold;
 	}
+	.suspicious-metric-title {
+		font-weight: bold;
+
+		.suspicious-metric-info-button {
+			font-size: 18px;
+			position: relative;
+			left: -12px;
+		}
+	}
+
+	.suspicious-metric-info-text {
+		margin-bottom: 8px;
+		font-size: 16px;
+	}
 
 	.new-section {
 		margin-top: 16px;
@@ -48,12 +62,13 @@ cc-artificial-intelligence {
 		.metric-button {
 			border-radius: 5px;
 			padding: 0 12px;
+			font-size: 16px;
 		}
 
 		.risk-button {
 			border-radius: 0 5px 5px 0;
 			margin-left: 4px;
-			width: 36px;
+			font-size: 16px;
 			color: #9c0e6a;
 		}
 	}

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.module.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/artificialIntelligence.module.ts
@@ -4,11 +4,18 @@ import { MaterialModule } from "../../../../material/material.module"
 import { ArtificialIntelligenceComponent } from "./artificialIntelligence.component"
 import { HighRiskProfileComponent } from "./highRiskProfile/highRiskProfile.component"
 import { RiskProfileBarDirective } from "./highRiskProfile/riskProfileBar.directive"
-import { SuspiciousMetricComponent } from "./suspiciousMetrics/suspiciousMetrics.component"
+import { SuspiciousMetricComponent, SuspiciousMetricDialogComponent } from "./suspiciousMetrics/suspiciousMetrics.component"
+import { MatDialogModule } from "@angular/material/dialog"
 
 @NgModule({
-	imports: [CommonModule, MaterialModule],
-	declarations: [ArtificialIntelligenceComponent, HighRiskProfileComponent, SuspiciousMetricComponent, RiskProfileBarDirective],
+	imports: [CommonModule, MaterialModule, MatDialogModule],
+	declarations: [
+		ArtificialIntelligenceComponent,
+		HighRiskProfileComponent,
+		SuspiciousMetricComponent,
+		RiskProfileBarDirective,
+		SuspiciousMetricDialogComponent
+	],
 	exports: [ArtificialIntelligenceComponent]
 })
 export class ArtificialIntelligenceModule {}

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetricDialog.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetricDialog.component.html
@@ -1,0 +1,27 @@
+<div id="suspiciousMetricPopover" data-testid="suspiciousMetricPopover">
+	<h2 mat-dialog-title class="title" style="font-size: 16px; font-weight: bold; text-align: center">Suspicious Metrics Information</h2>
+	<mat-dialog-content class="suspicious-metric-info-text" style="color: black; line-height: 1.5rem; padding-bottom: 0px">
+		This feature compares the values of certain metrics from the loaded cc.json file with metric values of 241 Open Source Java
+		projects. Based on this data suspicious and inconspicuous metrics are identified and corresponding suggestions can be clicked to
+		view them. Be aware that metrics for other programming languages might not be comparable to Java Reference metric values. More
+		information can be found here:
+		<a href="https://maibornwolff.github.io/codecharta/docs/suspicious-metrics/">link</a> to How-To article.</mat-dialog-content
+	>
+	<mat-dialog-actions style="display: flex; justify-content: center">
+		<button
+			mat-button
+			mat-dialog-close
+			style="
+				border-radius: 12px;
+				margin-top: 2px;
+				background-color: lightgrey;
+				border-bottom-color: black;
+				font-size: 14px;
+				font-weight: bold;
+				width: 100px;
+			"
+		>
+			Close
+		</button>
+	</mat-dialog-actions>
+</div>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -69,9 +69,12 @@
 
 	<div *ngIf="data.untrackedMetrics.length">
 		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-			Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+			<button type="button" class="untracked-metrics-button" (click)="toggleMetricsVisibility()">
+				Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+				<i class="fa fa-caret-down untracked-metrics-icon"></i>
+			</button>
 		</div>
-		<ul>
+		<ul *ngIf="isUntrackedMetricsVisible">
 			<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
 		</ul>
 	</div>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -14,66 +14,72 @@
 </button>
 
 <mat-menu #menu="matMenu" class="ai-drop-down suspicious-metric-panel">
-	<div class="suspicious-metric-title">
-		<div>
-			Suspicious Metrics
+	<div (click)="$event.stopPropagation()">
+		<div class="suspicious-metric-title">
+			<div>
+				Suspicious Metrics
+				<button
+					title="Open Information about Suspicious Metrics"
+					popovertarget="suspiciousMetricPopover"
+					mat-icon-button
+					(click)="openDialog()"
+				>
+					<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
+				</button>
+			</div>
+		</div>
+		<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
+			Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
+		</div>
+		<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
 			<button
-				title="Open Information about Suspicious Metrics"
-				popovertarget="suspiciousMetricPopover"
-				mat-icon-button
-				(click)="openDialog($event)"
+				class="metric-button"
+				(click)="applySuspiciousMetric(item, false); closeDialog()"
+				title="Apply Map Configuration to show files with suspicious metric {{
+					item.metric
+				}} and high risk or very high risk depending on selection"
 			>
-				<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
+				{{ getNameAndDescriptionOfMetric(item.metric) }}
+			</button>
+
+			<button
+				*ngIf="item.isOutlier"
+				class="risk-button"
+				(click)="applySuspiciousMetric(item, true); closeDialog()"
+				title="Show very high risk files (90th percentile)"
+			>
+				Highlight Outliers
+				<i class="fa fa-exclamation-triangle"></i>
 			</button>
 		</div>
-	</div>
-	<div class="title" *ngIf="data.unsuspiciousMetrics.length">
-		{{
-			data.analyzedProgrammingLanguage?.length
-				? "Unsuspicious Metrics in " + data.analyzedProgrammingLanguage + " code"
-				: "Unsuspicious Metrics"
-		}}
-	</div>
-	<ul>
-		<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
-	</ul>
-	<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
-		Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
-	</div>
-	<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
-		<button
-			class="metric-button"
-			(click)="applySuspiciousMetric(item, false)"
-			title="Apply Map Configuration to show files with suspicious metric {{
-				item.metric
-			}} and high risk or very high risk depending on selection"
-		>
-			{{ getNameAndDescriptionOfMetric(item.metric) }}
-		</button>
-
-		<button
-			*ngIf="item.isOutlier"
-			class="risk-button"
-			(click)="applySuspiciousMetric(item, true)"
-			title="Show very high risk files (90th percentile)"
-		>
-			Highlight Outliers
-			<i class="fa fa-exclamation-triangle"></i>
-		</button>
-	</div>
-
-	<div *ngIf="data.untrackedMetrics.length">
-		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-			<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleMetricsVisibility($event)">
-				Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
-				<i class="fa fa-caret-down untracked-metrics-icon"></i>
-			</button>
+		<div *ngIf="data.unsuspiciousMetrics.length">
+			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
+				<button
+					data-testid="Unsuspicious Metrics"
+					class="untracked-metrics-button"
+					(click)="toggleUnsuspiciousMetricsVisibility($event)"
+				>
+					Unsuspicious metrics in {{ data.analyzedProgrammingLanguage }} code
+					<i class="fa fa-caret-down untracked-metrics-icon"></i>
+				</button>
+			</div>
+			<ul data-testid="List of Unsuspicious Metrics in ts Code" *ngIf="isUnsuspiciuosMetricsVisible">
+				<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
+			</ul>
 		</div>
-		<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
-			<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
-		</ul>
-		<div *ngIf="data.analyzedProgrammingLanguage === undefined">
-			No programming language was found for analyzing suspicious metrics.
+		<div *ngIf="data.untrackedMetrics.length">
+			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
+				<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleUntrackedMetricsVisibility($event)">
+					Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+					<i class="fa fa-caret-down untracked-metrics-icon"></i>
+				</button>
+			</div>
+			<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
+				<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
+			</ul>
+			<div *ngIf="data.analyzedProgrammingLanguage === undefined">
+				No programming language was found for analyzing suspicious metrics.
+			</div>
 		</div>
 	</div>
 </mat-menu>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -15,10 +15,15 @@
 
 <mat-menu #menu="matMenu" class="ai-drop-down suspicious-metric-panel">
 	<div>
-		<div class="title">
-			<div>Suspicious Metrics</div>
+		<div class="suspicious-metric-title">
+			<div>
+				Suspicious Metrics
+				<button popovertarget="suspiciousMetricPopover" mat-icon-button (click)="togglePopup($event)">
+					<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
+				</button>
+			</div>
 		</div>
-		<div class="suspicious-metric">
+		<div id="suspiciousMetricPopover" *ngIf="showSuspiciousMetricInfo" class="suspicious-metric-info-text">
 			This feature compares the values of certain metrics from the loaded cc.json file with metric values of 241 Open Source Java
 			projects. Based on this data suspicious and inconspicuous metrics are identified and corresponding suggestions can be clicked to
 			view them. Be aware that metrics for other programming languages might not be comparable to Java Reference metric values. More
@@ -48,7 +53,7 @@
 				item.metric
 			}} and high risk or very high risk depending on selection"
 		>
-			Suspicious {{ item.metric | uppercase }} Files
+			{{ getNameAndDescriptionOfMetric(item.metric) }}
 		</button>
 
 		<button
@@ -57,6 +62,7 @@
 			(click)="applySuspiciousMetric(item, true)"
 			title="Show very high risk files (90th percentile)"
 		>
+			Highlight Outliers
 			<i class="fa fa-exclamation-triangle"></i>
 		</button>
 	</div>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -14,16 +14,26 @@
 </button>
 
 <mat-menu #menu="matMenu" class="ai-drop-down suspicious-metric-panel">
-	<div>
+	<div (click)="$event.stopPropagation()">
 		<div class="suspicious-metric-title">
 			<div>
 				Suspicious Metrics
-				<button popovertarget="suspiciousMetricPopover" mat-icon-button (click)="togglePopup($event)">
+				<button
+					title="Open Information about Suspicious Metrics"
+					popovertarget="suspiciousMetricPopover"
+					mat-icon-button
+					(click)="togglePopup()"
+				>
 					<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
 				</button>
 			</div>
 		</div>
-		<div id="suspiciousMetricPopover" *ngIf="showSuspiciousMetricInfo" class="suspicious-metric-info-text">
+		<div
+			id="suspiciousMetricPopover"
+			data-testid="suspiciousMetricPopover"
+			*ngIf="showSuspiciousMetricInfo"
+			class="suspicious-metric-info-text"
+		>
 			This feature compares the values of certain metrics from the loaded cc.json file with metric values of 241 Open Source Java
 			projects. Based on this data suspicious and inconspicuous metrics are identified and corresponding suggestions can be clicked to
 			view them. Be aware that metrics for other programming languages might not be comparable to Java Reference metric values. More
@@ -40,44 +50,44 @@
 		<ul>
 			<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
 		</ul>
-	</div>
+		<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
+			Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
+		</div>
+		<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
+			<button
+				class="metric-button"
+				(click)="applySuspiciousMetric(item, false)"
+				title="Apply Map Configuration to show files with suspicious metric {{
+					item.metric
+				}} and high risk or very high risk depending on selection"
+			>
+				{{ getNameAndDescriptionOfMetric(item.metric) }}
+			</button>
 
-	<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
-		Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
-	</div>
-	<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
-		<button
-			class="metric-button"
-			(click)="applySuspiciousMetric(item, false)"
-			title="Apply Map Configuration to show files with suspicious metric {{
-				item.metric
-			}} and high risk or very high risk depending on selection"
-		>
-			{{ getNameAndDescriptionOfMetric(item.metric) }}
-		</button>
-
-		<button
-			*ngIf="item.isOutlier"
-			class="risk-button"
-			(click)="applySuspiciousMetric(item, true)"
-			title="Show very high risk files (90th percentile)"
-		>
-			Highlight Outliers
-			<i class="fa fa-exclamation-triangle"></i>
-		</button>
-	</div>
-
-	<div *ngIf="data.untrackedMetrics.length">
-		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-			<button type="button" class="untracked-metrics-button" (click)="toggleMetricsVisibility()">
-				Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
-				<i class="fa fa-caret-down untracked-metrics-icon"></i>
+			<button
+				*ngIf="item.isOutlier"
+				class="risk-button"
+				(click)="applySuspiciousMetric(item, true)"
+				title="Show very high risk files (90th percentile)"
+			>
+				Highlight Outliers
+				<i class="fa fa-exclamation-triangle"></i>
 			</button>
 		</div>
-		<ul *ngIf="isUntrackedMetricsVisible">
-			<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
-		</ul>
-	</div>
 
-	<div *ngIf="data.analyzedProgrammingLanguage === undefined">No programming language was found for analyzing suspicious metrics.</div>
+		<div *ngIf="data.untrackedMetrics.length">
+			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
+				<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleMetricsVisibility()">
+					Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+					<i class="fa fa-caret-down untracked-metrics-icon"></i>
+				</button>
+			</div>
+			<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
+				<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
+			</ul>
+			<div *ngIf="data.analyzedProgrammingLanguage === undefined">
+				No programming language was found for analyzing suspicious metrics.
+			</div>
+		</div>
+	</div>
 </mat-menu>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -14,80 +14,66 @@
 </button>
 
 <mat-menu #menu="matMenu" class="ai-drop-down suspicious-metric-panel">
-	<div (click)="$event.stopPropagation()">
-		<div class="suspicious-metric-title">
-			<div>
-				Suspicious Metrics
-				<button
-					title="Open Information about Suspicious Metrics"
-					popovertarget="suspiciousMetricPopover"
-					mat-icon-button
-					(click)="togglePopup()"
-				>
-					<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
-				</button>
-			</div>
+	<div class="suspicious-metric-title">
+		<div>
+			Suspicious Metrics
+			<button
+				title="Open Information about Suspicious Metrics"
+				popovertarget="suspiciousMetricPopover"
+				mat-icon-button
+				(click)="openDialog($event)"
+			>
+				<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
+			</button>
 		</div>
-		<div
-			id="suspiciousMetricPopover"
-			data-testid="suspiciousMetricPopover"
-			*ngIf="showSuspiciousMetricInfo"
-			class="suspicious-metric-info-text"
+	</div>
+	<div class="title" *ngIf="data.unsuspiciousMetrics.length">
+		{{
+			data.analyzedProgrammingLanguage?.length
+				? "Unsuspicious Metrics in " + data.analyzedProgrammingLanguage + " code"
+				: "Unsuspicious Metrics"
+		}}
+	</div>
+	<ul>
+		<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
+	</ul>
+	<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
+		Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
+	</div>
+	<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
+		<button
+			class="metric-button"
+			(click)="applySuspiciousMetric(item, false)"
+			title="Apply Map Configuration to show files with suspicious metric {{
+				item.metric
+			}} and high risk or very high risk depending on selection"
 		>
-			This feature compares the values of certain metrics from the loaded cc.json file with metric values of 241 Open Source Java
-			projects. Based on this data suspicious and inconspicuous metrics are identified and corresponding suggestions can be clicked to
-			view them. Be aware that metrics for other programming languages might not be comparable to Java Reference metric values. More
-			information can be found here:
-			<a href="https://maibornwolff.github.io/codecharta/docs/suspicious-metrics/">link</a> to How-To article.
+			{{ getNameAndDescriptionOfMetric(item.metric) }}
+		</button>
+
+		<button
+			*ngIf="item.isOutlier"
+			class="risk-button"
+			(click)="applySuspiciousMetric(item, true)"
+			title="Show very high risk files (90th percentile)"
+		>
+			Highlight Outliers
+			<i class="fa fa-exclamation-triangle"></i>
+		</button>
+	</div>
+
+	<div *ngIf="data.untrackedMetrics.length">
+		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
+			<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleMetricsVisibility($event)">
+				Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+				<i class="fa fa-caret-down untracked-metrics-icon"></i>
+			</button>
 		</div>
-		<div class="title" *ngIf="data.unsuspiciousMetrics.length">
-			{{
-				data.analyzedProgrammingLanguage?.length
-					? "Unsuspicious Metrics in " + data.analyzedProgrammingLanguage + " code"
-					: "Unsuspicious Metrics"
-			}}
-		</div>
-		<ul>
-			<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
+		<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
+			<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
 		</ul>
-		<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
-			Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
-		</div>
-		<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
-			<button
-				class="metric-button"
-				(click)="applySuspiciousMetric(item, false)"
-				title="Apply Map Configuration to show files with suspicious metric {{
-					item.metric
-				}} and high risk or very high risk depending on selection"
-			>
-				{{ getNameAndDescriptionOfMetric(item.metric) }}
-			</button>
-
-			<button
-				*ngIf="item.isOutlier"
-				class="risk-button"
-				(click)="applySuspiciousMetric(item, true)"
-				title="Show very high risk files (90th percentile)"
-			>
-				Highlight Outliers
-				<i class="fa fa-exclamation-triangle"></i>
-			</button>
-		</div>
-
-		<div *ngIf="data.untrackedMetrics.length">
-			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-				<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleMetricsVisibility()">
-					Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
-					<i class="fa fa-caret-down untracked-metrics-icon"></i>
-				</button>
-			</div>
-			<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
-				<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
-			</ul>
-			<div *ngIf="data.analyzedProgrammingLanguage === undefined">
-				No programming language was found for analyzing suspicious metrics.
-			</div>
+		<div *ngIf="data.analyzedProgrammingLanguage === undefined">
+			No programming language was found for analyzing suspicious metrics.
 		</div>
 	</div>
 </mat-menu>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.html
@@ -14,72 +14,70 @@
 </button>
 
 <mat-menu #menu="matMenu" class="ai-drop-down suspicious-metric-panel">
-	<div (click)="$event.stopPropagation()">
-		<div class="suspicious-metric-title">
-			<div>
-				Suspicious Metrics
-				<button
-					title="Open Information about Suspicious Metrics"
-					popovertarget="suspiciousMetricPopover"
-					mat-icon-button
-					(click)="openDialog()"
-				>
-					<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
-				</button>
-			</div>
-		</div>
-		<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
-			Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
-		</div>
-		<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
+	<div class="suspicious-metric-title">
+		<div>
+			Suspicious Metrics
 			<button
-				class="metric-button"
-				(click)="applySuspiciousMetric(item, false); closeDialog()"
-				title="Apply Map Configuration to show files with suspicious metric {{
-					item.metric
-				}} and high risk or very high risk depending on selection"
+				title="Open Information about Suspicious Metrics"
+				popovertarget="suspiciousMetricPopover"
+				mat-icon-button
+				(click)="openDialog($event)"
 			>
-				{{ getNameAndDescriptionOfMetric(item.metric) }}
+				<i matSuffix class="fa fa-info-circle suspicious-metric-info-button"></i>
 			</button>
+		</div>
+	</div>
+	<div *ngIf="data.suspiciousMetricSuggestionLinks.length" class="title new-section">
+		Suspicious Metrics in {{ data.analyzedProgrammingLanguage }} code
+	</div>
+	<div class="suspicious-metric" *ngFor="let item of data.suspiciousMetricSuggestionLinks">
+		<button
+			class="metric-button"
+			(click)="applySuspiciousMetric(item, false)"
+			title="Apply Map Configuration to show files with suspicious metric {{
+				item.metric
+			}} and high risk or very high risk depending on selection"
+		>
+			{{ getNameAndDescriptionOfMetric(item.metric) }}
+		</button>
 
+		<button
+			*ngIf="item.isOutlier"
+			class="risk-button"
+			(click)="applySuspiciousMetric(item, true)"
+			title="Show very high risk files (90th percentile)"
+		>
+			Highlight Outliers
+			<i class="fa fa-exclamation-triangle"></i>
+		</button>
+	</div>
+	<div *ngIf="data.unsuspiciousMetrics.length">
+		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
 			<button
-				*ngIf="item.isOutlier"
-				class="risk-button"
-				(click)="applySuspiciousMetric(item, true); closeDialog()"
-				title="Show very high risk files (90th percentile)"
+				data-testid="Unsuspicious Metrics"
+				class="untracked-metrics-button"
+				(click)="toggleUnsuspiciousMetricsVisibility($event)"
 			>
-				Highlight Outliers
-				<i class="fa fa-exclamation-triangle"></i>
+				Unsuspicious metrics in {{ data.analyzedProgrammingLanguage }} code
+				<i class="fa fa-caret-down untracked-metrics-icon"></i>
 			</button>
 		</div>
-		<div *ngIf="data.unsuspiciousMetrics.length">
-			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-				<button
-					data-testid="Unsuspicious Metrics"
-					class="untracked-metrics-button"
-					(click)="toggleUnsuspiciousMetricsVisibility($event)"
-				>
-					Unsuspicious metrics in {{ data.analyzedProgrammingLanguage }} code
-					<i class="fa fa-caret-down untracked-metrics-icon"></i>
-				</button>
-			</div>
-			<ul data-testid="List of Unsuspicious Metrics in ts Code" *ngIf="isUnsuspiciuosMetricsVisible">
-				<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
-			</ul>
+		<ul data-testid="List of Unsuspicious Metrics in ts Code" *ngIf="isUnsuspiciuosMetricsVisible">
+			<li *ngFor="let unsuspiciousMetric of data.unsuspiciousMetrics">{{ unsuspiciousMetric }}</li>
+		</ul>
+	</div>
+	<div *ngIf="data.untrackedMetrics.length">
+		<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
+			<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleUntrackedMetricsVisibility($event)">
+				Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
+				<i class="fa fa-caret-down untracked-metrics-icon"></i>
+			</button>
 		</div>
-		<div *ngIf="data.untrackedMetrics.length">
-			<div *ngIf="data.analyzedProgrammingLanguage.length" class="title">
-				<button data-testid="Untracked Metrics" class="untracked-metrics-button" (click)="toggleUntrackedMetricsVisibility($event)">
-					Untracked metrics in {{ data.analyzedProgrammingLanguage }} code
-					<i class="fa fa-caret-down untracked-metrics-icon"></i>
-				</button>
-			</div>
-			<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
-				<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
-			</ul>
-			<div *ngIf="data.analyzedProgrammingLanguage === undefined">
-				No programming language was found for analyzing suspicious metrics.
-			</div>
+		<ul data-testid="List of Untracked Metrics in ts Code" *ngIf="isUntrackedMetricsVisible">
+			<li *ngFor="let untrackedMetric of data.untrackedMetrics">{{ untrackedMetric }}</li>
+		</ul>
+		<div *ngIf="data.analyzedProgrammingLanguage === undefined">
+			No programming language was found for analyzing suspicious metrics.
 		</div>
 	</div>
 </mat-menu>

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
@@ -118,7 +118,7 @@ describe("SuspiciousMetricsComponent", () => {
 				componentProperties: {
 					data: {
 						analyzedProgrammingLanguage: "ts",
-						unsuspiciousMetrics: ["rloc"],
+						unsuspiciousMetrics: [],
 						suspiciousMetricSuggestionLinks: [{ metric: "mcc", from: 10, to: 22 }],
 						untrackedMetrics: []
 					}
@@ -126,8 +126,6 @@ describe("SuspiciousMetricsComponent", () => {
 			})
 			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
 			expect(screen.queryByText("No programming language was found for analyzing suspicious metrics.")).toBe(null)
-			expect(screen.getByText("Unsuspicious Metrics in ts code")).not.toBe(null)
-			expect(screen.getByText("rloc")).not.toBe(null)
 			expect(screen.getByText("Suspicious Metrics in ts code")).not.toBe(null)
 			expect(screen.getByText("MCC (cyclomatic complexity)")).not.toBe(null)
 

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.spec.ts
@@ -107,7 +107,7 @@ describe("SuspiciousMetricsComponent", () => {
 				}
 			})
 			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
-			expect(screen.getByText("No programming language was found for analyzing suspicious metrics.")).toBeTruthy()
+			expect(screen.findByText("No programming language was found for analyzing suspicious metrics.")).toBeTruthy()
 			expect(screen.queryByText("Unsuspicious Metrics")).toBe(null)
 			expect(screen.queryByText("Suspicious Metrics in undefined code")).toBe(null)
 		})
@@ -129,9 +129,9 @@ describe("SuspiciousMetricsComponent", () => {
 			expect(screen.getByText("Unsuspicious Metrics in ts code")).not.toBe(null)
 			expect(screen.getByText("rloc")).not.toBe(null)
 			expect(screen.getByText("Suspicious Metrics in ts code")).not.toBe(null)
-			expect(screen.getByText("Suspicious MCC Files")).not.toBe(null)
+			expect(screen.getByText("MCC (cyclomatic complexity)")).not.toBe(null)
 
-			await userEvent.click(screen.getByText("Suspicious MCC Files"), undefined)
+			await userEvent.click(screen.getByText("MCC (cyclomatic complexity)"), undefined)
 			const store = TestBed.inject(Store)
 			expect(store.dispatch).toHaveBeenCalledWith(setHeightMetric({ value: "mcc" }))
 			expect(store.dispatch).toHaveBeenCalledWith(setColorMetric({ value: "mcc" }))
@@ -147,7 +147,15 @@ describe("SuspiciousMetricsComponent", () => {
 					data: {
 						analyzedProgrammingLanguage: "ts",
 						unsuspiciousMetrics: ["rloc"],
-						suspiciousMetricSuggestionLinks: [{ metric: "mcc", from: 10, to: 22, isOutlier: true, outlierThreshold: 120 }],
+						suspiciousMetricSuggestionLinks: [
+							{
+								metric: "mcc",
+								from: 10,
+								to: 22,
+								isOutlier: true,
+								outlierThreshold: 120
+							}
+						],
 						untrackedMetrics: []
 					}
 				}
@@ -158,6 +166,46 @@ describe("SuspiciousMetricsComponent", () => {
 			expect(store.dispatch).toHaveBeenCalledWith(setHeightMetric({ value: "mcc" }))
 			expect(store.dispatch).toHaveBeenCalledWith(setColorMetric({ value: "mcc" }))
 			expect(store.dispatch).toHaveBeenCalledWith(setColorRange({ value: { from: 10, to: 120 } }))
+		})
+	})
+
+	describe("info-button", () => {
+		it("should show the suspicious metrics information by clicking the information button", async () => {
+			await render(SuspiciousMetricComponent, {
+				excludeComponentDeclaration: true,
+				componentProperties: {
+					data: {
+						analyzedProgrammingLanguage: undefined,
+						unsuspiciousMetrics: [],
+						suspiciousMetricSuggestionLinks: [],
+						untrackedMetrics: []
+					}
+				}
+			})
+			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
+			expect(screen.queryByTestId("suspiciousMetricPopover")).toBe(null)
+			await userEvent.click(screen.getByTitle("Open Information about Suspicious Metrics"))
+			expect(screen.queryByTestId("suspiciousMetricPopover")).not.toBe(null)
+		})
+	})
+
+	describe("untracked-metrics-button", () => {
+		it("should show the suspicious metrics information by clicking the information button", async () => {
+			await render(SuspiciousMetricComponent, {
+				excludeComponentDeclaration: true,
+				componentProperties: {
+					data: {
+						analyzedProgrammingLanguage: "ts",
+						unsuspiciousMetrics: [],
+						suspiciousMetricSuggestionLinks: [],
+						untrackedMetrics: ["pairingRate", "avgCommits", "unary"]
+					}
+				}
+			})
+			await userEvent.click(screen.getByTitle("Open Suspicious Metrics Panel"))
+			expect(screen.queryByTestId("List of Untracked Metrics in ts Code")).toBe(null)
+			await userEvent.click(screen.queryByTestId("Untracked Metrics"))
+			expect(screen.queryByTestId("List of Untracked Metrics in ts Code")).not.toBe(null)
 		})
 	})
 })

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -25,7 +25,8 @@ export class SuspiciousMetricComponent implements OnChanges {
 	>
 	hideBadge = false
 	isUntrackedMetricsVisible = false
-
+	isUnsuspiciuosMetricsVisible = false
+	//, public dialogRef: MatDialogRef<SuspiciousMetricComponent>
 	constructor(private store: Store, public dialog: MatDialog) {}
 
 	getNameAndDescriptionOfMetric(metricName: string): string {
@@ -35,19 +36,26 @@ export class SuspiciousMetricComponent implements OnChanges {
 		}
 		return metricName.toUpperCase()
 	}
-
-	toggleMetricsVisibility(event: MouseEvent): void {
+	closeDialog() {
+		//this.dialogRef.close()
+	}
+	toggleUntrackedMetricsVisibility(event: MouseEvent): void {
 		event.stopPropagation()
 		this.isUntrackedMetricsVisible = !this.isUntrackedMetricsVisible
 	}
+
+	toggleUnsuspiciousMetricsVisibility(event: MouseEvent): void {
+		event.stopPropagation()
+		this.isUnsuspiciuosMetricsVisible = !this.isUnsuspiciuosMetricsVisible
+	}
+
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.data && !dequal(changes.data.previousValue, changes.data.currentValue)) {
 			this.hideBadge = false
 		}
 	}
 
-	openDialog(event: MouseEvent): void {
-		event.stopPropagation()
+	openDialog(): void {
 		this.dialog.open(SuspiciousMetricDialogComponent, {
 			width: "500px"
 		})

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -11,6 +11,7 @@ import { ArtificialIntelligenceData } from "../selectors/artificialIntelligence.
 import { AREA_METRIC } from "../selectors/util/riskProfileHelper"
 import { MetricSuggestionParameters } from "../selectors/util/suspiciousMetricsHelper"
 import { metricTitles } from "../../../../util/metric/metricTitles"
+import { MatDialog } from "@angular/material/dialog"
 
 @Component({
 	selector: "cc-suspicious-metrics",
@@ -23,10 +24,9 @@ export class SuspiciousMetricComponent implements OnChanges {
 		"analyzedProgrammingLanguage" | "unsuspiciousMetrics" | "suspiciousMetricSuggestionLinks" | "untrackedMetrics"
 	>
 	hideBadge = false
-	showSuspiciousMetricInfo = false
 	isUntrackedMetricsVisible = false
 
-	constructor(private store: Store) {}
+	constructor(private store: Store, public dialog: MatDialog) {}
 
 	getNameAndDescriptionOfMetric(metricName: string): string {
 		const metricDescription = metricTitles.get(metricName)
@@ -36,7 +36,8 @@ export class SuspiciousMetricComponent implements OnChanges {
 		return metricName.toUpperCase()
 	}
 
-	toggleMetricsVisibility(): void {
+	toggleMetricsVisibility(event: MouseEvent): void {
+		event.stopPropagation()
 		this.isUntrackedMetricsVisible = !this.isUntrackedMetricsVisible
 	}
 	ngOnChanges(changes: SimpleChanges): void {
@@ -45,8 +46,11 @@ export class SuspiciousMetricComponent implements OnChanges {
 		}
 	}
 
-	togglePopup(): void {
-		this.showSuspiciousMetricInfo = !this.showSuspiciousMetricInfo
+	openDialog(event: MouseEvent): void {
+		event.stopPropagation()
+		this.dialog.open(SuspiciousMetricDialogComponent, {
+			width: "500px"
+		})
 	}
 
 	applySuspiciousMetric(metric: MetricSuggestionParameters, markOutlier: boolean) {
@@ -72,3 +76,10 @@ export class SuspiciousMetricComponent implements OnChanges {
 		)
 	}
 }
+
+@Component({
+	selector: "cc-suspicious-metric-dialog",
+	templateUrl: "./suspiciousMetricDialog.component.html",
+	encapsulation: ViewEncapsulation.None
+})
+export class SuspiciousMetricDialogComponent {}

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -24,6 +24,7 @@ export class SuspiciousMetricComponent implements OnChanges {
 	>
 	hideBadge = false
 	showSuspiciousMetricInfo = false
+	isUntrackedMetricsVisible = false
 
 	constructor(private store: Store) {}
 
@@ -35,6 +36,9 @@ export class SuspiciousMetricComponent implements OnChanges {
 		return metricName.toUpperCase()
 	}
 
+	toggleMetricsVisibility(): void {
+		this.isUntrackedMetricsVisible = !this.isUntrackedMetricsVisible
+	}
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.data && !dequal(changes.data.previousValue, changes.data.currentValue)) {
 			this.hideBadge = false

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -45,8 +45,7 @@ export class SuspiciousMetricComponent implements OnChanges {
 		}
 	}
 
-	togglePopup(event: MouseEvent): void {
-		event.stopPropagation()
+	togglePopup(): void {
 		this.showSuspiciousMetricInfo = !this.showSuspiciousMetricInfo
 	}
 

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -26,7 +26,7 @@ export class SuspiciousMetricComponent implements OnChanges {
 	hideBadge = false
 	isUntrackedMetricsVisible = false
 	isUnsuspiciuosMetricsVisible = false
-	//, public dialogRef: MatDialogRef<SuspiciousMetricComponent>
+
 	constructor(private store: Store, public dialog: MatDialog) {}
 
 	getNameAndDescriptionOfMetric(metricName: string): string {
@@ -36,9 +36,7 @@ export class SuspiciousMetricComponent implements OnChanges {
 		}
 		return metricName.toUpperCase()
 	}
-	closeDialog() {
-		//this.dialogRef.close()
-	}
+
 	toggleUntrackedMetricsVisibility(event: MouseEvent): void {
 		event.stopPropagation()
 		this.isUntrackedMetricsVisible = !this.isUntrackedMetricsVisible
@@ -55,7 +53,8 @@ export class SuspiciousMetricComponent implements OnChanges {
 		}
 	}
 
-	openDialog(): void {
+	openDialog(event: MouseEvent): void {
+		event.stopPropagation()
 		this.dialog.open(SuspiciousMetricDialogComponent, {
 			width: "500px"
 		})

--- a/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
+++ b/visualization/app/codeCharta/ui/ribbonBar/artificialIntelligence/suspiciousMetrics/suspiciousMetrics.component.ts
@@ -10,6 +10,7 @@ import { setHeightMetric } from "../../../../state/store/dynamicSettings/heightM
 import { ArtificialIntelligenceData } from "../selectors/artificialIntelligence.selector"
 import { AREA_METRIC } from "../selectors/util/riskProfileHelper"
 import { MetricSuggestionParameters } from "../selectors/util/suspiciousMetricsHelper"
+import { metricTitles } from "../../../../util/metric/metricTitles"
 
 @Component({
 	selector: "cc-suspicious-metrics",
@@ -22,13 +23,27 @@ export class SuspiciousMetricComponent implements OnChanges {
 		"analyzedProgrammingLanguage" | "unsuspiciousMetrics" | "suspiciousMetricSuggestionLinks" | "untrackedMetrics"
 	>
 	hideBadge = false
+	showSuspiciousMetricInfo = false
 
 	constructor(private store: Store) {}
+
+	getNameAndDescriptionOfMetric(metricName: string): string {
+		const metricDescription = metricTitles.get(metricName)
+		if (metricDescription) {
+			return `${metricName.toUpperCase()} (${metricDescription.toLowerCase()})`
+		}
+		return metricName.toUpperCase()
+	}
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.data && !dequal(changes.data.previousValue, changes.data.currentValue)) {
 			this.hideBadge = false
 		}
+	}
+
+	togglePopup(event: MouseEvent): void {
+		event.stopPropagation()
+		this.showSuspiciousMetricInfo = !this.showSuspiciousMetricInfo
 	}
 
 	applySuspiciousMetric(metric: MetricSuggestionParameters, markOutlier: boolean) {


### PR DESCRIPTION
**Overhaul the Suspicious Metrics menu**

Closes: #3493

## Description

The 'Suspicious Metrics' tab has been streamlined and is now more user-friendly. Key improvements include:
  - Information about suspicious metrics is neatly concealed within an info box, accessible via click or hover for easy visibility.
  - Untracked metrics in the code are now neatly tucked away in a toggle feature, which can be expanded with a click, similar to the functionality of our file explorer.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [X] All TODOs related to this PR have been closed
- [X] There are automated tests for newly written code and bug fixes
- [X] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [X] CHANGELOG.md has been updated


