### PR TITLE
Enable automatic merge of non-major-updates for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,11 @@
 	"extends": ["config:base", ":preserveSemverRanges"],
 	"packageRules": [
 		{
+			"description": "Automerge non-major updates",
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		},
+		{
 			"matchPaths": ["build.gradle"],
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
 			"excludePackageNames": ["org.sonarsource.java:sonar-java-plugin"],


### PR DESCRIPTION
# Enable automatic merge of non-major-updates for renovate

⚠️  In addition to editing the `renovate.json` I added the following config to this repository: `Settings -> Branches -> main -> Allow specified actors to bypass required pull requests -> renovate`

Closes: #3595

## Description

**Descriptive pull request text**, answering:
  - Enable automatic merging of minor and patch updates created by renovate

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] ~~Changes have been manually tested~~
- [x] All TODOs related to this PR have been closed
- [ ] ~~There are automated tests for newly written code and bug fixes~~
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] ~~Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)~~
- [ ] ~~CHANGELOG.md has been updated~~