### PR TITLE
`ccsh` no Read Rights - Change fileMode to 755 (binary) in startScript task

### DIFF
--- a/analysis/build.gradle.kts
+++ b/analysis/build.gradle.kts
@@ -78,7 +78,8 @@ distributions {
           into("bin") {
             subproject.tasks.findByName("startScripts").let {
               from(it!!.outputs.files) {
-                fileMode = 755
+                // 7-5-5 in binary
+                fileMode = 0b111101101
               }
             }
           }


### PR DESCRIPTION
# `ccsh` no Read Rights - Change fileMode to 755 (binary) in startScript task

Closes: #3603

Change `fileMode` property in Gradle build file to the binary representation of 7 5 5. 
The number 755 was previously interpreted as a random assortment of read and write rights, that didn't make any sense.

We can remove the addition of read rights in our `golden_test.sh`. This will be done in #3571 to avoid unnecessary merge conflicts. 

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
