### PR TITLE
Fix CcshTest for version printing fails on Windows

### DIFF
--- a/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
+++ b/analysis/tools/ccsh/src/test/kotlin/de/maibornwolff/codecharta/ccsh/CcshTest.kt
@@ -153,8 +153,8 @@ private val outContent = ByteArrayOutputStream()
 
         // then
         Assertions.assertThat(exitCode).isEqualTo(0)
-        Assertions.assertThat(outStream.toString())
-            .contains(listOf("version", "Copyright(c) 2024, MaibornWolff GmbH\n"))
+        // The actual printed version is null, as well as the package name, as it is not set for this test class
+        Assertions.assertThat(outStream.toString()).contains("version", "Copyright(c) 2024, MaibornWolff GmbH")
         verify(exactly = 0) { ParserService.executePreconfiguredParser(any(), any()) }
 
         // clean up


### PR DESCRIPTION
# Fix Windows Test for version printing

Closes: #3619

## Description

Change assert to vararg string contains instead of listOf
and remove line break from string test

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] ~~CHANGELOG.md has been updated~~ not needed

## Screenshots or gifs
