### PR TITLE
fix/3308/docker-user-args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,9 +151,10 @@ jobs:
       - name: Docker Test Analysis
         run: |
           user_instance="docker_runner"
-          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001 --build-arg USERNAME=${user_instance}
+          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001 --build-arg USERNAME=${user_instance} --no-cache
           current_version=$(node -pe "require('./analysis/node-wrapper/package.json').version")
           docker run -w /home/${user_instance}/cc/analysis/test -v $(pwd):/home/${user_instance}/cc local-ccsh bash ./golden_test.sh ${current_version} /home/${user_instance}/tmp-files/ /usr/local/bin/ccsh
+          docker build ./analysis -t local-ccsh --no-cache
         working-directory: ${{env.project-directory}}
 
       - name: Setup Java JDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,9 @@ jobs:
 
       - name: Docker Test Analysis
         run: |
-          docker build ./analysis -t local-ccsh --build-arg USER_UID=1001
+          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true USER_ID=1001
           current_version=$(node -pe "require('./analysis/node-wrapper/package.json').version")
-          docker run -w /home/nonroot-docker-user/cc/analysis/test -v $(pwd):/home/nonroot-docker-user/cc local-ccsh bash ./golden_test.sh ${current_version} /home/nonroot-docker-user/tmp-files/ /usr/local/bin/ccsh
+          docker run -w /home/ubuntu/cc/analysis/test -v $(pwd):/home/ubuntu/cc local-ccsh bash ./golden_test.sh ${current_version} /home/ubuntu/tmp-files/ /usr/local/bin/ccsh
         working-directory: ${{env.project-directory}}
 
       - name: Setup Java JDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Docker Test Analysis
         run: |
-          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true USER_ID=1001
+          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001
           current_version=$(node -pe "require('./analysis/node-wrapper/package.json').version")
           docker run -w /home/ubuntu/cc/analysis/test -v $(pwd):/home/ubuntu/cc local-ccsh bash ./golden_test.sh ${current_version} /home/ubuntu/tmp-files/ /usr/local/bin/ccsh
         working-directory: ${{env.project-directory}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,10 @@ jobs:
 
       - name: Docker Test Analysis
         run: |
-          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001
+          user_instance="docker_runner"
+          docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001 --build-arg USERNAME=${user_instance}
           current_version=$(node -pe "require('./analysis/node-wrapper/package.json').version")
-          docker run -w /home/ubuntu/cc/analysis/test -v $(pwd):/home/ubuntu/cc local-ccsh bash ./golden_test.sh ${current_version} /home/ubuntu/tmp-files/ /usr/local/bin/ccsh
+          docker run -w /home/${user_instance}/cc/analysis/test -v $(pwd):/home/${user_instance}/cc local-ccsh bash ./golden_test.sh ${current_version} /home/${user_instance}/tmp-files/ /usr/local/bin/ccsh
         working-directory: ${{env.project-directory}}
 
       - name: Setup Java JDK

--- a/DEV_START_GUIDE.md
+++ b/DEV_START_GUIDE.md
@@ -98,6 +98,10 @@ For the visualisation, we utilize Jest and puppeteer for unit- and e2e-tests. To
 
 When opening a pull requests, all tests are executed automatically using GitHub-actions and a branch can only be merged if all tests are successful. However, it is highly recommended to test changes before pushing them!
 
+# Docker
+
+For deployment and usage of the docker images, check out our documentation page [here](https://maibornwolff.github.io/codecharta/docs/docker-containers/).
+
 # Troubleshooting
 
 We mainly use IntelliJ for our development. The project generally works right away, but sometimes issues can occur:

--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Changed
+
+-   Update GH-Pages and dev guide on how to use our docker images [#3621](https://github.com/MaibornWolff/codecharta/pull/3621/files)
+
 ### Fixed 🐞
 
 -   Add default Docker user to mitigate `GitLogParser` issues during repo-scan [#3571](https://github.com/MaibornWolff/codecharta/pull/3571)

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -2,7 +2,7 @@ FROM sapmachine:11.0.23
 
 ARG USER_ADD
 ARG USER_ID=1000
-ARG USER_GID=$USER_UID
+ARG USER_GID=$USER_ID
 ARG USERNAME=ubuntu
 
 COPY ./build/distributions/codecharta-analysis-*.tar /usr/local/

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -3,7 +3,7 @@ FROM sapmachine:11.0.23
 ARG USER_ADD
 ARG USER_ID=1000
 ARG USER_GID=$USER_UID
-ARG USERNAME=nonroot-docker-user
+ARG USERNAME=ubuntu
 
 COPY ./build/distributions/codecharta-analysis-*.tar /usr/local/
 
@@ -43,8 +43,6 @@ RUN wget -qO /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distributio
 RUN if [ -n "$USER_ADD" ]; then \
       groupadd --gid $USER_GID $USERNAME \
           && useradd --uid $USER_ID --gid $USER_GID -m $USERNAME; \
-    else \
-      USERNAME=ubuntu; \
     fi
 
 USER $USERNAME

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -1,5 +1,10 @@
 FROM sapmachine:11.0.23
 
+ARG USER_ADD
+ARG USER_ID=1000
+ARG USER_GID=$USER_UID
+ARG USERNAME=nonroot-docker-user
+
 COPY ./build/distributions/codecharta-analysis-*.tar /usr/local/
 
 RUN cd /usr/local; \
@@ -34,12 +39,13 @@ RUN wget -qO /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distributio
     mkdir --parents /usr/local/conf ; cp ./conf/sonar-scanner.properties /usr/local/conf/; \
     cp -r ./jre/ /usr/local/jre; cd /; rm /tmp/sonar-scanner.zip; rm -rf /tmp/sonar-scanner-*-linux;
 
-ARG USERNAME=nonroot-docker-user
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME;
+RUN if [ -n "$USER_ADD" ]; then \
+      groupadd --gid $USER_GID $USERNAME \
+          && useradd --uid $USER_ID --gid $USER_GID -m $USERNAME; \
+    else \
+      USERNAME=ubuntu; \
+    fi
 
 USER $USERNAME
 

--- a/gh-pages/_docs/01-04-docker-containers.md
+++ b/gh-pages/_docs/01-04-docker-containers.md
@@ -83,5 +83,39 @@ docker run -it -v $(pwd):/src -w /src codecharta/codecharta-analysis ccsh gitlog
 # gitlogparser [...] : check the gitlogparser documentation for more info
 ```
 
-> Be aware, that by default the user inside the docker image is 'nonroot-docker-user' with an ID of 1000. You may
+> Be aware, that by default the user inside the docker image is 'ubuntu' with an ID of 1000. You may
 > encounter errors with `git` when you try to execute commands inside a repository cloned by a different `UID`
+
+> For **macOS users**, it is necessary to add `--user=501:dialout` Before the image name. Why? because docker on mac is fun :)
+
+### Build it yourself
+
+You can also build a docker image from the locally installed instance of codecharta. To do this, you would execute the following commands:
+
+```bash
+# to build the container you need to navigate into the analysis folder
+cd analysis
+
+# makes a clean build to ensure everything will be built correctly
+./gradlew clean build
+
+# builds the docker container with an image name of your choice
+docker build . -t your-image-name
+
+# executes bash inside of the created container
+docker run -it your-image-name bash
+
+# to run the docker container with your current working directory mounted into it,
+# you can alternatively run this
+docker run -it -v $(pwd):/src -w /src your-image-name bash
+```
+
+There is also the option to customize the used docker user during the build.
+This will create a new user with the given name and IDs.
+
+```bash
+#USER_ADD: set it to any value to to add a new user
+#USERNAME: the name of the user to be created
+#USER_ID: the ID that is used for the new user and for its group
+docker build ./analysis -t local-ccsh --build-arg USER_ADD=true --build-arg USER_ID=1001 --build-arg USERNAME=your_name
+```


### PR DESCRIPTION
# Add user arguments to change the default container user in case 1000 1000 already exists

Issue: #3308 

## Description

Due to sapmachine adding a 1000 1000 user in a patch update :) we added arguments that the user can be changed during docker build

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
