### PR TITLE
Dev: Add tag verification check against both package.json versions

### DIFF
--- a/VERSION_BUMPING.md
+++ b/VERSION_BUMPING.md
@@ -11,9 +11,10 @@
 
 -   Call `pipenv run make_release`.
 -   On Windows it is recommended to run the command in `cmd.exe` rather than in a git bash.
--   Note that you have to add the Changelog notes manually on GitHub (GitHub > Latest (new) release > Edit).
+-   Check the release process on GitHub after the script is completed
 
 > You can add `-f` or `--force` to disable the protections of the script. You can't release in force mode.
+> This is especially useful when testing changes on the release script
 
 ## Explanation of the script
 
@@ -21,6 +22,20 @@
 -   The version number will be updated automatically in corresponding files.
 -   The Changelog section `[unreleased]` will be renamed to the release date like e.g. `[2020-12-12]` and a new `[unreleased]` section will be added on top of the Changelog.
 -   A release post will be created for the GitHub Pages with the corresponding release notes from the Changelog.
+-   If you release visualization, a static version of our webpack will be copied to our github-pages folder to enable the webdemo, when analysis is released.
 -   You will be asked if you want to commit and tag the automatically changed files and thus, the release itself.
 -   Then you will be asked if you want to push the release commits finally.
--   Our build pipeline will detect the new release (tag) and starts a build to publish the new release as npm packages on npmjs.com
+-   Our build pipeline will detect the new release (tag) and starts a build to publish the new release as npm packages on npmjs.com and our images to docker
+
+> There are checks in place to verify that your local repository is in the correct state before releasing:
+> e.g. location (codecharta/), branch (main), status (clean working directory), fetch (up-to-date)
+
+### Release Failure
+
+If there is an error during the release process make sure to undo changes carefully:
+
+-   Revert the release commit (`git revert your-commit-hash && git push`)
+-   Delete the version tag (locally and remote)
+
+> If faulty versions get (partially) published to npm or docker take the appropriate actions to fix them. Either by
+> developing a hotfix (and/or) removing the versions from npm/docker if possible.

--- a/script/make_release.py
+++ b/script/make_release.py
@@ -136,8 +136,8 @@ if not FORCE and repo.active_branch.name != "main":
     print("You can only release on main branch. Aborting.")
     quit(1)
 
-# Pull changes to ensure we are up to date
-repo.remotes.origin.pull()
+# Fetch updates, to ensure the status is UPTODATE (4)
+assert(repo.remotes.origin.fetch()[0].flags == 4)
 
 # Get latest tag for visualization and analysis
 all_tags_sorted = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)

--- a/script/make_release.py
+++ b/script/make_release.py
@@ -136,6 +136,9 @@ if not FORCE and repo.active_branch.name != "main":
     print("You can only release on main branch. Aborting.")
     quit(1)
 
+# Pull changes to ensure we are up to date
+repo.remotes.origin.pull()
+
 # Get latest tag for visualization and analysis
 all_tags_sorted = sorted(repo.tags, key=lambda t: t.commit.committed_datetime)
 tags_vis = [tag for tag in all_tags_sorted if tag.name.startswith("vis-")]


### PR DESCRIPTION
## Release Script Improvement: Tag Verification

### Description

This PR adds a verification method to our release script. This method matches the version in `analysis/node-wrapper/package.json` and `visualization/package.json` against the latest `ana-*.*.*` and `vis-*.*.*` tags. If they don't match, the script will abort with an error message. This ensures, that there are no floating tags of unreleased versions remote or locally. 

Also adds a check that verifies, that the branch is up-to-date via git fetch.

### Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] ~~There are automated tests for newly written code and bug fixes~~
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.)
- [x] ~~CHANGELOG.md has been updated~~

## Screenshots or gifs
