### PR TITLE
docs/3638/remove-zenhub-refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ $ ccsh sourcecodeparser junit4 -p junit4 -o junit4.source.cc.json
 
 Have a **bug**, a **feature** request or any question? Please open [a new issue](https://github.com/MaibornWolff/codecharta/issues/new). Feedback is always welcome.
 
-Want to know what we are **working on**? Please check out [our board](https://app.zenhub.com/workspaces/codecharta-workspace-5cd16b609795a865159e7107/board) or install the Zenhub Firefox/Chrome plugin.
-
 Want to have even **more information**? Please check our [news](https://maibornwolff.github.io/codecharta/news/).
 
 ## Further Information

--- a/gh-pages/_docs/01-07-feedback.md
+++ b/gh-pages/_docs/01-07-feedback.md
@@ -6,5 +6,3 @@ title: "Feedback"
 Are you using CodeCharta and want to give feedback? Or are you not using CodeCharta because we missed something? Or do you want to contribute to CodeCharta? We are eager to get your feedback.
 
 We communicate a lot using Github Issues. All enhancements and bugs are tracked using issues. We then give each other feedback by commenting on these issues. Likewise you can create bugs, feature request and the like as well. Or just a simple "thank you" issue if you like CodeCharta. :) If you want to contribute please check [new to this code?]({{site.baseurl}}{% link _docs/07-01-new-to-code.md %}).
-
-To see what we'll be working on soon (the backlog) or what we are working right now on (in progress) please click [this Zenhub link](https://app.zenhub.com/workspaces/codecharta-workspace-5cd16b609795a865159e7107/board) or install the Zenhub Firefox/Chrome plugin.


### PR DESCRIPTION
# Remove references of ZenHub from the Docs

Closes: #3638

## Description

Removes references of zenhub from the Readme and feedback GH-page as we are no longer using zenhub.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
