### PR TITLE
Bug/3653/improve steetmap and treemapstreet layout

### DIFF
--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
@@ -1,7 +1,7 @@
 import { AmbientLight, Box3, BufferGeometry, DirectionalLight, Group, Line, Material, Object3D, Raycaster, Scene, Vector3 } from "three"
 import { CodeMapMesh } from "../rendering/codeMapMesh"
 import { CodeMapBuilding } from "../rendering/codeMapBuilding"
-import { CodeMapNode, LayoutAlgorithm, Node, CcState } from "../../../codeCharta.model"
+import { CodeMapNode, Node, CcState } from "../../../codeCharta.model"
 import { hierarchy } from "d3-hierarchy"
 import { ColorConverter } from "../../../util/color/colorConverter"
 import { FloorLabelDrawer } from "./floorLabels/floorLabelDrawer"
@@ -82,10 +82,10 @@ export class ThreeSceneService implements OnDestroy {
     private initFloorLabels(nodes: Node[]) {
         this.floorLabelPlanes.clear()
 
-        const { layoutAlgorithm, enableFloorLabels } = this.state.getValue().appSettings
+        /* const { layoutAlgorithm, enableFloorLabels } = this.state.getValue().appSettings
         if (layoutAlgorithm !== LayoutAlgorithm.SquarifiedTreeMap || !enableFloorLabels) {
             return
-        }
+        }*/
 
         const rootNode = this.getRootNode(nodes)
         if (!rootNode) {

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/boundingBox.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/boundingBox.ts
@@ -5,7 +5,7 @@ import Rectangle from "./rectangle"
 export default abstract class BoundingBox {
     height = 0
     width = 0
-    protected node: CodeMapNode
+    node: CodeMapNode
     protected metricValue: number
     protected FIXED_MARGIN = 0.5
 

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
@@ -165,11 +165,15 @@ export default class HorizontalStreet extends Street {
      * @param children children of the current node
      */
     protected splitChildrenToRows(children: BoundingBox[]): void {
-        const totalLength = this.getLength(children)
+        let totalLength = 0
         let sum = 0
 
         for (const child of children) {
-            if (sum < totalLength / 2) {
+            totalLength += child.width
+        }
+
+        for (const child of children) {
+            if (sum <= totalLength / 2) {
                 this.topRow.push(child)
                 sum += child.width
             } else {

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
@@ -19,15 +19,9 @@ export default class HorizontalStreet extends Street {
     orientation: HorizontalOrientation
     protected depth: number
 
-    constructor(
-        node: CodeMapNode,
-        children: BoundingBox[],
-        depth: number,
-        orientation: HorizontalOrientation = HorizontalOrientation.RIGHT
-    ) {
+    constructor(node: CodeMapNode, children: BoundingBox[], orientation: HorizontalOrientation = HorizontalOrientation.RIGHT) {
         super(node)
         this.children = children
-        this.depth = depth
         this.orientation = orientation
     }
 

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/horizontalStreet.ts
@@ -12,8 +12,8 @@ export enum HorizontalOrientation {
 }
 
 export default class HorizontalStreet extends Street {
-    private children: BoundingBox[] = []
-    protected node: CodeMapNode
+    protected children: BoundingBox[] = []
+    node: CodeMapNode
     protected topRow: BoundingBox[] = []
     protected bottomRow: BoundingBox[] = []
     orientation: HorizontalOrientation
@@ -46,7 +46,7 @@ export default class HorizontalStreet extends Street {
         // TODO Add a comment what the following calculations are doing.
         this.metricValue = StreetViewHelper.calculateSize(this.node, metricName)
         this.width = Math.max(this.getLength(this.topRow), this.getLength(this.bottomRow))
-        this.height = this.getMaxHeight(this.topRow) + this.getStreetThickness() + this.getMaxHeight(this.bottomRow) + 2 * this.spacer
+        this.height = this.getMaxHeight(this.topRow) + this.getStreetThickness() + this.getMaxHeight(this.bottomRow) + this.spacer
     }
 
     layout(margin: number, origin: Vector2): CodeMapNode[] {
@@ -132,7 +132,7 @@ export default class HorizontalStreet extends Street {
     /**
      * Calculates y-coordinate of street.
      * @param origin origin of local coordinate system
-     * @param maxLeftWidth highest node in topRow
+     * @param maxTopHeight highest node in topRow
      */
     private calculateStreetOffsetY(origin: Vector2, maxTopHeight: number): number {
         return origin.y + this.spacer + maxTopHeight

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/rectangle.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/rectangle.ts
@@ -4,7 +4,7 @@ export default class Rectangle {
     topLeft: Vector2
     width: number
     height: number
-    private bottomRight: Vector2
+    protected bottomRight: Vector2
 
     constructor(topLeft: Vector2, width: number, height: number) {
         this.topLeft = topLeft

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
@@ -11,7 +11,8 @@ export enum StreetOrientation {
 export default abstract class Street extends BoundingBox {
     streetRect: Rectangle | undefined
     protected spacer = 2
-    private maxStreetThickness = 10
+    private maxStreetThickness = 8
+    private rootStreetThickness = 20
     protected abstract depth: number
 
     protected abstract layoutStreet(origin: Vector2, maxNodeSideLength: number): CodeMapNode
@@ -20,6 +21,9 @@ export default abstract class Street extends BoundingBox {
     protected abstract rearrangeRows(): void
 
     protected getStreetThickness(): number {
-        return this.maxStreetThickness / (this.depth + 1)
+        const pathParts = this.node.path.split("/")
+        const isDirectChildOfRoot = this.node.path.startsWith("/root/") && pathParts.length === 3 && pathParts[2] !== ""
+
+        return this.node.path === "/root" || isDirectChildOfRoot ? this.rootStreetThickness : this.maxStreetThickness / (this.depth + 1)
     }
 }

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
@@ -10,7 +10,7 @@ export enum StreetOrientation {
 
 export default abstract class Street extends BoundingBox {
     streetRect: Rectangle | undefined
-    protected spacer = 2
+    protected spacer = 1
     private maxStreetThickness = 8
     private rootStreetThickness = 20
     protected abstract depth: number

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
@@ -10,9 +10,8 @@ export enum StreetOrientation {
 
 export default abstract class Street extends BoundingBox {
     streetRect: Rectangle | undefined
-    protected spacer = 1
+    protected spacer = 2
     private maxStreetThickness = 8
-    private rootStreetThickness = 20
     protected abstract depth: number
 
     protected abstract layoutStreet(origin: Vector2, maxNodeSideLength: number): CodeMapNode
@@ -24,6 +23,22 @@ export default abstract class Street extends BoundingBox {
         const pathParts = this.node.path.split("/")
         const isDirectChildOfRoot = this.node.path.startsWith("/root/") && pathParts.length === 3 && pathParts[2] !== ""
 
-        return this.node.path === "/root" || isDirectChildOfRoot ? this.rootStreetThickness : this.maxStreetThickness / (this.depth + 1)
+        return this.node.path === "/root" || isDirectChildOfRoot
+            ? this.calculateRootStreetThickness(this.node)
+            : this.calculateNonRootThickness(this.node)
+    }
+
+    protected calculateNonRootThickness(node: CodeMapNode): number {
+        const baseThickness = 2
+        const sizeFactor = 0.0005
+        const fileSize = node.attributes.unary
+        return baseThickness + fileSize * sizeFactor
+    }
+
+    protected calculateRootStreetThickness(node: CodeMapNode): number {
+        const baseThickness = 8
+        const sizeFactor = 0.001
+        const fileSize = node.attributes.unary
+        return baseThickness + fileSize * sizeFactor
     }
 }

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/street.ts
@@ -11,8 +11,6 @@ export enum StreetOrientation {
 export default abstract class Street extends BoundingBox {
     streetRect: Rectangle | undefined
     protected spacer = 2
-    private maxStreetThickness = 8
-    protected abstract depth: number
 
     protected abstract layoutStreet(origin: Vector2, maxNodeSideLength: number): CodeMapNode
     protected abstract splitChildrenToRows(children: BoundingBox[]): void

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
@@ -99,7 +99,7 @@ export class StreetLayoutGenerator {
     private static calculateHeightScale(map: CodeMapNode, treeMapSize: number, maxHeight: number): number {
         // Constants to control the curve and scaling
         const linearCoefficient = 0.0001
-        const rootCoefficient = 0.03
+        const rootCoefficient = 0.01
 
         // Calculate linear and square root components
         const linearComponent = linearCoefficient * map.attributes.unary

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
@@ -99,7 +99,7 @@ export class StreetLayoutGenerator {
     private static calculateHeightScale(map: CodeMapNode, treeMapSize: number, maxHeight: number): number {
         // Constants to control the curve and scaling
         const linearCoefficient = 0.0001
-        const rootCoefficient = 0.01
+        const rootCoefficient = 0.005
 
         // Calculate linear and square root components
         const linearComponent = linearCoefficient * map.attributes.unary

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/streetLayoutGenerator.ts
@@ -48,21 +48,14 @@ export class StreetLayoutGenerator {
         const children: BoundingBox[] = []
         const areaMetric = state.dynamicSettings.areaMetric
         for (let child of node.children) {
-            if (isPathBlacklisted(child.path, state.fileSettings.blacklist, "exclude")) {
-                continue
-            }
             if (isLeaf(child)) {
                 children.push(new House(child))
                 continue
             }
-            if (child.type === NodeType.FOLDER && child.children && child.children.length < 5) {
-                for (const file of child.children) {
-                    if (file.type === NodeType.FILE) {
-                        file.isExcluded = true
-                    }
-                }
+            if (this.hasFewerThanFiveNonDirectoryFiles(child)) {
+                continue
             }
-            if (this.areAllChildrenNodesExcluded(child)) {
+            if (isPathBlacklisted(child.path, state.fileSettings.blacklist, "exclude")) {
                 continue
             }
 
@@ -88,13 +81,17 @@ export class StreetLayoutGenerator {
         return children
     }
 
-    private static areAllChildrenNodesExcluded(child: CodeMapNode): boolean {
-        for (let index = 0; index < child.children.length; index++) {
-            if (!child.children[index].isExcluded) {
-                return false
+    private static hasFewerThanFiveNonDirectoryFiles(node: CodeMapNode): boolean {
+        let nonDirectoryFileCount = 0
+        for (const child of node.children) {
+            if (child.type === NodeType.FOLDER) {
+                return false // Skip node if it contains files
+            }
+            if (child.type === NodeType.FILE) {
+                nonDirectoryFileCount++
             }
         }
-        return true
+        return nonDirectoryFileCount < 5
     }
 
     private static createStreet(node: CodeMapNode, orientation: StreetOrientation, children: BoundingBox[], depth: number) {

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/streetViewHelper.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/streetViewHelper.ts
@@ -36,10 +36,10 @@ function mergeDirectories(node: CodeMapNode, metricName: string): CodeMapNode {
     return mergedNode
 }
 
-function buildNodeFrom(layoutNode: CodeMapNode, heightScale: number, maxHeight: number, s: CcState, isDeltaState: boolean): Node {
+function buildNodeFrom(layoutNode: CodeMapNode, heightScale: number, maxHeight: number, state: CcState, isDeltaState: boolean): Node {
     const isNodeLeaf = !(layoutNode.children && layoutNode.children.length > 0)
-    const flattened: boolean = isNodeFlat(layoutNode, s)
-    const heightValue: number = TreeMapHelper.getHeightValue(s, layoutNode, maxHeight, flattened)
+    const flattened: boolean = isNodeFlat(layoutNode, state)
+    const heightValue: number = TreeMapHelper.getHeightValue(state, layoutNode, maxHeight, flattened)
     const height = Math.abs(
         isNodeLeaf ? Math.max(heightScale * heightValue, TreeMapHelper.MIN_BUILDING_HEIGHT) : TreeMapHelper.FOLDER_HEIGHT
     )
@@ -64,15 +64,15 @@ function buildNodeFrom(layoutNode: CodeMapNode, heightScale: number, maxHeight: 
         attributes: layoutNode.attributes,
         edgeAttributes: layoutNode.edgeAttributes,
         deltas: layoutNode.deltas,
-        heightDelta: layoutNode.deltas?.[s.dynamicSettings.heightMetric]
-            ? heightScale * layoutNode.deltas[s.dynamicSettings.heightMetric]
+        heightDelta: layoutNode.deltas?.[state.dynamicSettings.heightMetric]
+            ? heightScale * layoutNode.deltas[state.dynamicSettings.heightMetric]
             : 0,
-        visible: isVisible(layoutNode, isNodeLeaf, s, flattened),
+        visible: isVisible(layoutNode, isNodeLeaf, state, flattened),
         path: layoutNode.path,
         link: layoutNode.link,
-        markingColor: getMarkingColor(layoutNode, s.fileSettings.markedPackages),
+        markingColor: getMarkingColor(layoutNode, state.fileSettings.markedPackages),
         flat: flattened,
-        color: getBuildingColor(layoutNode, s, selectedColorMetricDataSelector(s), isDeltaState, flattened),
+        color: getBuildingColor(layoutNode, state, selectedColorMetricDataSelector(state), isDeltaState, flattened),
         incomingEdgePoint: getIncomingEdgePoint(layoutNode.rect.width, height, length, new Vector3(x0, z0, y0), treeMapSize),
         outgoingEdgePoint: getIncomingEdgePoint(layoutNode.rect.width, height, length, new Vector3(x0, z0, y0), treeMapSize)
     }

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/verticalStreet.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/verticalStreet.ts
@@ -16,13 +16,11 @@ export default class VerticalStreet extends Street {
     protected leftRow: BoundingBox[] = []
     protected rightRow: BoundingBox[] = []
     orientation: VerticalOrientation
-    protected depth: number
     private _origin: Vector2
 
     constructor(node: CodeMapNode, children: BoundingBox[], depth: number, orientation: VerticalOrientation = VerticalOrientation.UP) {
         super(node)
         this.children = children
-        this.depth = depth
         this.orientation = orientation
     }
 

--- a/visualization/app/codeCharta/util/algorithm/streetLayout/verticalStreet.ts
+++ b/visualization/app/codeCharta/util/algorithm/streetLayout/verticalStreet.ts
@@ -124,26 +124,27 @@ export default class VerticalStreet extends Street {
 
     protected sortChildrenByType(children: BoundingBox[]): void {
         children.sort((a, b) => {
-            // Unterscheiden zwischen File und Folder
             if (a.node.type === b.node.type) {
-                return 0 // Keine Änderung in der Reihenfolge, wenn beide Nodes denselben Typ haben
+                return 0
             }
             if (a.node.type === NodeType.FILE) {
-                return -1 // a ist ein File, b ist ein Folder, a soll vor b kommen
+                return -1
             }
-            return 1 // a ist ein Folder, b ist ein File, b soll vor a kommen
+            return 1
         })
     }
     protected splitChildrenToRows(children: BoundingBox[]): void {
-        // Zuerst die Kinder nach Typ sortieren
         this.sortChildrenByType(children)
 
-        const totalLength = this.getLength(children)
+        let totalLength = 0
         let sum = 0
 
         for (const child of children) {
-            if (sum < totalLength / 2) {
-                // Handhabung, falls spezifische Anweisungen basierend auf dem Typ notwendig sind
+            totalLength += child.height
+        }
+
+        for (const child of children) {
+            if (sum <= totalLength / 2) {
                 if (child instanceof HorizontalStreet) {
                     child.orientation = HorizontalOrientation.LEFT
                 }
@@ -165,42 +166,6 @@ export default class VerticalStreet extends Street {
 
     private getMaxWidth(boxes: BoundingBox[]): number {
         return boxes.reduce((max, n) => Math.max(max, n.width), Number.MIN_VALUE)
-    }
-
-    private getMaxEffectiveWidth(boxes: BoundingBox[]): number {
-        if (boxes.length === 0) {
-            return 0
-        }
-
-        //let minX = Number.POSITIVE_INFINITY;
-        //let maxX = Number.NEGATIVE_INFINITY;
-
-        // Find actual min and max X considering position and width
-        /*for (const box of boxes) {
-            minX = Math.min(minX, box.x);
-            maxX = Math.max(maxX, box.x + box.width);
-        }*/
-
-        //return maxX - minX;  // the effective width used
-    }
-
-    private getCorners(
-        origin: Vector2,
-        box: BoundingBox
-    ): {
-        bottomFrontLeft: { x: number; y: number }
-        bottomFrontRight: { x: number; y: number }
-        bottomBackLeft: { x: number; y: number }
-        bottomBackRight: { x: number; y: number }
-    } {
-        this._origin = origin
-
-        return {
-            bottomFrontLeft: { x: origin.x, y: origin.y },
-            bottomFrontRight: { x: origin.x + box.width, y: origin.y },
-            bottomBackLeft: { x: origin.x, y: origin.y + box.width },
-            bottomBackRight: { x: origin.x + box.width, y: origin.y + box.width }
-        }
     }
 
     protected calculateStreetOverhang(streetOrigin: Vector2): number {


### PR DESCRIPTION
# Small visual adjustments for a better overview

Issue: #3653 

## Description

**Descriptive pull request text**
  - The root street stands out way more then before, because it has it's own thickness
  - height scaling is dynamic now and is calculated in dependence of directory count
  - before on a street which contained files and directories there was no specific order, so it looked chaotic
       -> now files come first and then directories
- directories which contain less then 5 single files are excluded
- small adjust for the layout algorithm

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
![image](https://github.com/MaibornWolff/codecharta/assets/152617178/fed71da5-92b7-4f42-b08b-63756ab6e1ce)

