### PR TITLE
Tech: Enable metric-gardener inside analysis and docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
       - name: Build
         run: |
           chmod +x ./gradlew

--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Changed
+
+- Re-activate metric-gardener on-the-fly execution [#3691](https://github.com/MaibornWolff/codecharta/pull/3691)
+
 ### Chore 👨‍💻 👩‍💻
 
 - Bump node version from 18 to 20 [#3690](https://github.com/MaibornWolff/codecharta/pull/3690)

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -27,9 +27,10 @@ RUN wget -qO codemaat.jar https://github.com/adamtornhill/code-maat/releases/dow
     mkdir --parents /opt/codemaat; \
     mv codemaat.jar /opt/codemaat/;
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh; \
+RUN curl -sL https://deb.nodesource.com/setup_20.x -o /tmp/nodesource_setup.sh; \
     bash /tmp/nodesource_setup.sh; \
-    apt-get install nodejs make gcc build-essential -y;
+    apt-get install nodejs make gcc build-essential -y; \
+    npm install -g metric-gardener;
 
 RUN wget -qO /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.1.0.4477-linux-x64.zip; \
     apt-get install unzip -y; \

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -12,8 +12,6 @@ CodeCharta analysis tools generally follow the pipes and filters architecture pr
 
 Components that import data from an external source, e.g. SonarQube, and generate visualisation data.
 
-> Attention: The direct execution of metric-gardener has been temporarily disabled.
-
 | Source             | Project                                                                          |
 | ------------------ | -------------------------------------------------------------------------------- |
 | CodeMaat CSV       | [CodeMaatImporter](import/CodeMaatImporter/README.md)                            |

--- a/analysis/import/MetricGardenerImporter/README.md
+++ b/analysis/import/MetricGardenerImporter/README.md
@@ -1,8 +1,5 @@
 # MetricGardener Importer
 
-> Attention: The direct execution of metric-gardener has been temporarily disabled. Please provide the JSON files
-> directly.
-
 This importer allows to use metrics calculated by [MetricGardener](https://github.com/MaibornWolff/metric-gardener), a
 multi-language code parser based on [tree-sitter](https://github.com/tree-sitter/tree-sitter). The importer can be used
 to parse files locally or to just import a MetricGardener.json file and convert it into a regular CodeCharta.cc.json

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
@@ -177,5 +177,4 @@ class MetricGardenerImporterTest {
         Assertions.assertThat(errContent.toString())
             .contains("Error while executing metric gardener! Process returned with status")
     }
-
 }

--- a/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
+++ b/analysis/import/MetricGardenerImporter/src/test/kotlin/de/maibornwolff/codecharta/importer/metricgardenerimporter/MetricGardenerImporterTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -91,7 +90,6 @@ class MetricGardenerImporterTest {
         assertTrue(file.exists())
     }
 
-    @Disabled
     @Test
     fun `should create file when MG needs to run first`() {
         main(
@@ -151,7 +149,6 @@ class MetricGardenerImporterTest {
             .contains("Input invalid file for MetricGardenerImporter, stopping execution")
     }
 
-    @Disabled
     @Test
     fun `should stop execution if error happens while executing metric gardener`() {
         val npm = if (System.getProperty("os.name").contains("win", ignoreCase = true)) "npm.cmd" else "npm"
@@ -181,18 +178,4 @@ class MetricGardenerImporterTest {
             .contains("Error while executing metric gardener! Process returned with status")
     }
 
-    @Test
-    fun `should stop execution if no MG json is present`() {
-        System.setErr(PrintStream(errContent))
-        main(
-            arrayOf(
-                "src/test/resources/MetricGardenerRawFile.kt",
-                "-nc",
-                "-o=src/test/resources/import-result-mg"
-            )
-        )
-        System.setErr(originalErr)
-        Assertions.assertThat(errContent.toString())
-            .contains("Direct metric-gardener execution has been temporarily disabled.")
-    }
 }

--- a/analysis/test/golden_test.sh
+++ b/analysis/test/golden_test.sh
@@ -134,10 +134,10 @@ check_metricgardener() {
   "${CCSH}" metricgardenerimport "${DATA}/metricgardener.json" -o "${ACTUAL_METRICGARDENER_JSON}" --is-json-file
   validate "${ACTUAL_METRICGARDENER_JSON}.cc.json.gz"
 
-  # echo " -- expect MetricGardenerImporter to produce valid cc.json file when no MG.json was available"
-  # ACTUAL_METRICGARDENER_JSON2="${TEMP_DIR}/actual_metricgardenerparser2"
-  # "${CCSH}" metricgardenerimport "${DATA}/metric-gardener-Example" -o "${ACTUAL_METRICGARDENER_JSON2}"
-  # validate "${ACTUAL_METRICGARDENER_JSON2}.cc.json.gz"
+  echo " -- expect MetricGardenerImporter to produce valid cc.json file when no MG.json was available"
+  ACTUAL_METRICGARDENER_JSON2="${TEMP_DIR}/actual_metricgardenerparser2"
+  "${CCSH}" metricgardenerimport "${DATA}/metric-gardener-Example" -o "${ACTUAL_METRICGARDENER_JSON2}"
+  validate "${ACTUAL_METRICGARDENER_JSON2}.cc.json.gz"
 }
 
 check_sonar() {

--- a/gh-pages/_docs/01-04-docker-containers.md
+++ b/gh-pages/_docs/01-04-docker-containers.md
@@ -44,8 +44,6 @@ the analysis container, copy them over using `docker cp`
 
 See also [CodeCharta Analysis]({{site.baseurl}}{% link _docs/05-01-analysis.md %})
 
-> Attention: The direct execution of metric-gardener has been temporarily disabled. It is not included.
-
 Almost all tools the ccsh can import data from are included in the container, so you can get started immediately.
 Installed are:
 

--- a/gh-pages/_docs/04-13-metricgardener.md
+++ b/gh-pages/_docs/04-13-metricgardener.md
@@ -3,8 +3,6 @@ permalink: /docs/metricgardener-importer
 title: "MetricGardener Importer"
 ---
 
-> Attention: The direct execution of metric-gardener has been temporarily disabled.
-
 This importer allows to use metrics calculated by [MetricGardener](https://github.com/MaibornWolff/metric-gardener), a
 multi-language code parser based on [tree-sitter](https://github.com/tree-sitter/tree-sitter). The importer can be used
 to parse files locally or to just import a MetricGardener.json file and convert it into a regular CodeCharta.cc.json


### PR DESCRIPTION
# Tech: Re-Add metric-gardener to the analysis project and its docker container

Closes: #3547 

## Description

- Enable metric-gardener on-the-fly execution in analysis
- Add metric-gardener installation to the analysis Dockerfile
- Upgrade node to version 20 inside the analysis Dockerfile

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

