### PR TITLE
Feature/3685/mcc migration

### DIFF
--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
@@ -1,0 +1,84 @@
+package de.maibornwolff.codecharta.filter.structuremodifier
+
+import de.maibornwolff.codecharta.model.AttributeDescriptor
+import de.maibornwolff.codecharta.model.AttributeType
+import de.maibornwolff.codecharta.model.BlacklistItem
+import de.maibornwolff.codecharta.model.Edge
+import de.maibornwolff.codecharta.model.MutableNode
+import de.maibornwolff.codecharta.model.Project
+import de.maibornwolff.codecharta.model.ProjectBuilder
+
+class MetricRenamer(
+    private val project: Project
+    //TODO: add newName as val here
+) {
+    fun rename(): Project {
+        val updatedRoot = renameMCCRecursivelyInNodes(project.rootNode.toMutableNode())
+        val updatedAttributeTypes = updatedAttributeTypes(project.attributeTypes)
+        val updatedAttributesDescriptors = updatedAttributeDescriptors(project.attributeDescriptors)
+
+        return ProjectBuilder(
+            listOf(updatedRoot),
+            copyEdges(),
+            updatedAttributeTypes.toMutableMap(),
+            updatedAttributesDescriptors.toMutableMap(),
+            copyBlacklist(),
+        ).build()
+    }
+
+    private fun renameMCCRecursivelyInNodes(node: MutableNode): MutableNode {
+        if (node.attributes.containsKey("mcc")) {
+            val updatedAttributes = node.attributes.toMutableMap()
+
+            val mccValue = updatedAttributes.remove("mcc")
+            if (mccValue == null) {
+                throw NullPointerException("Input file contains null value for a node attribute! Please ensure the input is a valid cc.json file.")
+            }
+            updatedAttributes["complexity"] = mccValue
+
+            node.attributes = updatedAttributes
+        }
+
+        if (node.children.isEmpty()) {
+            return node
+        }
+
+        node.children.forEach { child -> renameMCCRecursivelyInNodes(child) }
+
+        return node
+    }
+
+    private fun updatedAttributeTypes(attributeTypes: Map<String, MutableMap<String, AttributeType>>): Map<String, MutableMap<String, AttributeType>> {
+        val nodeAttributes = attributeTypes["nodes"] ?: return attributeTypes
+
+        val mccType = nodeAttributes.remove("mcc")
+        if (mccType == null) {
+            throw NullPointerException("Input file contains null value for an attribute type! Please ensure the input is a valid cc.json file.")
+        }
+        nodeAttributes["complexity"] = mccType
+
+        return attributeTypes
+    }
+
+    private fun updatedAttributeDescriptors(attributeDescriptors: Map<String, AttributeDescriptor>): Map<String, AttributeDescriptor> {
+        if (!attributeDescriptors.containsKey("mcc")) return attributeDescriptors
+
+        val updatedAttributeDescriptors = attributeDescriptors.toMutableMap()
+        val mccDescriptor = updatedAttributeDescriptors.remove("mcc")
+
+        if (mccDescriptor == null) {
+
+            throw NullPointerException("Input file contains null value for an attribute descriptor! Please ensure the input is a valid cc.json file.")
+        }
+        updatedAttributeDescriptors["complexity"] = mccDescriptor
+        return updatedAttributeDescriptors
+    }
+
+    private fun copyEdges(): MutableList<Edge> {
+        return project.edges.toMutableList()
+    }
+
+    private fun copyBlacklist(): MutableList<BlacklistItem> {
+        return project.blacklist.toMutableList()
+    }
+}

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
@@ -9,8 +9,8 @@ import de.maibornwolff.codecharta.model.Project
 import de.maibornwolff.codecharta.model.ProjectBuilder
 
 class MetricRenamer(
-    private val project: Project
-    //TODO: add newName as val here
+    private val project: Project,
+    private val newName: String = "complexity"
 ) {
     fun rename(): Project {
         val updatedRoot = renameMCCRecursivelyInNodes(project.rootNode.toMutableNode())
@@ -34,7 +34,7 @@ class MetricRenamer(
             if (mccValue == null) {
                 throw NullPointerException("Input file contains null value for a node attribute! Please ensure the input is a valid cc.json file.")
             }
-            updatedAttributes["complexity"] = mccValue
+            updatedAttributes[newName] = mccValue
 
             node.attributes = updatedAttributes
         }
@@ -55,7 +55,7 @@ class MetricRenamer(
         if (mccType == null) {
             throw NullPointerException("Input file contains null value for an attribute type! Please ensure the input is a valid cc.json file.")
         }
-        nodeAttributes["complexity"] = mccType
+        nodeAttributes[newName] = mccType
 
         return attributeTypes
     }
@@ -70,7 +70,7 @@ class MetricRenamer(
 
             throw NullPointerException("Input file contains null value for an attribute descriptor! Please ensure the input is a valid cc.json file.")
         }
-        updatedAttributeDescriptors["complexity"] = mccDescriptor
+        updatedAttributeDescriptors[newName] = mccDescriptor
         return updatedAttributeDescriptors
     }
 

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/ParserDialog.kt
@@ -28,6 +28,7 @@ class ParserDialog {
                     choices =
                         listOf(
                             StructureModifierAction.PRINT_STRUCTURE.descripton,
+                            StructureModifierAction.MIGRATE_MCC.descripton,
                             StructureModifierAction.SET_ROOT.descripton,
                             StructureModifierAction.MOVE_NODES.descripton,
                             StructureModifierAction.REMOVE_NODES.descripton
@@ -36,6 +37,7 @@ class ParserDialog {
 
             return when (selectedAction) {
                 StructureModifierAction.PRINT_STRUCTURE.descripton -> listOf(inputFileName, *collectPrintArguments())
+                StructureModifierAction.MIGRATE_MCC.descripton -> listOf(inputFileName, *collectMCCArguments())
                 StructureModifierAction.SET_ROOT.descripton -> listOf(inputFileName, *collectSetRootArguments())
                 StructureModifierAction.MOVE_NODES.descripton ->
                     listOf(
@@ -61,6 +63,17 @@ class ParserDialog {
                     hint = "0"
                 )
             return arrayOf("--print-levels=$printLevels")
+        }
+
+        private fun collectMCCArguments(): Array<String> {
+            val newName: String =
+                KInquirer.promptList(
+                    message = "This action will rename the mcc metric. Which should the new name be?",
+                    choices = listOf("complexity", "sonar_complexity")
+                )
+            val renameParam = if (newName == "sonar_complexity") "--rename-mcc=sonar" else "--rename-mcc"
+            val outputFileName = collectOutputFileName()
+            return arrayOf(renameParam, "--output-file=$outputFileName")
         }
 
         private fun collectSetRootArguments(): Array<String> {

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifier.kt
@@ -44,6 +44,10 @@ class StructureModifier(
     )
     private var printLevels: Int? = null
 
+    @CommandLine.Option(names = ["--rename-mcc"], arity = "0..1", description = ["rename the mcc metric to complexity. " +
+        "Optionally specify 'sonar' for it to be renamed to sonar_complexity"])
+    private var renameMcc: String? = null
+
     @CommandLine.Option(names = ["-o", "--output-file"], description = ["output File (or empty for stdout)"])
     private var outputFile: String? = null
 
@@ -96,6 +100,14 @@ class StructureModifier(
             }
 
             setRoot != null -> project = SubProjectExtractor(project).extract(setRoot!!)
+            renameMcc != null -> { project =
+                if (renameMcc == "sonar") {
+                    MetricRenamer(project, "sonar_complexity").rename()
+                } else if (renameMcc == "") {
+                    MetricRenamer(project).rename()
+                } else throw IllegalArgumentException("Invalid value for rename flag, stopping execution...")
+
+            }
             remove.isNotEmpty() -> project = NodeRemover(project).remove(remove)
             moveFrom != null -> project = FolderMover(project).move(moveFrom, moveTo) ?: return null
         }

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierAction.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierAction.kt
@@ -6,5 +6,6 @@ enum class StructureModifierAction(
     PRINT_STRUCTURE("Print the structure of the project"),
     SET_ROOT("Extract a sub path as the new root"),
     MOVE_NODES("Move nodes within the project"),
-    REMOVE_NODES("Remove nodes")
+    REMOVE_NODES("Remove nodes"),
+    MIGRATE_MCC("Update MCC metric name to complexity or sonar_complexity")
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamerTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamerTest.kt
@@ -27,7 +27,7 @@ class MetricRenamerTest {
     }
 
     @Test
-    fun `should rename all occurrences of mcc in the projects nodes when the project contains this metric`() {
+    fun `should rename all occurrences of mcc in the projects nodes to complexity when the project contains this metric`() {
         val bufferedReader = File("src/test/resources/sample_project.cc.json").bufferedReader()
         val sampleProject = ProjectDeserializer.deserializeProject(bufferedReader)
 
@@ -63,6 +63,15 @@ class MetricRenamerTest {
 
         Assertions.assertThat(result.attributeDescriptors.containsKey("mcc")).isFalse()
         Assertions.assertThat(result.attributeDescriptors.containsKey("ymcc")).isTrue()
+    }
+
+    @Test
+    fun `should rename mcc to sonar_complexity when specified`() {
+        val result = MetricRenamer(attributeDescriptorsProject, "sonar_complexity").rename()
+
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "mcc")).isFalse()
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "complexity")).isFalse()
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "sonar_complexity")).isTrue()
     }
 
     @Test   //TODO: revisit

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamerTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamerTest.kt
@@ -1,0 +1,73 @@
+package de.maibornwolff.codecharta.filter.structuremodifier
+
+import de.maibornwolff.codecharta.model.MutableNode
+import de.maibornwolff.codecharta.model.Project
+import de.maibornwolff.codecharta.serialization.ProjectDeserializer
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class MetricRenamerTest {
+    private lateinit var attributeDescriptorsProject: Project
+
+    private fun doesAttributeExistInNode(node: MutableNode, attributeName: String): Boolean {
+        if (node.attributes.containsKey(attributeName)) return true
+
+        if (node.children.isEmpty()) return false
+
+        val resultOfChildNodes = node.children.any { doesAttributeExistInNode(it, attributeName) }
+        return resultOfChildNodes
+    }
+
+    @BeforeEach
+    fun serializeProject() {
+        val bufferedReader = File("src/test/resources/test_attributeDescriptors.cc.json").bufferedReader()
+        attributeDescriptorsProject = ProjectDeserializer.deserializeProject(bufferedReader)
+    }
+
+    @Test
+    fun `should rename all occurrences of mcc in the projects nodes when the project contains this metric`() {
+        val bufferedReader = File("src/test/resources/sample_project.cc.json").bufferedReader()
+        val sampleProject = ProjectDeserializer.deserializeProject(bufferedReader)
+
+        val result = MetricRenamer(sampleProject).rename()
+
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "mcc")).isFalse()
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "complexity")).isTrue()
+    }
+
+    @Test
+    fun `should rename all occurrences of mcc in the attributeDescriptors and attributeTypes when it is present`() {
+        val result = MetricRenamer(attributeDescriptorsProject).rename()
+
+        val attributeTypeNodes = result.attributeTypes["nodes"]!!
+        Assertions.assertThat(attributeTypeNodes.containsKey("mcc")).isFalse()
+        Assertions.assertThat(attributeTypeNodes.containsKey("complexity")).isTrue()
+
+        Assertions.assertThat(result.attributeDescriptors.containsKey("mcc")).isFalse()
+        Assertions.assertThat(result.attributeDescriptors.containsKey("complexity")).isTrue()
+    }
+
+
+    @Test
+    fun `should not rename other metrics that contain mcc as part of their name`() {
+        val result = MetricRenamer(attributeDescriptorsProject).rename()
+
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "mcc")).isFalse()
+        Assertions.assertThat(doesAttributeExistInNode(result.rootNode.toMutableNode(), "ymcc")).isTrue()
+
+        val attributeTypeNodes = result.attributeTypes["nodes"]!!
+        Assertions.assertThat(attributeTypeNodes.containsKey("mcc")).isFalse()
+        Assertions.assertThat(attributeTypeNodes.containsKey("ymcc")).isTrue()
+
+        Assertions.assertThat(result.attributeDescriptors.containsKey("mcc")).isFalse()
+        Assertions.assertThat(result.attributeDescriptors.containsKey("ymcc")).isTrue()
+    }
+
+    @Test   //TODO: revisit
+    fun `should do something if the input file did not contain mcc metric`() {
+        Assertions.assertThat(true).isFalse()
+    }
+
+}

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/NodeRemoverTest.kt
@@ -13,7 +13,7 @@ class NodeRemoverTest {
     private lateinit var sampleProject: Project
 
     companion object {
-        private const val DESCRIPTOR_TEST_PATH = "test_attributeDescriptors.json"
+        private const val DESCRIPTOR_TEST_PATH = "test_attributeDescriptors.cc.json"
     }
 
     @BeforeEach

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
@@ -129,7 +129,7 @@ class StructureModifierTest {
         val cliResult =
             executeForOutput(
                 "",
-                arrayOf("src/test/resources/test_attributeDescriptors.json", "-s=/root/AnotherParentLeaf")
+                arrayOf("src/test/resources/test_attributeDescriptors.cc.json", "-s=/root/AnotherParentLeaf")
             )
         val resultProject = ProjectDeserializer.deserializeProject(cliResult)
 
@@ -144,7 +144,7 @@ class StructureModifierTest {
         val cliResult =
             executeForOutput(
                 "",
-                arrayOf("src/test/resources/test_attributeDescriptors.json", "-r=/root/AnotherParentLeaf")
+                arrayOf("src/test/resources/test_attributeDescriptors.cc.json", "-r=/root/AnotherParentLeaf")
             )
         val resultProject = ProjectDeserializer.deserializeProject(cliResult)
 

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/StructureModifierTest.kt
@@ -27,8 +27,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should read project when prodided with input file`() {
-// when
+    fun `should read project when provided with input file`() {
+        // when
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-r=/does/not/exist"))
 
         // then
@@ -36,7 +36,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should read project when receiving piped input`() { // given
+    fun `should read project when receiving piped input`() {
+        // given
         val inputFilePath = "src/test/resources/sample_project.cc.json"
         val input =
             File(inputFilePath).bufferedReader().readLines().joinToString(separator = "") {
@@ -51,7 +52,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should not produce output when provided with invalid project file`() { // given
+    fun `should not produce output when provided with invalid project file`() {
+        // given
         System.setErr(PrintStream(errContent))
 
         // when
@@ -65,7 +67,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should return error when given malformed piped input`() { // given
+    fun `should return error when given malformed piped input`() {
+        // given
         val input = "{this: 12}"
         System.setErr(PrintStream(errContent))
 
@@ -80,8 +83,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should set the  root for new subproject when provided with new root`() {
-// when
+    fun `should set the root for new subproject when provided with new root`() {
+        // when
         val cliResult =
             executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-s=/root/src/folder3"))
 
@@ -92,7 +95,7 @@ class StructureModifierTest {
 
     @Test
     fun `should remove single node when given single folder to remove`() {
-// when
+        // when
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-r=/root/src"))
 
         // then
@@ -102,7 +105,7 @@ class StructureModifierTest {
 
     @Test
     fun `should move nodes when move-from flag is specified`() {
-// when
+        // when
         val cliResult =
             executeForOutput(
                 "",
@@ -116,7 +119,7 @@ class StructureModifierTest {
 
     @Test
     fun `should print structure accordingly when print-level is set`() {
-// when
+        // when
         val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "-p=2"))
 
         // then
@@ -125,7 +128,7 @@ class StructureModifierTest {
 
     @Test
     fun `should set root and remove unused descriptors when root specified`() {
-// when
+        // when
         val cliResult =
             executeForOutput(
                 "",
@@ -140,7 +143,7 @@ class StructureModifierTest {
 
     @Test
     fun `should remove nodes and unused descriptors when provided with an input file containing unused descriptors`() {
-// when
+        // when
         val cliResult =
             executeForOutput(
                 "",
@@ -154,7 +157,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should stop execution when input file is invalid`() { // given
+    fun `should stop execution when input file is invalid`() {
+        // given
         mockkObject(InputHelper)
         every {
             InputHelper.isInputValid(any(), any())
@@ -172,7 +176,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should remove all specified nodes when multiple values are provided for the remove flag`() { // given
+    fun `should remove all specified nodes when multiple values are provided for the remove flag`() {
+        // given
         val file1 = "/root/src/main/file1.java"
         val file2 = "/root/src/main/file2.java"
         val nodesToRemove = listOf(file1, file2)
@@ -187,7 +192,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should log warning when more than one action is specified`() { // given
+    fun `should log warning when more than one action is specified`() {
+        // given
         val file1 = "/root/src/main/file1.java"
         val file2 = "/root/src/main/file2.java"
         val nodesToRemove = listOf(file1, file2)
@@ -213,7 +219,8 @@ class StructureModifierTest {
     }
 
     @Test
-    fun `should log error when move-from but not move-to is specified`() { // given
+    fun `should log error when move-from but not move-to is specified`() {
+        // given
         val folderToMove = "/root/src/main"
 
         val lambdaSlot = mutableListOf<() -> String>()
@@ -228,5 +235,41 @@ class StructureModifierTest {
 
         // then
         assertThat(lambdaSlot.last()().isNotEmpty()).isTrue()
+    }
+
+    @Test
+    fun `should rename mcc to complexity when rename flag is specified`() {
+        //when
+        val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "--rename-mcc"))
+
+        //then
+        assertThat(cliResult).doesNotContain("mcc")
+        assertThat(cliResult).contains("complexity")
+        assertThat(cliResult).doesNotContain("sonar_complexity")
+    }
+
+    @Test
+    fun `should rename mcc to sonar_complexity when rename flag is specified with sonar option`() {
+        //when
+        val cliResult = executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "--rename-mcc=sonar"))
+
+        //then
+        assertThat(cliResult).doesNotContain("mcc")
+        assertThat(cliResult).contains("sonar_complexity")
+    }
+
+    @Test
+    fun `should throw Exception when rename flag is specified with an invalid option`() {
+        // given
+        System.setErr(PrintStream(errContent))
+
+        // when
+        executeForOutput("", arrayOf("src/test/resources/sample_project.cc.json", "--rename-mcc=invalid"))
+
+        // then
+        assertThat(errContent.toString()).contains("Invalid value for rename flag, stopping execution...")
+
+        // clean up
+        System.setErr(originalErr)
     }
 }

--- a/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
+++ b/analysis/filter/StructureModifier/src/test/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/SubProjectExtractorTest.kt
@@ -84,7 +84,7 @@ class SubProjectExtractorTest {
 
     @Test
     fun `Subproject should contain a subset of attributeDescriptors when extracted`() {
-        val path = "test_attributeDescriptors.json"
+        val path = "test_attributeDescriptors.cc.json"
         val input = InputStreamReader(this.javaClass.classLoader.getResourceAsStream(path)!!)
         val attributeProject = ProjectDeserializer.deserializeProject(input)
         val resultProject = SubProjectExtractor(attributeProject).extract("/root/AnotherParentLeaf")

--- a/analysis/filter/StructureModifier/src/test/resources/sample_project.cc.json
+++ b/analysis/filter/StructureModifier/src/test/resources/sample_project.cc.json
@@ -18,14 +18,16 @@
                   "name": "file1.java",
                   "type": "File",
                   "attributes": {
-                    "nloc": 80.0
+                    "nloc": 80.0,
+                    "mcc": 1
                   }
                 },
                 {
                   "name": "file2.java",
                   "type": "File",
                   "attributes": {
-                    "nloc": 80.0
+                    "nloc": 80.0,
+                    "mcc": 2
                   }
                 }
               ]
@@ -38,7 +40,8 @@
                   "name": "otherFile.java",
                   "type": "File",
                   "attributes": {
-                    "nloc": 80.0
+                    "nloc": 80.0,
+                    "mcc": 3
                   }
                 }
               ]
@@ -51,7 +54,8 @@
                   "name": "otherFile2.java",
                   "type": "File",
                   "attributes": {
-                    "nloc": 80.0
+                    "nloc": 80.0,
+                    "mcc": 80.0
                   }
                 }
               ]

--- a/analysis/filter/StructureModifier/src/test/resources/test_attributeDescriptors.cc.json
+++ b/analysis/filter/StructureModifier/src/test/resources/test_attributeDescriptors.cc.json
@@ -98,7 +98,8 @@
         "rloc": "absolute",
         "functions": "absolute",
         "mcc": "absolute",
-        "pairingRate": "relative"
+        "pairingRate": "relative",
+        "ymcc": "absolute"
       }
     },
     "attributeDescriptors": {


### PR DESCRIPTION
# Add mcc rename option to StructureModifier

Issue: #3685

## Description

Adds an option to rename the outdated 'mcc' metric to either 'complexity' or 'sonar_complexity' to the StructureModifier.
This does not yet close the connected issue as it also includes more todo for the visualisation

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
