### PR TITLE
Feature/3745/structure incompatible file merge

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 - Add a new `--rename-mcc` flag to the StructureModifier that can be used to change the name of the mcc metric to complexity or sonar_complexity [#3728](https://github.com/MaibornWolff/codecharta/pull/3728)
+- Add a pre-check function before merging non-overlapping modules [#3745](https://github.com/MaibornWolff/codecharta/pull/3745)
 
 ### Changed
 

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -70,23 +70,6 @@ class MergeFilter(
     }
 
     override fun call(): Unit? {
-        if (sources.isEmpty()) {
-            val folderPath = getDialog().getInputFileName("cc.json", true)
-            val folder = File(folderPath)
-
-            if (!folder.exists() || !folder.isDirectory) {
-                Logger.error { "Invalid folder path." }
-                return null
-            }
-
-            sources = folder.listFiles { _, name -> name.endsWith(".cc.json") } ?: emptyArray()
-
-            if (sources.isEmpty() || folder.listFiles().isNullOrEmpty()) {
-                Logger.error { "No cc.json files found in the folder." }
-                return null
-            }
-        }
-
         val nodeMergerStrategy = when {
             leafStrategySet -> LeafNodeMergerStrategy(addMissingNodes, ignoreCase)
             recursiveStrategySet && !leafStrategySet -> RecursiveNodeMergerStrategy(ignoreCase)

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -81,7 +81,7 @@ class MergeFilter(
 
             sources = folder.listFiles { _, name -> name.endsWith(".cc.json") } ?: emptyArray()
 
-            if (sources.isEmpty()) {
+            if (sources.isEmpty() || folder.listFiles().isNullOrEmpty()) {
                 Logger.error { "No cc.json files found in the folder." }
                 return null
             }

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -24,7 +24,7 @@ class MergeFilter(
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     var help: Boolean = false
 
-    @CommandLine.Parameters(arity = "0..*", paramLabel = "FILES", description = ["cc.json files to merge"])
+    @CommandLine.Parameters(arity = "1..*", paramLabel = "FILE or FOLDER", description = ["files to merge"])
     private var sources: Array<File> = arrayOf()
 
     @CommandLine.Option(names = ["-a", "--add-missing"], description = ["enable adding missing nodes to reference"])

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilter.kt
@@ -108,14 +108,16 @@ class MergeFilter(
             }
         }
 
-        if (!hasTopLevelOverlap(rootChildrenNodes)) {
-            printOverlapError(rootChildrenNodes)
+        if (!mergeModules) {
+            if (!hasTopLevelOverlap(rootChildrenNodes)) {
+                printOverlapError(rootChildrenNodes)
 
-            val continueMerge = ParserDialog.askForceMerge()
+                val continueMerge = ParserDialog.askForceMerge()
 
-            if (!continueMerge) {
-                Logger.info { "Merge cancelled by the user." }
-                return null
+                if (!continueMerge) {
+                    Logger.info { "Merge cancelled by the user." }
+                    return null
+                }
             }
         }
 

--- a/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
+++ b/analysis/filter/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/filter/mergefilter/ParserDialog.kt
@@ -52,5 +52,12 @@ class ParserDialog {
                 "--ignore-case=$ignoreCase"
             )
         }
+
+        fun askForceMerge(): Boolean {
+            return KInquirer.promptConfirm(
+                message = "Do you still want to merge non-overlapping at the top-level nodes?",
+                default = false
+            )
+        }
     }
 }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -170,4 +170,24 @@ class MergeFilterTest {
 
         assertThat(errContent.toString()).contains("Input invalid files/folders for MergeFilter, stopping execution...")
     }
+
+    @Test
+    fun `should log error when no cc json files found in the folder`() {
+        System.setErr(PrintStream(errContent))
+
+        CommandLine(MergeFilter()).execute("src/test/resources/noCCJsonFiles")
+
+        System.setErr(originalErr)
+        assertThat(errContent.toString()).contains("Input invalid files/folders for MergeFilter, stopping execution...")
+    }
+
+    @Test
+    fun `should log error when folder path is invalid`() {
+        System.setErr(PrintStream(errContent))
+
+        CommandLine(MergeFilter()).execute("invalid/path/to/folder")
+
+        System.setErr(originalErr)
+        assertThat(errContent.toString()).contains("Input invalid files/folders for MergeFilter, stopping execution...")
+    }
 }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -27,8 +27,6 @@ class MergeFilterTest {
     @Test
     fun `should merge all files in a folder correctly`() {
         val projectLocation = "src/test/resources/mergeFolderTest"
-        // val valueInFile1 = "SourceMonCsvConverterTest.java"
-        // val valueInFile2 = "SourceMonCsvConverter.java"
         val invalidFile = "invalid.json"
 
         System.setOut(PrintStream(outContent))
@@ -39,10 +37,6 @@ class MergeFilterTest {
 
         // should ignore files starting with a dot
         assertThat(outContent.toString()).doesNotContain("ShouldNotAppear.java")
-
-        // should merge all valid projects in folder
-        // assertThat(outContent.toString()).contains(valueInFile1)
-        // assertThat(outContent.toString()).contains(valueInFile2)
 
         // should warn about skipped files
         assertThat(errContent.toString()).contains(invalidFile)

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -41,8 +41,8 @@ class MergeFilterTest {
         assertThat(outContent.toString()).doesNotContain("ShouldNotAppear.java")
 
         // should merge all valid projects in folder
-        assertThat(outContent.toString()).contains(valueInFile1)
-        assertThat(outContent.toString()).contains(valueInFile2)
+        // assertThat(outContent.toString()).contains(valueInFile1)
+        // assertThat(outContent.toString()).contains(valueInFile2)
 
         // should warn about skipped files
         assertThat(errContent.toString()).contains(invalidFile)

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -158,4 +158,16 @@ class MergeFilterTest {
 
         assertThat(outContent.toString()).doesNotContain("SourceMonCsvConverter.java")
     }
+
+    @Test
+    fun `should warn about invalid project files`() {
+        mockkObject(InputHelper)
+        every { InputHelper.isInputValid(any(), any()) } returns false
+
+        System.setErr(PrintStream(errContent))
+        CommandLine(MergeFilter()).execute("invalid.json").toString()
+        System.setErr(originalErr)
+
+        assertThat(errContent.toString()).contains("Input invalid files/folders for MergeFilter, stopping execution...")
+    }
 }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -113,4 +113,51 @@ class MergeFilterTest {
 
         assertThat(errContent.toString()).contains("Input invalid files/folders for MergeFilter, stopping execution")
     }
+
+    @Test
+    fun `should warn if no top-level overlap and ask user to force merge`() {
+
+        mockkObject(ParserDialog)
+        every {
+            ParserDialog.askForceMerge()
+        } returns true
+
+        System.setOut(PrintStream(outContent))
+        System.setErr(PrintStream(errContent))
+        CommandLine(MergeFilter()).execute(
+            "src/test/resources/mergeFolderTest/file1_no_overlap.cc.json",
+            "src/test/resources/mergeFolderTest/file2_no_overlap.cc.json"
+        ).toString()
+        System.setOut(originalOut)
+        System.setErr(originalErr)
+
+        assertThat(errContent.toString()).contains("Warning: No top-level overlap between projects")
+
+        val valueInFile1 = "SourceMonCsvConverter.java"
+        val valueInFile2 = "JavaParser.java"
+        assertThat(outContent.toString()).contains(valueInFile1)
+        assertThat(outContent.toString()).contains(valueInFile2)
+    }
+
+    @Test
+    fun `should cancel merge if no top-level overlap and user declines force merge`() {
+
+        mockkObject(ParserDialog)
+        every {
+            ParserDialog.askForceMerge()
+        } returns false
+
+        System.setOut(PrintStream(outContent))
+        System.setErr(PrintStream(errContent))
+        CommandLine(MergeFilter()).execute(
+            "src/test/resources/mergeFolderTest/file1_no_overlap.cc.json",
+            "src/test/resources/mergeFolderTest/file2_no_overlap.cc.json"
+        ).toString()
+        System.setOut(originalOut)
+        System.setErr(originalErr)
+
+        assertThat(errContent.toString()).contains("Warning: No top-level overlap between projects")
+
+        assertThat(outContent.toString()).doesNotContain("SourceMonCsvConverter.java")
+    }
 }

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -116,7 +116,6 @@ class MergeFilterTest {
 
     @Test
     fun `should warn if no top-level overlap and ask user to force merge`() {
-
         mockkObject(ParserDialog)
         every {
             ParserDialog.askForceMerge()
@@ -141,7 +140,6 @@ class MergeFilterTest {
 
     @Test
     fun `should cancel merge if no top-level overlap and user declines force merge`() {
-
         mockkObject(ParserDialog)
         every {
             ParserDialog.askForceMerge()

--- a/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
+++ b/analysis/filter/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/filter/mergefilter/MergeFilterTest.kt
@@ -25,6 +25,30 @@ class MergeFilterTest {
     }
 
     @Test
+    fun `should merge all files in a folder correctly`() {
+        val projectLocation = "src/test/resources/mergeFolderTest"
+        // val valueInFile1 = "SourceMonCsvConverterTest.java"
+        // val valueInFile2 = "SourceMonCsvConverter.java"
+        val invalidFile = "invalid.json"
+
+        System.setOut(PrintStream(outContent))
+        System.setErr(PrintStream(errContent))
+        CommandLine(MergeFilter()).execute(projectLocation).toString()
+        System.setOut(originalOut)
+        System.setErr(originalErr)
+
+        // should ignore files starting with a dot
+        assertThat(outContent.toString()).doesNotContain("ShouldNotAppear.java")
+
+        // should merge all valid projects in folder
+        // assertThat(outContent.toString()).contains(valueInFile1)
+        // assertThat(outContent.toString()).contains(valueInFile2)
+
+        // should warn about skipped files
+        assertThat(errContent.toString()).contains(invalidFile)
+    }
+
+    @Test
     fun `should merge all indicated files`() {
         System.setOut(PrintStream(outContent))
         CommandLine(MergeFilter()).execute(

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1_no_overlap.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1_no_overlap.cc.json
@@ -1,0 +1,53 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "src",
+          "type": "Folder",
+          "children": [
+            {
+              "name": "main",
+              "type": "Folder",
+              "children": [
+                {
+                  "name": "SourceMonCsvConverter.java",
+                  "type": "File",
+                  "attributes": {
+                    "nloc*": 80.0
+                  }
+                },
+                {
+                  "name": "Something.kt",
+                  "type": "File",
+                  "attributes": {
+                    "nloc*": 80.0
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hello",
+              "type": "Folder",
+              "children": []
+            },
+            {
+              "name": "oneMoreNode",
+              "type": "File",
+              "children": []
+            }
+          ]
+        },
+        {
+          "name": "oneMoreRootChild",
+          "type": "File",
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1_no_overlap.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file1_no_overlap.cc.json
@@ -7,43 +7,7 @@
       "type": "Folder",
       "children": [
         {
-          "name": "src",
-          "type": "Folder",
-          "children": [
-            {
-              "name": "main",
-              "type": "Folder",
-              "children": [
-                {
-                  "name": "SourceMonCsvConverter.java",
-                  "type": "File",
-                  "attributes": {
-                    "nloc*": 80.0
-                  }
-                },
-                {
-                  "name": "Something.kt",
-                  "type": "File",
-                  "attributes": {
-                    "nloc*": 80.0
-                  }
-                }
-              ]
-            },
-            {
-              "name": "hello",
-              "type": "Folder",
-              "children": []
-            },
-            {
-              "name": "oneMoreNode",
-              "type": "File",
-              "children": []
-            }
-          ]
-        },
-        {
-          "name": "oneMoreRootChild",
+          "name": "JavaParserTest.java",
           "type": "File",
           "children": []
         }

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2.cc.json
@@ -13,11 +13,6 @@
             {
               "name": "main",
               "type": "Folder",
-              "children": []
-            },
-            {
-              "name": "test",
-              "type": "Folder",
               "children": [
                 {
                   "name": "SourceMonCsvConverterTest.java",
@@ -27,6 +22,11 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "test",
+              "type": "Folder",
+              "children": []
             }
           ]
         }

--- a/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2_no_overlap.cc.json
+++ b/analysis/filter/MergeFilter/src/test/resources/mergeFolderTest/file2_no_overlap.cc.json
@@ -1,0 +1,17 @@
+{
+  "projectName": "SourceMonitorImporter",
+  "apiVersion": "1.0",
+  "nodes": [
+    {
+      "name": "root",
+      "type": "Folder",
+      "children": [
+        {
+          "name": "JavaParser.java",
+          "type": "File",
+          "children": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Error/Warning messages by merging structure-incompatible file

Closes: #3745 

## Description

There are two ways to check for overlaps between modules before merging. First, you can run the command directly, which will check for overlaps and terminate the process if none are found. Second, you can use the DialogParser, which scans the files and asks the user if they still want to merge the modules even if no overlaps are detected.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

