### PR TITLE
tech/github-runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
 
     - name: Test and Linter
       env:
-        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium-browser"
+        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chrome"
       run: |
         npm run build
         npm run e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
 
     - name: Test and Linter
       env:
-        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chrome"
+        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome"
       run: |
         npm run build
         npm run e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
 
     - name: Test and Linter
       env:
-        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium"
+        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium-browser"
       run: |
         npm run build
         npm run e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
 
     - name: Test and Linter
       env:
-        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome"
+        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/chromium"
       run: |
         npm run build
         npm run e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Test and Linter
+      env:
+        PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome"
       run: |
         npm run build
         npm run e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,15 @@ jobs:
       with:
         node-version: '20'
 
+    - name: Debug Info
+      run: |
+        uname -a
+        lsb_release -a
+        node -v
+        npm -v
+        google-chrome --version
+        dpkg -l
+
     - name: Cache node modules
       uses: actions/cache@v4
       env:
@@ -122,15 +131,6 @@ jobs:
         npm run build
         npm run e2e:ci
       working-directory: ${{env.working-directory}}
-
-    - name: Debug Info
-      run: |
-        uname -a
-        lsb_release -a
-        node -v
-        npm -v
-        google-chrome --version
-        dpkg -l
 
  test_and_sonar_analysis:
     name: "Build, Test and Publish Analysis Sonar Results"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,15 +101,6 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Debug Info
-      run: |
-        uname -a
-        lsb_release -a
-        node -v
-        npm -v
-        google-chrome --version
-        dpkg -l
-
     - name: Cache node modules
       uses: actions/cache@v4
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,14 @@ jobs:
         npm run e2e:ci
       working-directory: ${{env.working-directory}}
 
+    - name: Debug Info
+      run: |
+        uname -a
+        lsb_release -a
+        node -v
+        npm -v
+        google-chrome --version
+        dpkg -l
 
  test_and_sonar_analysis:
     name: "Build, Test and Publish Analysis Sonar Results"


### PR DESCRIPTION
# Fix Github Runner
## Description
- The e2e Tests failed due to the error: 
`Error: Jest: Got error running globalSetup - /home/runner/work/codecharta/codecharta/visualization/node_modules/jest-environment-puppeteer/setup.js, reason: Failed to launch the browser process!
[1015/074210.016703:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.`
- Added PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome"

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
