### PR TITLE
Extend maximal camera angle to be plane with the map

### DIFF
--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeMapControls.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeMapControls.service.ts
@@ -134,7 +134,7 @@ export class ThreeMapControlsService {
         })
 
         this.controls.minPolarAngle = 0
-        this.controls.maxPolarAngle = Math.PI / 3
+        this.controls.maxPolarAngle = Math.PI / 2
         this.controls.listenToKeyEvents(window)
         this.controls.addEventListener("change", () => {
             this.onInput(this.threeCameraService.camera)


### PR DESCRIPTION
## changes maximal camera angle 


Issue: #3730

## Description

Changes maximal polar camera angle to be PI/2 instead of PI/3. This allows the camera to be positioned via mouse movement (native three.js controls) in one plane with the map. This was previously only possible via the ViewCube.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] ~~CHANGELOG.md has been updated~~ (no changelog for unreleased features)

## Screenshots or gifs
