### PR TITLE
Tech/Fix web demo file creation script

### DIFF
--- a/script/build_demo_file_analysis.sh
+++ b/script/build_demo_file_analysis.sh
@@ -3,11 +3,12 @@
 analysis/gradlew -p analysis/ installDist
 
 mkdir gh-pages/demo_files
+
+git ls-files > gh-pages/demo_files/file-name-list.txt
+git log --numstat --raw --topo-order --reverse -m > gh-pages/demo_files/git.log
+
 cd gh-pages/demo_files || exit
 CCSH=../../analysis/build/install/codecharta-analysis/bin/ccsh
-
-git log --numstat --raw --topo-order --reverse -m > git.log
-git ls-files > file-name-list.txt
 
 # Data for for both visualization and analysis
 $CCSH gitlogparser log-scan --git-log git.log --repo-files file-name-list.txt -o codecharta_git.cc.json -nc

--- a/script/build_demo_file_visualization.sh
+++ b/script/build_demo_file_visualization.sh
@@ -8,11 +8,12 @@ cp -R visualization/dist/webpack/ gh-pages/visualization/app/
 analysis/gradlew -p analysis/ installDist
 
 mkdir gh-pages/demo_files
+
+git ls-files > gh-pages/demo_files/file-name-list.txt
+git log --numstat --raw --topo-order --reverse -m > gh-pages/demo_files/git.log
+
 cd gh-pages/demo_files || exit
 CCSH=../../analysis/build/install/codecharta-analysis/bin/ccsh
-
-git log --numstat --raw --topo-order --reverse -m > git.log
-git ls-files > file-name-list.txt
 
 # Data for for both visualization and analysis
 $CCSH gitlogparser log-scan --git-log git.log --repo-files file-name-list.txt -o codecharta_git.cc.json -nc

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+- Fix an issue which caused the web demo files to be incomplete [#3790](https://github.com/MaibornWolff/codecharta/pull/3758)
+
 ## [1.129.0] - 2024-10-17
 
 ### Added 🚀


### PR DESCRIPTION
### Fix for the demo file creation problems during the last release 1.129.0

The git ls-files call did not create a list of files as it's supposed to, because it looked for files relative to the current shell position, unlike git log which looks for the project root. Executing the ls-files call in the project root fixes the succeeding gitlogparser call and such, the problems of the script occurring because it encountered an empty project file.

## Description

Moves the git calls in such a way, that they are executed at the project root, fixing the empty project issues.

> I ran both scripts locally and both created their respektive project files as expected (but now again with gitlogparser content included)