### PR TITLE
Old mcc maps can be migrated to new metric names #3685

### DIFF
--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
@@ -59,7 +59,7 @@ class MetricRenamer(
     ): Map<String, MutableMap<String, AttributeType>> {
         val nodeAttributes = attributeTypes["nodes"] ?: return attributeTypes
 
-        if(nodeAttributes.containsKey("mcc")) {
+        if (nodeAttributes.containsKey("mcc")) {
             val mccType = nodeAttributes.remove("mcc")
                 ?: throw NullPointerException(
                     "Input file contains null value for an attribute type! Please ensure the input is a valid cc.json file."

--- a/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
+++ b/analysis/filter/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/filter/structuremodifier/MetricRenamer.kt
@@ -37,11 +37,9 @@ class MetricRenamer(
             val updatedAttributes = node.attributes.toMutableMap()
 
             val mccValue = updatedAttributes.remove("mcc")
-            if (mccValue == null) {
-                throw NullPointerException(
+                ?: throw NullPointerException(
                     "Input file contains null value for a node attribute! Please ensure the input is a valid cc.json file."
                 )
-            }
             updatedAttributes[newName] = mccValue
 
             node.attributes = updatedAttributes
@@ -61,13 +59,13 @@ class MetricRenamer(
     ): Map<String, MutableMap<String, AttributeType>> {
         val nodeAttributes = attributeTypes["nodes"] ?: return attributeTypes
 
-        val mccType = nodeAttributes.remove("mcc")
-        if (mccType == null) {
-            throw NullPointerException(
-                "Input file contains null value for an attribute type! Please ensure the input is a valid cc.json file."
-            )
+        if(nodeAttributes.containsKey("mcc")) {
+            val mccType = nodeAttributes.remove("mcc")
+                ?: throw NullPointerException(
+                    "Input file contains null value for an attribute type! Please ensure the input is a valid cc.json file."
+                )
+            nodeAttributes[newName] = mccType
         }
-        nodeAttributes[newName] = mccType
 
         return attributeTypes
     }
@@ -77,12 +75,10 @@ class MetricRenamer(
 
         val updatedAttributeDescriptors = attributeDescriptors.toMutableMap()
         val mccDescriptor = updatedAttributeDescriptors.remove("mcc")
-
-        if (mccDescriptor == null) {
-            throw NullPointerException(
+            ?: throw NullPointerException(
                 "Input file contains null value for an attribute descriptor! Please ensure the input is a valid cc.json file."
             )
-        }
+
         updatedAttributeDescriptors[newName] = mccDescriptor
         return updatedAttributeDescriptors
     }

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Add experimental feature: show buildings with an area metric value of 0 [#3789](https://github.com/MaibornWolff/codecharta/pull/3789)
 - Add further functionality for nested data to show popup when comparing files with different complexity metrics [#3791](https://github.com/MaibornWolff/codecharta/pull/3791)
+- Add improvements to the migration script for old mcc maps [#3803](https://github.com/MaibornWolff/codecharta/pull/3803)
 
 ### Changed
 


### PR DESCRIPTION
# Old mcc maps can be migrated to new metric names
Closes: #3685 

## Description
- Add additional check for mcc metric before removing it

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated
