### PR TITLE
Tech: enable security updates through renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:recommended", ":preserveSemverRanges"],
+  "vulnerabilityAlerts": {
+    "labels": ["security", "dependencies"],
+    "automerge": true
+  },
   "packageRules": [
     {
       "description": "Automerge non-major updates",


### PR DESCRIPTION
## Tech: Enable Renovate for security dependabot alerts.

Updated the name of the base rule set to recommended.

This PR adds to the Renovate config, so that is able to create security updates based on dependabot alerts.

I already disabled dependabot PR creation in the repo settings, but I might also need to delete a custom rule (which might enable it to continue to work on a subset of updates). 

> I can't verify that Renovate has the correct access for this to work. Only the owner of the organization is able to change those settings. As far as I can tell, the settings look correct.
