### PR TITLE
Documentation/Tech: 3756/release script on windows

### DIFF
--- a/DEV_START_GUIDE.md
+++ b/DEV_START_GUIDE.md
@@ -15,7 +15,7 @@ All major decisions are documented in our [architecture decision records (ADR)](
 
 To work on CodeCharta, please ensure your system includes:
 
-- Git
+- Git (with bash utilities for Windows)
 - Java >= 11, <= 21
 - Node >= 20
 

--- a/VERSION_BUMPING.md
+++ b/VERSION_BUMPING.md
@@ -17,7 +17,7 @@ For the Visualization release, the project must be built, so it is advisable to 
 ## Start the automatic release process
 
 - Call `pipenv run make_release`.
-- On Windows it is recommended to run the command in `cmd.exe` rather than in a git bash.
+- **On Windows**: Make sure that the git bash utilities are on your path variable if you are using the `cmd`. Alternatively, you can use the git `bash` directly.
 - Check the release process on GitHub after the script is completed
 
 > You can add `-f` or `--force` to disable the protections of the script. You can't release in force mode.

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -57,6 +57,8 @@ $ codecharta-visualization
 
 > To clone and run this application, you'll need [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (version >=20) installed
 
+> (Windows) For some tasks the Git bash utilities are required
+
 ```bash
 # Clone the CodeCharta repo
 $ git clone https://github.com/MaibornWolff/codecharta.git


### PR DESCRIPTION
## Documentation/Tech: Add section about the required git bash utilities under windows

This adds small sections to the dev_start_guide, visualization/readme and versionbumping to ensure that developers can install the required dependencies to contribute/release codecharta.

Closes: #3756

