### PR TITLE
Bug/3848/gitlog with authors

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- Fix loading cc.json files that contain the 'authors' attribute [#3848](https://github.com/MaibornWolff/codecharta/pull/3897)
 - Fix applying Custom Views [#3898](https://github.com/MaibornWolff/codecharta/pull/3898)
 - The camera is now only reset when the area or the height of the map is changed [#3896](https://github.com/MaibornWolff/codecharta/pull/3896)
 

--- a/visualization/app/codeCharta/services/loadFile/fileParser.ts
+++ b/visualization/app/codeCharta/services/loadFile/fileParser.ts
@@ -2,7 +2,12 @@ import { ExportBlacklistItem, ExportCCFile } from "../../codeCharta.api.model"
 import { CCFile, NameDataPair } from "../../codeCharta.model"
 import { FileSelectionState, FileState } from "../../model/files/files"
 import { getCCFile } from "../../util/fileHelper"
-import { CCFileValidationResult as FileValidationResult, checkErrors, checkWarnings } from "../../util/fileValidator"
+import {
+    CCFileValidationResult as FileValidationResult,
+    checkErrors,
+    checkWarnings,
+    removeAuthorsAttributes
+} from "../../util/fileValidator"
 import { NodeDecorator } from "../../util/nodeDecorator"
 
 export function getNameDataPair(ccFile: CCFile): NameDataPair {
@@ -48,10 +53,13 @@ export function enrichFileStatesAndRecentFilesWithValidationResults(
             errors: [],
             warnings: []
         }
+        fileValidationResult.warnings.push(...removeAuthorsAttributes(nameDataPair?.content)) //Needs to be done before schema validation
+
         fileValidationResult.errors.push(...checkErrors(nameDataPair?.content))
 
         if (fileValidationResult.errors.length === 0) {
             fileValidationResult.warnings.push(...checkWarnings(nameDataPair?.content))
+
             addFile(fileStates, recentFiles, nameDataPair, currentFilesAreSampleFilesCallback, setCurrentFilesAreNotSampleFilesCallback)
         }
 

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -753,6 +753,84 @@ export const VALID_NODE_DECORATED: CodeMapNode = {
     ]
 }
 
+export const GIT_LOG_NODE_WITH_AUTHORS = {
+    name: "root",
+    type: NodeType.FOLDER,
+    attributes: {},
+    children: [
+        {
+            name: ".gitignore",
+            type: NodeType.FILE,
+            attributes: {
+                number_of_authors: 1,
+                number_of_commits: 2,
+                range_of_weeks_with_commits: 1,
+                weeks_with_commits: 1,
+                highly_coupled_files: 0,
+                median_coupled_files: 72.0,
+                number_of_renames: 0,
+                age_in_weeks: 11,
+                authors: ["TestAuthor1", "TestAuthor2"]
+            },
+            children: []
+        },
+        {
+            name: "tabs.tsx",
+            type: NodeType.FILE,
+            attributes: {
+                number_of_authors: 1,
+                number_of_commits: 1,
+                range_of_weeks_with_commits: 1,
+                weeks_with_commits: 1,
+                highly_coupled_files: 0,
+                median_coupled_files: 30.0,
+                number_of_renames: 0,
+                age_in_weeks: 11,
+                authors: ["TestAuthor"]
+            },
+            children: []
+        }
+    ]
+}
+
+export const VALID_GIT_LOG_NODE_WITHOUT_AUTHORS: CodeMapNode = {
+    name: "root",
+    type: NodeType.FOLDER,
+    attributes: {},
+    children: [
+        {
+            name: ".gitignore",
+            type: NodeType.FILE,
+            attributes: {
+                number_of_authors: 1,
+                number_of_commits: 2,
+                range_of_weeks_with_commits: 1,
+                weeks_with_commits: 1,
+                highly_coupled_files: 0,
+                median_coupled_files: 72.0,
+                number_of_renames: 0,
+                age_in_weeks: 11
+            },
+            children: []
+        },
+        {
+            name: "tabs.tsx",
+            type: NodeType.FILE,
+            attributes: {
+                number_of_authors: 1,
+                number_of_commits: 1,
+                range_of_weeks_with_commits: 1,
+                weeks_with_commits: 1,
+                highly_coupled_files: 0,
+                median_coupled_files: 30.0,
+                number_of_renames: 0,
+                age_in_weeks: 11
+            },
+            children: []
+        }
+    ]
+}
+
 export const VALID_EDGES_DECORATED: Edge[] = [
     {
         fromNodeName: "/root/big leaf",
@@ -826,6 +904,20 @@ export const TEST_FILE_CONTENT_NO_API: ExportCCFile = {
     fileChecksum: "invalid-md5-sample",
     apiVersion: null,
     nodes: [VALID_NODE_WITH_MCC]
+}
+
+export const TEST_FILE_CONTENT_WITH_AUTHORS = {
+    projectName: "Valid GitLogParser Sample Map",
+    fileChecksum: "md5-git-log-parser-file",
+    apiVersion: APIVersions.ONE_POINT_THREE,
+    nodes: [GIT_LOG_NODE_WITH_AUTHORS]
+}
+
+export const TEST_FILE_CONTENT_WITHOUT_AUTHORS: ExportCCFile = {
+    projectName: "Valid GitLogParser Sample Map",
+    fileChecksum: "md5-git-log-parser-file",
+    apiVersion: APIVersions.ONE_POINT_THREE,
+    nodes: [VALID_GIT_LOG_NODE_WITHOUT_AUTHORS]
 }
 
 export const FILE_META: FileMeta = {


### PR DESCRIPTION
# CCjson from Gitlogparser with Authors cannot be imported

Closes: #3848 

## Description

Added a remove Authors function that removes all Authors Attributes.
For every removed Authors Attribute there is a warning created.
Removing the Authors is done before validating the cc.json, so the automatic creating of the "generatedSchema.json" can still be used.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
