### PR TITLE
Bug/3899/upload same map twice

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 - Fix loading cc.json files that contain the 'authors' attribute [#3848](https://github.com/MaibornWolff/codecharta/pull/3897)
 - Fix applying Custom Views [#3898](https://github.com/MaibornWolff/codecharta/pull/3898)
 - The camera is now only reset when the area or the height of the map is changed [#3896](https://github.com/MaibornWolff/codecharta/pull/3896)
+- Fix freezing app on uploading already loaded files [#3901](https://github.com/MaibornWolff/codecharta/pull/3901)
 
 ## [1.131.2] - 2024-12-04
 

--- a/visualization/app/codeCharta/services/loadFile/fileParser.ts
+++ b/visualization/app/codeCharta/services/loadFile/fileParser.ts
@@ -47,7 +47,7 @@ export function enrichFileStatesAndRecentFilesWithValidationResults(
     currentFilesAreSampleFilesCallback: () => boolean,
     setCurrentFilesAreNotSampleFilesCallback: () => void
 ): boolean {
-    let newFilesWereAdded = false
+    let hasAddedAtLeastOneFile = false
     for (const nameDataPair of nameDataPairs) {
         const fileValidationResult: FileValidationResult = {
             fileName: nameDataPair?.fileName,
@@ -60,15 +60,15 @@ export function enrichFileStatesAndRecentFilesWithValidationResults(
 
         if (fileValidationResult.errors.length === 0) {
             fileValidationResult.warnings.push(...checkWarnings(nameDataPair?.content))
-            const addedFile = addFile(
+            const hasAddedFile = addFile(
                 fileStates,
                 recentFiles,
                 nameDataPair,
                 currentFilesAreSampleFilesCallback,
                 setCurrentFilesAreNotSampleFilesCallback
             )
-            if (addedFile) {
-                newFilesWereAdded = true
+            if (hasAddedFile) {
+                hasAddedAtLeastOneFile = true
             }
         }
 
@@ -76,7 +76,7 @@ export function enrichFileStatesAndRecentFilesWithValidationResults(
             fileValidationResults.push(fileValidationResult)
         }
     }
-    return newFilesWereAdded
+    return hasAddedAtLeastOneFile
 }
 
 function addFile(

--- a/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
+++ b/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
@@ -15,6 +15,7 @@ import { Store, State } from "@ngrx/store"
 import { setCurrentFilesAreSampleFiles } from "../../state/store/appStatus/currentFilesAreSampleFiles/currentFilesAreSampleFiles.actions"
 
 export const NO_FILES_LOADED_ERROR_MESSAGE = "File(s) could not be loaded"
+export const FILES_ALREADY_LOADED_ERROR_MESSAGE = "File(s) are already loaded"
 
 @Injectable({ providedIn: "root" })
 export class LoadFileService implements OnDestroy {
@@ -46,7 +47,7 @@ export class LoadFileService implements OnDestroy {
         const recentFiles: string[] = []
         const fileValidationResults: CCFileValidationResult[] = []
 
-        enrichFileStatesAndRecentFilesWithValidationResults(
+        const newFilesWereAdded = enrichFileStatesAndRecentFilesWithValidationResults(
             fileStates,
             recentFiles,
             nameDataPairs,
@@ -71,5 +72,9 @@ export class LoadFileService implements OnDestroy {
         const rootName = this.state.getValue().files.find(f => f.file.fileMeta.fileName === recentFile).file.map.name
         this.store.dispatch(setStandardByNames({ fileNames: recentFiles }))
         fileRoot.updateRoot(rootName)
+
+        if (!newFilesWereAdded) {
+            throw new Error(FILES_ALREADY_LOADED_ERROR_MESSAGE)
+        }
     }
 }

--- a/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
+++ b/visualization/app/codeCharta/services/loadFile/loadFile.service.ts
@@ -47,7 +47,7 @@ export class LoadFileService implements OnDestroy {
         const recentFiles: string[] = []
         const fileValidationResults: CCFileValidationResult[] = []
 
-        const newFilesWereAdded = enrichFileStatesAndRecentFilesWithValidationResults(
+        const hasAddedAtLeastOneFile = enrichFileStatesAndRecentFilesWithValidationResults(
             fileStates,
             recentFiles,
             nameDataPairs,
@@ -73,7 +73,7 @@ export class LoadFileService implements OnDestroy {
         this.store.dispatch(setStandardByNames({ fileNames: recentFiles }))
         fileRoot.updateRoot(rootName)
 
-        if (!newFilesWereAdded) {
+        if (!hasAddedAtLeastOneFile) {
             throw new Error(FILES_ALREADY_LOADED_ERROR_MESSAGE)
         }
     }

--- a/visualization/app/codeCharta/ui/toolBar/uploadFilesButton/uploadFiles.service.spec.ts
+++ b/visualization/app/codeCharta/ui/toolBar/uploadFilesButton/uploadFiles.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from "@angular/core/testing"
+import { UploadFilesService } from "./uploadFiles.service"
+import { LoadFileService } from "../../../services/loadFile/loadFile.service"
+import { setIsLoadingFile } from "../../../state/store/appSettings/isLoadingFile/isLoadingFile.actions"
+import { setIsLoadingMap } from "../../../state/store/appSettings/isLoadingMap/isLoadingMap.actions"
+import { createCCFileInput } from "../../../util/uploadFiles/createCCFileInput"
+import { TEST_FILE_CONTENT } from "../../../util/dataMocks"
+import stringify from "safe-stable-stringify"
+import { EffectsModule } from "@ngrx/effects"
+import { Store, StoreModule } from "@ngrx/store"
+import { appReducers, setStateMiddleware } from "../../../state/store/state.manager"
+import { MatDialog } from "@angular/material/dialog"
+import { CcState } from "../../../codeCharta.model"
+import { RenderCodeMapEffect } from "../../../state/effects/renderCodeMapEffect/renderCodeMap.effect"
+import { setFiles, setStandardByNames } from "../../../state/store/files/files.actions"
+import { UnfocusNodesEffect } from "../../../state/effects/unfocusNodes/unfocusNodes.effect"
+
+jest.mock("../../../util/uploadFiles/createCCFileInput")
+
+describe("UploadFilesService", () => {
+    let loadFileService: LoadFileService
+    let uploadFilesService: UploadFilesService
+    let store: Store<CcState>
+    let dispatchSpy: jest.SpyInstance
+    let mockFileInput: HTMLInputElement
+
+    beforeEach(() => {
+        restartSystem()
+        rebuildServices()
+
+        dispatchSpy = jest.spyOn(store, "dispatch")
+
+        mockFileInput = {
+            files: [new File([stringify(TEST_FILE_CONTENT)], "test.cc.json", { type: "application/json" })],
+            click: jest.fn(),
+            addEventListener: jest.fn((event, callback) => {})
+        } as unknown as HTMLInputElement
+        ;(createCCFileInput as jest.Mock).mockReturnValue(mockFileInput)
+    })
+
+    afterEach(() => {
+        loadFileService.referenceFileSubscription.unsubscribe()
+    })
+
+    function restartSystem() {
+        TestBed.configureTestingModule({
+            imports: [
+                StoreModule.forRoot(appReducers, { metaReducers: [setStateMiddleware] }),
+                EffectsModule.forRoot([RenderCodeMapEffect, UnfocusNodesEffect])
+            ],
+            providers: [UploadFilesService, LoadFileService, MatDialog]
+        })
+        store = TestBed.inject(Store)
+    }
+
+    function rebuildServices() {
+        uploadFilesService = TestBed.inject(UploadFilesService)
+        loadFileService = TestBed.inject(LoadFileService)
+    }
+
+    it("should upload file", async () => {
+        uploadFilesService.uploadFiles()
+
+        expect(mockFileInput.click).toHaveBeenCalled()
+        await uploadFilesService["uploadFilesOnEvent"](mockFileInput)
+
+        expect(dispatchSpy).toHaveBeenCalledWith(setFiles({ value: [expect.anything()] }))
+        expect(dispatchSpy).toHaveBeenCalledWith(setStandardByNames({ fileNames: ["test.cc.json"] }))
+    })
+
+    it("should dispatch loading false if already loaded file is uploaded", async () => {
+        uploadFilesService.uploadFiles()
+
+        expect(mockFileInput.click).toHaveBeenCalled()
+        await uploadFilesService["uploadFilesOnEvent"](mockFileInput)
+        dispatchSpy.mockClear()
+
+        uploadFilesService.uploadFiles()
+
+        expect(mockFileInput.click).toHaveBeenCalled()
+        await uploadFilesService["uploadFilesOnEvent"](mockFileInput)
+
+        expect(dispatchSpy).toHaveBeenNthCalledWith(4, setStandardByNames({ fileNames: ["test.cc.json"] }))
+        expect(dispatchSpy).toHaveBeenNthCalledWith(5, setIsLoadingFile({ value: false }))
+        expect(dispatchSpy).toHaveBeenNthCalledWith(6, setIsLoadingMap({ value: false }))
+    })
+})


### PR DESCRIPTION
# App freeze when uploading a file that is already loaded

Closes: #3899 

## Description

When uploading, if all files are already uploaded, the application remains stuck in the loading animation. The visibleFiles does not change if only already uploaded files are uploaded again (This behavior was introduced in #3788). This was intentional, but it had the side effect that the RgNx store did not trigger the effects that would normally follow a file upload. One of these effects was responsible for removing the loading animation.

I fixed the issue by checking if a file upload added any new files. If no new files were added, there is an error that is caught by the file upload process, which then stops the loading animation.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
