### PR TITLE
Bug/3900/flipping delta maps

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 - Fix applying Custom Views [#3898](https://github.com/MaibornWolff/codecharta/pull/3898)
 - The camera is now only reset when the area or the height of the map is changed [#3896](https://github.com/MaibornWolff/codecharta/pull/3896)
 - Fix freezing app on uploading already loaded files [#3901](https://github.com/MaibornWolff/codecharta/pull/3901)
+- Fix switching maps in delta view [#3903](https://github.com/MaibornWolff/codecharta/pull/3903)
 
 ## [1.131.2] - 2024-12-04
 

--- a/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.spec.ts
+++ b/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.spec.ts
@@ -2,7 +2,7 @@ import { FileSelectionState, FileState } from "../../../model/files/files"
 import { FILE_META, TEST_FILE_DATA, TEST_FILE_DATA_JAVA, TEST_FILE_DATA_TWO } from "../../../util/dataMocks"
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
 import { TestBed } from "@angular/core/testing"
-import { onlyVisibleFilesMatterComparer, visibleFileStatesSelector } from "./visibleFileStates.selector"
+import { _onlyVisibleFilesMatterComparer, visibleFileStatesSelector } from "./visibleFileStates.selector"
 
 describe("_onlyVisibleFilesMatterComparer with standard state", () => {
     const fileStatePartial1 = { selectedAs: FileSelectionState.Partial, file: TEST_FILE_DATA }
@@ -10,30 +10,30 @@ describe("_onlyVisibleFilesMatterComparer with standard state", () => {
     const fileStateNone = { selectedAs: FileSelectionState.None, file: TEST_FILE_DATA_JAVA }
 
     it("should return true for two empty file states", () => {
-        expect(onlyVisibleFilesMatterComparer([], [])).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer([], [])).toBe(true)
     })
 
     it("should return true for the same file states", () => {
         const fileStates = [fileStatePartial1, fileStateNone]
-        expect(onlyVisibleFilesMatterComparer(fileStates, fileStates)).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer(fileStates, fileStates)).toBe(true)
     })
 
     it("should return false for file states with different number of visible files", () => {
         const fileStates1 = [fileStatePartial1, fileStatePartial2]
         const fileStates2 = [fileStatePartial1, fileStateNone]
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return false for file states with different visible files", () => {
         const fileStates1 = [fileStatePartial1]
         const fileStates2 = [fileStatePartial2]
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return true for file states with same visible files in different order", () => {
         const fileStates1 = [fileStatePartial1, fileStatePartial2]
         const fileStates2 = [fileStatePartial2, fileStatePartial1]
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
     })
 })
 
@@ -45,47 +45,47 @@ describe("_onlyVisibleFilesMatterComparer with delta state", () => {
     it("should return false for states of different lengths", () => {
         const fileStates1 = [fileStateReference]
         const fileStates2 = []
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return true for states with the same visible files", () => {
         const fileStates1: FileState[] = [fileStateReference, fileStateNone]
         const fileStates2 = [fileStateReference]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
     })
 
     it("should return false for states with no reference file", () => {
         const fileStates1: FileState[] = [fileStateReference, fileStateNone]
         const fileStates2 = [fileStateNone]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return false for states with no comparison file", () => {
         const fileStates1: FileState[] = [fileStateReference, fileStateComparison]
         const fileStates2 = [fileStateReference, fileStateNone]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return true for states with the same visible files in different orders", () => {
         const fileStates1: FileState[] = [fileStateReference, fileStateNone]
         const fileStates2 = [fileStateNone, fileStateReference]
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
     })
 
     it("should return false for states with different visible files", () => {
         const fileStates1: FileState[] = [fileStateReference]
         const fileStates2 = [fileStateNone]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return false for states of different file selection states", () => {
         const fileStates1: FileState[] = [fileStateReference]
         const fileStates2 = [{ ...fileStateReference, selectedAs: FileSelectionState.Comparison }]
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return true when both states have the same reference and comparison files correctly set", () => {
@@ -95,7 +95,7 @@ describe("_onlyVisibleFilesMatterComparer with delta state", () => {
         const fileStates1 = [referenceFile, comparisonFile]
         const fileStates2 = [referenceFile, comparisonFile]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(true)
     })
 
     it("should return false for different comparison files", () => {
@@ -113,7 +113,7 @@ describe("_onlyVisibleFilesMatterComparer with delta state", () => {
         const fileStates1 = [referenceFile1, comparisonFile1]
         const fileStates2 = [referenceFile2, comparisonFile2]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 
     it("should return false for different reference files", () => {
@@ -128,7 +128,7 @@ describe("_onlyVisibleFilesMatterComparer with delta state", () => {
         const fileStates1 = [referenceFile1, comparisonFile1]
         const fileStates2 = [referenceFile2, comparisonFile2]
 
-        expect(onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
+        expect(_onlyVisibleFilesMatterComparer(fileStates1, fileStates2)).toBe(false)
     })
 })
 

--- a/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.ts
@@ -2,7 +2,7 @@ import { FileSelectionState, FileState } from "../../../model/files/files"
 import { createSelectorFactory, defaultMemoize } from "@ngrx/store"
 import { filesSelector } from "../../store/files/files.selector"
 import { getVisibleFileStates, isDeltaState } from "../../../model/files/files.helper"
-import { compareContent } from "../../../util/arrayHelper"
+import { compareContentIgnoringOrder } from "../../../util/arrayHelper"
 
 export function _onlyVisibleFilesMatterComparer(fileStates1: FileState[], fileStates2: FileState[]): boolean {
     if (fileStates1 === fileStates2) {
@@ -28,7 +28,7 @@ export function _onlyVisibleFilesMatterComparer(fileStates1: FileState[], fileSt
         return false
     }
 
-    return compareContent(visibleFileChecksums1, visibleFileChecksum2)
+    return compareContentIgnoringOrder(visibleFileChecksums1, visibleFileChecksum2)
 }
 
 function compareDeltaState(fileStates1: FileState[], fileStates2: FileState[]): boolean {

--- a/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/visibleFileStates/visibleFileStates.selector.ts
@@ -2,12 +2,9 @@ import { FileSelectionState, FileState } from "../../../model/files/files"
 import { createSelectorFactory, defaultMemoize } from "@ngrx/store"
 import { filesSelector } from "../../store/files/files.selector"
 import { getVisibleFileStates, isDeltaState } from "../../../model/files/files.helper"
+import { compareContent } from "../../../util/arrayHelper"
 
-function removeMatch<T>(array: T[], matchIndex: number): T[] {
-    return [...array.slice(0, matchIndex), ...array.slice(matchIndex + 1)]
-}
-
-export function onlyVisibleFilesMatterComparer(fileStates1: FileState[], fileStates2: FileState[]): boolean {
+export function _onlyVisibleFilesMatterComparer(fileStates1: FileState[], fileStates2: FileState[]): boolean {
     if (fileStates1 === fileStates2) {
         return true
     }
@@ -16,55 +13,47 @@ export function onlyVisibleFilesMatterComparer(fileStates1: FileState[], fileSta
         return true
     }
 
+    if (isDeltaState(fileStates1) || isDeltaState(fileStates2)) {
+        return compareDeltaState(fileStates1, fileStates2)
+    }
+
+    const visibleFileChecksums1 = fileStates1
+        .filter(file => file.selectedAs === FileSelectionState.Partial)
+        .map(file => file.file.fileMeta.fileChecksum)
+    const visibleFileChecksum2 = fileStates2
+        .filter(file => file.selectedAs === FileSelectionState.Partial)
+        .map(file => file.file.fileMeta.fileChecksum)
+
+    if (visibleFileChecksums1.length !== visibleFileChecksum2.length) {
+        return false
+    }
+
+    return compareContent(visibleFileChecksums1, visibleFileChecksum2)
+}
+
+function compareDeltaState(fileStates1: FileState[], fileStates2: FileState[]): boolean {
     if (isDeltaState(fileStates1) !== isDeltaState(fileStates2)) {
         return false
     }
 
-    if (isDeltaState(fileStates1) || isDeltaState(fileStates2)) {
-        const referenceFile1 = fileStates1.find(file => file.selectedAs === FileSelectionState.Reference)
-        const referenceFile2 = fileStates2.find(file => file.selectedAs === FileSelectionState.Reference)
-        console.log(referenceFile1, referenceFile2)
-        if (referenceFile1.file.fileMeta.fileChecksum !== referenceFile2.file.fileMeta.fileChecksum) {
-            return false
-        }
-
-        const comparisonFile1 = fileStates1.find(file => file.selectedAs === FileSelectionState.Comparison)
-        const comparisonFile2 = fileStates2.find(file => file.selectedAs === FileSelectionState.Comparison)
-        console.log(comparisonFile1, comparisonFile2)
-        if (comparisonFile1.file.fileMeta.fileChecksum !== comparisonFile2.file.fileMeta.fileChecksum) {
-            return false
-        }
-        return true
-    }
-
-    const visibleFileStates1 = fileStates1
-        .filter(file => file.selectedAs === FileSelectionState.Partial)
-        .map(file => file.file.fileMeta.fileChecksum)
-    let visibleFileStates2 = fileStates2
-        .filter(file => file.selectedAs === FileSelectionState.Partial)
-        .map(file => file.file.fileMeta.fileChecksum)
-
-    if (visibleFileStates1.length !== visibleFileStates2.length) {
+    const referenceFile1 = fileStates1.find(file => file.selectedAs === FileSelectionState.Reference)
+    const referenceFile2 = fileStates2.find(file => file.selectedAs === FileSelectionState.Reference)
+    if (referenceFile1.file.fileMeta.fileChecksum !== referenceFile2.file.fileMeta.fileChecksum) {
         return false
     }
 
-    function reduceToDetermineIfArraysContainSameContents(previousCallResult: boolean, arrayMember: any): boolean {
-        if (previousCallResult === false) {
-            return false
-        }
-
-        const matchIndex = visibleFileStates2.indexOf(arrayMember)
-        if (matchIndex >= 0) {
-            visibleFileStates2 = removeMatch(visibleFileStates2, matchIndex)
-            return true
-        }
-
+    const comparisonFile1 = fileStates1.find(file => file.selectedAs === FileSelectionState.Comparison)
+    const comparisonFile2 = fileStates2.find(file => file.selectedAs === FileSelectionState.Comparison)
+    if (
+        comparisonFile1?.file.fileMeta.fileChecksum !== comparisonFile2?.file.fileMeta.fileChecksum ||
+        !comparisonFile1 !== !comparisonFile2
+    ) {
         return false
     }
 
-    return visibleFileStates1.reduce(reduceToDetermineIfArraysContainSameContents, true)
+    return true
 }
 
 export const visibleFileStatesSelector = createSelectorFactory(projection =>
-    defaultMemoize(projection, onlyVisibleFilesMatterComparer, onlyVisibleFilesMatterComparer)
+    defaultMemoize(projection, _onlyVisibleFilesMatterComparer, _onlyVisibleFilesMatterComparer)
 )(filesSelector, getVisibleFileStates)

--- a/visualization/app/codeCharta/util/arrayHelper.spec.ts
+++ b/visualization/app/codeCharta/util/arrayHelper.spec.ts
@@ -1,4 +1,4 @@
-import { addItemToArray, compareContent, removeItemFromArray } from "./arrayHelper"
+import { addItemToArray, compareContentIgnoringOrder, removeItemFromArray } from "./arrayHelper"
 
 function mutateObject(object: Record<string, number>) {
     object.x = 10_000
@@ -41,7 +41,7 @@ describe("arrayHelper", () => {
         })
     })
 
-    describe("compareContent", () => {
+    describe("compareContentIgnoringOrder", () => {
         it("should return true for arrays with the same contents", () => {
             const array1 = [
                 { x: 1, y: 2 },
@@ -52,7 +52,7 @@ describe("arrayHelper", () => {
                 { x: 3, y: 4 }
             ]
 
-            const result = compareContent(array1, array2)
+            const result = compareContentIgnoringOrder(array1, array2)
 
             expect(result).toBe(true)
         })
@@ -61,7 +61,7 @@ describe("arrayHelper", () => {
             const array1 = [{ x: 1, y: 2 }]
             const array2 = [{ x: 3, y: 4 }]
 
-            const result = compareContent(array1, array2)
+            const result = compareContentIgnoringOrder(array1, array2)
 
             expect(result).toBe(false)
         })
@@ -76,7 +76,7 @@ describe("arrayHelper", () => {
                 { x: 3, y: 4 }
             ]
 
-            const result = compareContent(array1, array2)
+            const result = compareContentIgnoringOrder(array1, array2)
 
             expect(result).toBe(true)
         })
@@ -88,8 +88,8 @@ describe("arrayHelper", () => {
                 { x: 3, y: 4 }
             ]
 
-            const result1 = compareContent(array1, array2)
-            const result2 = compareContent(array2, array1)
+            const result1 = compareContentIgnoringOrder(array1, array2)
+            const result2 = compareContentIgnoringOrder(array2, array1)
 
             expect(result1).toBe(false)
             expect(result2).toBe(false)
@@ -99,7 +99,7 @@ describe("arrayHelper", () => {
             const array1 = []
             const array2 = []
 
-            const result = compareContent(array1, array2)
+            const result = compareContentIgnoringOrder(array1, array2)
 
             expect(result).toBe(true)
         })
@@ -116,8 +116,8 @@ describe("arrayHelper", () => {
                 { x: 1, y: 3 }
             ]
 
-            const result1 = compareContent(array1, array2)
-            const result2 = compareContent(array2, array1)
+            const result1 = compareContentIgnoringOrder(array1, array2)
+            const result2 = compareContentIgnoringOrder(array2, array1)
 
             expect(result1).toBe(false)
             expect(result2).toBe(false)

--- a/visualization/app/codeCharta/util/arrayHelper.spec.ts
+++ b/visualization/app/codeCharta/util/arrayHelper.spec.ts
@@ -1,4 +1,4 @@
-import { addItemToArray, removeItemFromArray } from "./arrayHelper"
+import { addItemToArray, compareContent, removeItemFromArray } from "./arrayHelper"
 
 function mutateObject(object: Record<string, number>) {
     object.x = 10_000
@@ -38,6 +38,89 @@ describe("arrayHelper", () => {
                 { x: 10_000, y: 2 },
                 { x: 3, y: 4 }
             ])
+        })
+    })
+
+    describe("compareContent", () => {
+        it("should return true for arrays with the same contents", () => {
+            const array1 = [
+                { x: 1, y: 2 },
+                { x: 3, y: 4 }
+            ]
+            const array2 = [
+                { x: 1, y: 2 },
+                { x: 3, y: 4 }
+            ]
+
+            const result = compareContent(array1, array2)
+
+            expect(result).toBe(true)
+        })
+
+        it("should return false for arrays with different contents", () => {
+            const array1 = [{ x: 1, y: 2 }]
+            const array2 = [{ x: 3, y: 4 }]
+
+            const result = compareContent(array1, array2)
+
+            expect(result).toBe(false)
+        })
+
+        it("should return true for arrays with the same contents in different orders", () => {
+            const array1 = [
+                { x: 3, y: 4 },
+                { x: 1, y: 2 }
+            ]
+            const array2 = [
+                { x: 1, y: 2 },
+                { x: 3, y: 4 }
+            ]
+
+            const result = compareContent(array1, array2)
+
+            expect(result).toBe(true)
+        })
+
+        it("should return false for arrays with different length", () => {
+            const array1 = [{ x: 3, y: 4 }]
+            const array2 = [
+                { x: 3, y: 4 },
+                { x: 3, y: 4 }
+            ]
+
+            const result1 = compareContent(array1, array2)
+            const result2 = compareContent(array2, array1)
+
+            expect(result1).toBe(false)
+            expect(result2).toBe(false)
+        })
+
+        it("should return true for empty arrays", () => {
+            const array1 = []
+            const array2 = []
+
+            const result = compareContent(array1, array2)
+
+            expect(result).toBe(true)
+        })
+
+        it("should return false for arrays containing duplicate elements", () => {
+            const array1 = [
+                { x: 1, y: 2 },
+                { x: 1, y: 2 },
+                { x: 1, y: 3 }
+            ]
+            const array2 = [
+                { x: 1, y: 2 },
+                { x: 1, y: 3 },
+                { x: 1, y: 3 }
+            ]
+
+            const result1 = compareContent(array1, array2)
+            const result2 = compareContent(array2, array1)
+
+            expect(result1).toBe(false)
+            expect(result2).toBe(false)
         })
     })
 })

--- a/visualization/app/codeCharta/util/arrayHelper.ts
+++ b/visualization/app/codeCharta/util/arrayHelper.ts
@@ -26,7 +26,7 @@ export function addItemsToArray<T>(array: T[], items: T[]): T[] {
     return newArray
 }
 
-export function compareContent<T>(array1: T[], array2: T[]): boolean {
+export function compareContentIgnoringOrder<T>(array1: T[], array2: T[]): boolean {
     if (array1.length !== array2.length) {
         return false
     }

--- a/visualization/app/codeCharta/util/arrayHelper.ts
+++ b/visualization/app/codeCharta/util/arrayHelper.ts
@@ -5,18 +5,18 @@ export function removeItemFromArray<T>(array: T[], searchItem: T) {
     return array.filter(entry => !dequal(entry, searchItem))
 }
 
-export function removeEntryAtIndexFromArray<T>(array: T[], index: number) {
+export function removeEntryAtIndexFromArray<T>(array: T[], index: number): T[] {
     return [...array.slice(0, index), ...array.slice(index + 1)]
 }
 
-export function addItemToArray<T>(array: T[], item: T) {
+export function addItemToArray<T>(array: T[], item: T): T[] {
     if (!arrayContainsItem(array, item)) {
         return [...array, clone(item)]
     }
     return array
 }
 
-export function addItemsToArray<T>(array: T[], items: T[]) {
+export function addItemsToArray<T>(array: T[], items: T[]): T[] {
     const newArray = [...array]
     for (const item of items) {
         if (!arrayContainsItem(newArray, item)) {
@@ -24,6 +24,29 @@ export function addItemsToArray<T>(array: T[], items: T[]) {
         }
     }
     return newArray
+}
+
+export function compareContent<T>(array1: T[], array2: T[]): boolean {
+    if (array1.length !== array2.length) {
+        return false
+    }
+
+    let clonedArray2 = [...array2]
+
+    return array1.every(item => {
+        const index = findIndexOfItemInArray(clonedArray2, item)
+
+        if (index >= 0) {
+            clonedArray2 = removeEntryAtIndexFromArray(clonedArray2, index)
+            return true
+        }
+
+        return false
+    })
+}
+
+function findIndexOfItemInArray<T>(array: T[], item: T): number {
+    return array.findIndex(x => dequal(x, item))
 }
 
 function arrayContainsItem<T>(array: T[], item: T) {


### PR DESCRIPTION
# Switching the two maps in delta mode doesn't change anything

Closes: #3900 

## Description

The "_onlyVisibleFilesMatterComparer" didn't notice the change if the two maps were flipped. I fixed that.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
