### PR TITLE
Feat/3877/rename a button

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Changed
 
 - Increased the size of the color quantile diagram [#3827](https://github.com/MaibornWolff/codecharta/pull/3827)
+- Rename the "Reset camera..."-settings-button to make it more clear what it does [#3906](https://github.com/MaibornWolff/codecharta/pull/3906)
 
 ### Fixed 🐞
 

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Changed
 
 - Increased the size of the color quantile diagram [#3827](https://github.com/MaibornWolff/codecharta/pull/3827)
-- Rename the "Reset camera..."-settings-button to make it more clear what it does [#3906](https://github.com/MaibornWolff/codecharta/pull/3906)
+- Rename the "Reset camera..."-settings-button and add tooltip to make it more clear what it does [#3906](https://github.com/MaibornWolff/codecharta/pull/3906)
 
 ### Fixed 🐞
 

--- a/visualization/app/codeCharta/ui/toolBar/globalConfigurationButton/globalConfigurationDialog/globalConfigurationDialog.component.html
+++ b/visualization/app/codeCharta/ui/toolBar/globalConfigurationButton/globalConfigurationDialog/globalConfigurationDialog.component.html
@@ -12,7 +12,7 @@
             Hide Flattened Buildings
         </mat-slide-toggle>
         <mat-slide-toggle [checked]="resetCameraIfNewFileIsLoaded$ | async" (change)="handleResetCameraIfNewFileIsLoadedChanged($event)">
-            Reset Camera when changing map
+            Reset camera when map layout changes
         </mat-slide-toggle>
         <mat-slide-toggle [checked]="isWhiteBackground$ | async" (change)="handleIsWhiteBackgroundChanged($event)">
             White Background

--- a/visualization/app/codeCharta/ui/toolBar/globalConfigurationButton/globalConfigurationDialog/globalConfigurationDialog.component.html
+++ b/visualization/app/codeCharta/ui/toolBar/globalConfigurationButton/globalConfigurationDialog/globalConfigurationDialog.component.html
@@ -11,8 +11,9 @@
         <mat-slide-toggle [checked]="hideFlatBuildings$ | async" (change)="handleHideFlatBuildingsChanged($event)">
             Hide Flattened Buildings
         </mat-slide-toggle>
-        <mat-slide-toggle [checked]="resetCameraIfNewFileIsLoaded$ | async" (change)="handleResetCameraIfNewFileIsLoadedChanged($event)">
-            Reset camera when map layout changes
+        <mat-slide-toggle [checked]="resetCameraIfNewFileIsLoaded$ | async" (change)="handleResetCameraIfNewFileIsLoadedChanged($event)"
+                          title="The camera is reset to the default position when any change in the map layout is made. Layout changes could be area changes, file changes, layout algorithm changes, focussing, excluding etc.">
+            Reset camera when map layout changes <i class="fa fa-info-circle"></i>
         </mat-slide-toggle>
         <mat-slide-toggle [checked]="isWhiteBackground$ | async" (change)="handleIsWhiteBackgroundChanged($event)">
             White Background


### PR DESCRIPTION
# Add a tooltip to the "Reset camera..." toggle

Closes: #3877 

## Description

Add a tooltip to the "Reset camera when map layout changes" button.
This was forgotten in the first PR for this issue: #3906 

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
