### PR TITLE
Tech/3913/release changelog bug

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
-## [1.131.0] - 2025-02-11 (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
+## [1.131.0] - 2025-02-11
 
 ### Changed
 
 - Removed the top level from the output structure of the SonarImporter to match the other parsers and importers [3912](https://github.com/MaibornWolff/codecharta/pull/3912)
 
-## [1.130.0] - 2024-12-17 (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
+## [1.130.0] - 2024-12-17
 
 ### Added 🚀
 

--- a/script/version-manager.ts
+++ b/script/version-manager.ts
@@ -143,7 +143,7 @@ class VersionManager {
                 unreleasedChangelogSection = this.extractChangelogSection(changelog, "unreleased")
 
                 const updatedChangelog = changelog.replace(
-                    "## [unreleased]",
+                    "## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)",
                     `## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)\n\n## [${newVersion}] - ${date}`
                 )
                 fs.writeFileSync(changelogPath, updatedChangelog)

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -13,13 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [1.133.0] - 2025-02-11
 
-### Added
+### Added 🚀
 
 - Updated the preview slider of the edge metric options to prioritize buildings with higher number of edges [#3918](https://github.com/MaibornWolff/codecharta/pull/3918)
 
 ## [1.132.0] - 2025-02-04
 
-### Added
+### Added 🚀
 
 - Add a cross-hair when hovering over the color quantile diagram [#3827](https://github.com/MaibornWolff/codecharta/pull/3827)
 - Maps are always shown and rendered in alphabetical order [#3905](https://github.com/MaibornWolff/codecharta/pull/3905)

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+- Fixed changelog not displaying changes [#3925](https://github.com/MaibornWolff/codecharta/pull/3925)
+
 ## [1.133.0] - 2025-02-11
 
 ### Added

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
-## [1.133.0] - 2025-02-11 (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
+## [1.133.0] - 2025-02-11
 
 ### Added
 
 - Updated the preview slider of the edge metric options to prioritize buildings with higher number of edges [#3918](https://github.com/MaibornWolff/codecharta/pull/3918)
 
-## [1.132.0] - 2025-02-04 (Added 🚀 | Changed | Removed 🗑 | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
+## [1.132.0] - 2025-02-04
 
 ### Added
 


### PR DESCRIPTION
# Release changelog wrong has format

Closes: #3913 

## Description

The version-manager added the new line "[unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)" correctly, but did not remove the "(Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)" after the version, which lead to red tests in the release pipeline.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
