### PR TITLE
Changing Color Metrics resets colors

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+- Fix resetting colors in color metrics [#3943](https://github.com/MaibornWolff/codecharta/pull/3943)
+
 ## [1.133.1] - 2025-02-13
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/state/effects/updateMapColors/updateMapColors.effect.ts
+++ b/visualization/app/codeCharta/state/effects/updateMapColors/updateMapColors.effect.ts
@@ -20,15 +20,16 @@ export class UpdateMapColorsEffect {
             map(colorMetric => {
                 const state = this.state.getValue()
                 const attributeDescriptors = state.fileSettings.attributeDescriptors
+                const mapColors = state.appSettings.mapColors
                 if (attributeDescriptors[colorMetric]?.direction === 1) {
-                    const reversedMapColors: MapColors = JSON.parse(stringify(state.appSettings.mapColors))
+                    const reversedMapColors: MapColors = JSON.parse(stringify(mapColors))
                     const temporary = reversedMapColors.negative
                     reversedMapColors.negative = reversedMapColors.positive
                     reversedMapColors.positive = temporary
 
                     return setMapColors({ value: reversedMapColors })
                 }
-                return setMapColors({ value: defaultMapColors })
+                return setMapColors({ value: mapColors ?? defaultMapColors })
             })
         )
     )

--- a/visualization/app/codeCharta/state/store/dynamicSettings/colorRange/resetColorRange.effect.spec.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/colorRange/resetColorRange.effect.spec.ts
@@ -61,11 +61,11 @@ describe("ResetColorRangeEffect", () => {
         expect(await getLastAction(store)).not.toEqual({ value: { from: 53, to: 86 }, type: "SET_COLOR_RANGE" })
     })
 
-    it("should fire when colorMetric selection changed", async () => {
+    it("should not fire when colorMetric selection changed", async () => {
         const store = TestBed.inject(MockStore)
         store.overrideSelector(selectedColorMetricDataSelector, { minValue: 20, maxValue: 120, values: [20, 120] })
         store.refreshState()
         actions$.next(setColorMetric({ value: "anotherMetric" }))
-        expect(await getLastAction(store)).toEqual({ value: { from: 53, to: 86 }, type: "SET_COLOR_RANGE" })
+        expect(await getLastAction(store)).toEqual({ type: "@ngrx/effects/init" })
     })
 })

--- a/visualization/app/codeCharta/state/store/dynamicSettings/colorRange/resetColorRange.effect.ts
+++ b/visualization/app/codeCharta/state/store/dynamicSettings/colorRange/resetColorRange.effect.ts
@@ -7,7 +7,6 @@ import { calculateInitialColorRange } from "./calculateInitialColorRange"
 import { setColorRange } from "./colorRange.actions"
 import { fileActions } from "../../files/files.actions"
 import { CcState } from "../../../../codeCharta.model"
-import { setColorMetric } from "../colorMetric/colorMetric.actions"
 import { visibleFileStatesSelector } from "../../../selectors/visibleFileStates/visibleFileStates.selector"
 
 @Injectable()
@@ -22,14 +21,6 @@ export class ResetColorRangeEffect {
             ofType(...fileActions),
             withLatestFrom(this.store.select(visibleFileStatesSelector)),
             switchMap(() => this.store.select(selectedColorMetricDataSelector).pipe(skip(1), take(1))),
-            map(selectedColorMetricData => setColorRange({ value: calculateInitialColorRange(selectedColorMetricData) }))
-        )
-    )
-
-    resetColorRangeOnColorMetricChange$ = createEffect(() =>
-        this.actions$.pipe(
-            ofType(setColorMetric),
-            switchMap(() => this.store.select(selectedColorMetricDataSelector).pipe(take(1))),
             map(selectedColorMetricData => setColorRange({ value: calculateInitialColorRange(selectedColorMetricData) }))
         )
     )


### PR DESCRIPTION
# Changing Color Metrics resets colors

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/CONTRIBUTING.md) before opening a PR.**_

Closes: #3878

## Description

We removed the effect that resets the colors on a metrics change.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
