### PR TITLE
Bug/3951/readme badges red

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
   </a>
 
   <p>
-    Latest Release: <br>
-    Analysis <a href="https://github.com/MaibornWolff/codecharta/releases/tag/ana-1.131.0">1.131.0</a> | Visualization <a href="https://github.com/MaibornWolff/codecharta/releases/tag/vis-1.134.0">1.134.0</a>
-
-[comment]: ##################################################################################
-[comment]: <Ensure that the words 'latest release' are above the line with the links>
-[comment]: ##################################################################################
-
+    Latest Releases: <br>
+    <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue">
+    <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue">
   </p>
 
   <div>
@@ -21,19 +17,43 @@
     <a href="#links">Links</a>
   </div>
 
-  <div>
+  <div style="display: flex; justify-content: center; align-items: center;">
+  <!-- Analysis Column -->
+  <div style="display: flex; flex-direction: column; align-items: flex-end;">
     <a href="https://github.com/MaibornWolff/codecharta/actions/workflows/release-analysis.yml">
-      <img src="https://github.com/MaibornWolff/codecharta/actions/workflows/release-analysis.yml/badge.svg" alt="Release Analysis">
-    </a>
-    <a href="https://github.com/MaibornWolff/codecharta/actions/workflows/release-visualization.yml">
-      <img src="https://github.com/MaibornWolff/codecharta/actions/workflows/release-visualization.yml/badge.svg" alt="Release Visualization">
+      <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
-      <img src="https://sonarcloud.io/api/project_badges/measure?project=maibornwolff-gmbh_codecharta_analysis&metric=alert_status" alt="Quality Gate Analysis"></a>
-    <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
-      <img src="https://sonarcloud.io/api/project_badges/measure?project=maibornwolff-gmbh_codecharta_visualization&metric=alert_status" alt="Quality Gate Visualization">
+      <img alt="Quality Gate Analysis" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Analysis&style=plastic">
+    </a>
+    <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
+      <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
     </a>
   </div>
+
+  <!-- Visualization Column -->
+  <div style="display: flex; flex-direction: column; align-items: flex-start; margin-left: 5px;">
+    <a href="https://github.com/MaibornWolff/codecharta/actions/workflows/release-visualization.yml">
+      <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.131.0?label=Release%20-%20Visualization&style=plastic">
+    </a>
+    <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
+      <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic">
+    </a>
+    <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
+      <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic">
+    </a>
+  </div>
+  </div>
+
+  <div style="display: flex; flex-direction: column; align-items: center; margin-top: 10px;">
+      <a href="https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity">
+        <img alt="Website Up Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fvisualization%2Fapp%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dsonar_complexity%26color%3Dsonar_complexity&up_message=running&style=plastic&label=Web%20Studio">
+      </a>
+      <a href="https://codecharta.com/stg/visualization/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=functions&color=functions&currentFilesAreSampleFiles=true">
+        <img alt="Website Prerelease Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fstg%2Fvisualization%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dfunctions%26color%3Dfunctions%26currentFilesAreSampleFiles%3Dtrue&up_message=running&style=plastic&label=Web%20Studio%20Prerelease%20Environment">
+      </a>
+  </div>
+
 </div>
 
 ![Screenshot of CodeCharta](assets/promo_img.png)
@@ -66,7 +86,8 @@ and [Raw Text](https://maibornwolff.github.io/codecharta/docs/parser/raw-text).
 
 ### [Web Studio](https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity) (Visualisation)
 
-Our [Web Studio](https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity) allows you to visualize your code base in 3D. It takes the results from our Shell and displays them in a city-like map.
+Our [Web Studio](https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity)
+allows you to visualize your code base in 3D. It takes the results from our Shell and displays them in a city-like map.
 You can move around your code base, zoom in and out, and see the metrics of your code base in a 3D map.
 Files with metrics become buildings where the area, height and color represent different metrics, you can freely choose!
 Makes it easy to see the hotspots in your code base and find areas for improvement.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <div style="display: flex; justify-content: center; align-items: center;">
   <!-- Analysis Column -->
   <div style="display: flex; flex-direction: column; align-items: flex-end;">
-    <a href="https://github.com/MaibornWolff/codecharta/actions/workflows/release-analysis.yml">
+    <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
@@ -33,8 +33,8 @@
 
   <!-- Visualization Column -->
   <div style="display: flex; flex-direction: column; align-items: flex-start; margin-left: 5px;">
-    <a href="https://github.com/MaibornWolff/codecharta/actions/workflows/release-visualization.yml">
-      <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.131.0?label=Release%20-%20Visualization&style=plastic">
+    <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
+      <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
       <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic">

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
+    &nbsp;
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Quality Gate Analysis" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Analysis&style=plastic">
     </a>
+    <span></span>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
     </a>
@@ -36,6 +38,7 @@
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
       <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
+    <tab></tab>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
       <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic">
     </a>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </p>
 
   <!-- Analysis -->
-  <p>
+  <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
@@ -35,8 +35,10 @@
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
     </a>
-    <br>
-    <!-- Visualization -->
+  </div>
+
+  <!-- Visualization -->
+  <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
       <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
@@ -46,7 +48,7 @@
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
       <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic">
     </a>
-  </p>
+  </div>
 
   <br>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@
   <a href="https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity">
     <img alt="Website Up Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fvisualization%2Fapp%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dsonar_complexity%26color%3Dsonar_complexity&up_message=running&style=plastic&label=Web%20Studio">
   </a>
-  <br>
   <a href="https://codecharta.com/stg/visualization/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=functions&color=functions&currentFilesAreSampleFiles=true">
     <img alt="Website Prerelease Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fstg%2Fvisualization%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dfunctions%26color%3Dfunctions%26currentFilesAreSampleFiles%3Dtrue&up_message=running&style=plastic&label=Web%20Studio%20Prerelease%20Environment">
   </a>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   </p>
 
   <!-- Analysis -->
-  <div>
+  <p>
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
@@ -31,10 +31,8 @@
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
     </a>
-  </div>
-
-  <!-- Visualization -->
-  <div>
+    <br>
+    <!-- Visualization -->
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
       <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
@@ -44,7 +42,7 @@
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
       <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic">
     </a>
-  </div>
+  </p>
 
   <br>
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
-    &nbsp;
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Quality Gate Analysis" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Analysis&style=plastic">
     </a>
-    <span></span>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
       <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
     </a>
@@ -42,7 +40,6 @@
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
       <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
-    <tab></tab>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
       <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic">
     </a>

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 <div align="center">
+  <!-- Logo -->
   <a href="https://maibornwolff.github.io/codecharta/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&currentFilesAreSampleFiles=true">
     <img src="https://raw.githubusercontent.com/maibornwolff/codecharta/main/logo/codecharta_logo.svg" alt="CodeCharta logo" width="200"/>
   </a>
 
+  <!-- Releases -->
   <p>
     Latest Releases: <br>
     <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue">
     <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue">
   </p>
 
-  <div>
+  <!-- Links -->
+  <p>
     <a href="https://maibornwolff.github.io/codecharta/">Documentation</a> •
     <a href="#features">Features</a> •
     <a href="https://maibornwolff.github.io/codecharta/docs/overview/getting-started">Quickstart</a> •
     <a href="#get-involved">Get Involved</a> •
     <a href="#links">Links</a>
-  </div>
+  </p>
 
-  <div style="display: flex; justify-content: center; align-items: center;">
-  <!-- Analysis Column -->
-  <div style="display: flex; flex-direction: column; align-items: flex-end;">
+  <!-- Analysis -->
+  <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
       <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
     </a>
@@ -31,8 +33,8 @@
     </a>
   </div>
 
-  <!-- Visualization Column -->
-  <div style="display: flex; flex-direction: column; align-items: flex-start; margin-left: 5px;">
+  <!-- Visualization -->
+  <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
       <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
     </a>
@@ -43,16 +45,17 @@
       <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic">
     </a>
   </div>
-  </div>
 
-  <div style="display: flex; flex-direction: column; align-items: center; margin-top: 10px;">
-      <a href="https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity">
-        <img alt="Website Up Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fvisualization%2Fapp%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dsonar_complexity%26color%3Dsonar_complexity&up_message=running&style=plastic&label=Web%20Studio">
-      </a>
-      <a href="https://codecharta.com/stg/visualization/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=functions&color=functions&currentFilesAreSampleFiles=true">
-        <img alt="Website Prerelease Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fstg%2Fvisualization%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dfunctions%26color%3Dfunctions%26currentFilesAreSampleFiles%3Dtrue&up_message=running&style=plastic&label=Web%20Studio%20Prerelease%20Environment">
-      </a>
-  </div>
+  <br>
+
+  <!-- Web Studio -->
+  <a href="https://codecharta.com/visualization/app/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=sonar_complexity&color=sonar_complexity">
+    <img alt="Website Up Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fvisualization%2Fapp%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dsonar_complexity%26color%3Dsonar_complexity&up_message=running&style=plastic&label=Web%20Studio">
+  </a>
+  <br>
+  <a href="https://codecharta.com/stg/visualization/index.html?file=codecharta.cc.json.gz&file=codecharta_analysis.cc.json.gz&area=rloc&height=functions&color=functions&currentFilesAreSampleFiles=true">
+    <img alt="Website Prerelease Badge" src="https://img.shields.io/website?url=https%3A%2F%2Fcodecharta.com%2Fstg%2Fvisualization%2Findex.html%3Ffile%3Dcodecharta.cc.json.gz%26file%3Dcodecharta_analysis.cc.json.gz%26area%3Drloc%26height%3Dfunctions%26color%3Dfunctions%26currentFilesAreSampleFiles%3Dtrue&up_message=running&style=plastic&label=Web%20Studio%20Prerelease%20Environment">
+  </a>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@
   <!-- Releases -->
   <p>
     Latest Releases: <br>
-    <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue">
-    <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue">
+    <a href="https://github.com/MaibornWolff/codecharta/releases/tag/ana-1.131.0">
+      <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue">
+    </a>
+    <a href="https://github.com/MaibornWolff/codecharta/releases/tag/vis-1.134.0">
+      <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue">
+    </a>
   </p>
 
   <!-- Links -->

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
   <p>
     Latest Releases: <br>
     <a href="https://github.com/MaibornWolff/codecharta/releases/tag/ana-1.131.0">
-      <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue">
-    </a>
+      <img alt="Analysis Version Badge" src="https://img.shields.io/badge/1.131.0-x?style=plastic&label=Analysis&color=blue"></a>
     <a href="https://github.com/MaibornWolff/codecharta/releases/tag/vis-1.134.0">
-      <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue">
-    </a>
+      <img alt="Visualization Version Badge" src="https://img.shields.io/badge/1.134.0-x?label=Visualization&style=plastic&color=blue"></a>
   </p>
 
   <!-- Links -->
@@ -27,27 +25,21 @@
   <!-- Analysis -->
   <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/ana-1.131.0">
-      <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic">
-    </a>
+      <img alt="Release Analysis Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/ana-1.131.0?label=Release%20-%20Analysis&style=plastic"></a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
-      <img alt="Quality Gate Analysis" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Analysis&style=plastic">
-    </a>
+      <img alt="Quality Gate Analysis" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Analysis&style=plastic"></a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_analysis">
-      <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic">
-    </a>
+      <img alt="Sonar Analysis Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_analysis/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Analysis&style=plastic"></a>
   </div>
 
   <!-- Visualization -->
   <div>
     <a href="https://github.com/MaibornWolff/codecharta/tree/vis-1.134.0">
-      <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic">
-    </a>
+      <img alt="Release Visualization Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/vis-1.134.0?label=Release%20-%20Visualization&style=plastic"></a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
-      <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic">
-    </a>
+      <img alt="Quality Gate Visualization" src="https://img.shields.io/sonar/quality_gate/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Quality%20Gate%20Visualization&style=plastic"></a>
     <a href="https://sonarcloud.io/dashboard?id=maibornwolff-gmbh_codecharta_visualization">
-      <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic">
-    </a>
+      <img alt="Sonar Visualization Coverage" src="https://img.shields.io/sonar/coverage/maibornwolff-gmbh_codecharta_visualization/main?server=https%3A%2F%2Fsonarcloud.io&label=Coverage%20Visualization&style=plastic"></a>
   </div>
 
   <br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@biomejs/biome": "1.9.4",
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
+        "badge-maker": "^4.1.0",
         "husky": "^8.0.0",
         "lint-staged": "^15.4.3"
       },
@@ -480,6 +481,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anafanafo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-2.0.0.tgz",
+      "integrity": "sha512-Nlfq7NC4AOkTJerWRIZcOAiMNtIDVIGWGvQ98O7Jl6Kr2Dk0dX5u4MqN778kSRTy5KRqchpLdF2RtLFEz9FVkQ==",
+      "dev": true,
+      "dependencies": {
+        "char-width-table-consumer": "^1.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
@@ -531,6 +541,28 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
     },
+    "node_modules/badge-maker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/badge-maker/-/badge-maker-4.1.0.tgz",
+      "integrity": "sha512-qYImXoz0WZRMaauqSMo6QNurKp26K3RcOhefuGfno50xmAzHEJsgHbP4gnHs6Ps53KgQgFi4MJKB6Rq8H7siww==",
+      "dev": true,
+      "dependencies": {
+        "anafanafo": "2.0.0",
+        "css-color-converter": "^2.0.0"
+      },
+      "bin": {
+        "badge": "lib/badge-cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "dev": true
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -562,6 +594,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-width-table-consumer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/char-width-table-consumer/-/char-width-table-consumer-1.0.0.tgz",
+      "integrity": "sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ==",
+      "dev": true,
+      "dependencies": {
+        "binary-search": "^1.3.5"
       }
     },
     "node_modules/cli-cursor": {
@@ -800,6 +841,29 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-color-converter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-converter/-/css-color-converter-2.0.0.tgz",
+      "integrity": "sha512-oLIG2soZz3wcC3aAl/7Us5RS8Hvvc6I8G8LniF/qfMmrm7fIKQ8RIDDRZeKyGL2SrWfNqYspuLShbnjBMVWm8g==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^0.5.2",
+        "color-name": "^1.1.4",
+        "css-unit-converter": "^1.1.2"
+      }
+    },
+    "node_modules/css-color-converter/node_modules/color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true
+    },
+    "node_modules/css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
+      "dev": true
     },
     "node_modules/dargs": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "1.9.4",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "badge-maker": "^4.1.0",
     "husky": "^8.0.0",
     "lint-staged": "^15.4.3"
   },

--- a/script/version-manager.ts
+++ b/script/version-manager.ts
@@ -181,6 +181,7 @@ ${unreleasedChangelogSection}`
     }
 
     private replaceVersionBadge(repository: string, readme: string, newVersion: string): string {
+        const repositoryAbbreviation = repository === "visualization" ? "vis" : "ana"
         const repositoryCapitalized = repository === "visualization" ? "Visualization" : "Analysis"
 
         const versionBadgeRegex = new RegExp(`alt="${repositoryCapitalized} Version Badge" src="https://img\\.shields\\.io/badge/.*?-`)
@@ -190,9 +191,23 @@ ${unreleasedChangelogSection}`
             throw new Error(`Could not find version badge for ${repositoryCapitalized} in README.md`)
         }
 
-        return readme.replace(
+        const updatedReadme = readme.replace(
             versionBadgeRegex,
             `alt="${repositoryCapitalized} Version Badge" src="https://img.shields.io/badge/${newVersion}-`
+        )
+
+        const versionBadgeRefRegex = new RegExp(
+            `href="https://github\\.com/MaibornWolff/codecharta/releases/tag/${repositoryAbbreviation}-.*?"`
+        )
+        const matchVersionBadgeRef = versionBadgeRefRegex.exec(updatedReadme)
+
+        if (!matchVersionBadgeRef) {
+            throw new Error(`Could not find version badge reference for ${repositoryCapitalized} in README.md`)
+        }
+
+        return updatedReadme.replace(
+            versionBadgeRefRegex,
+            `href="https://github.com/MaibornWolff/codecharta/releases/tag/${repositoryAbbreviation}-${newVersion}"`
         )
     }
 

--- a/script/version-manager.ts
+++ b/script/version-manager.ts
@@ -94,9 +94,21 @@ class VersionManager {
             throw new Error(`Could not find release badge for ${repositoryCapitalized} in README.md`)
         }
 
-        return readme.replace(
+        const updatedReadme = readme.replace(
             releaseBadgeRegex,
             `alt="Release ${repositoryCapitalized} Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/${repositoryAbbreviation}-${newVersion}?`
+        )
+
+        const releaseBadgeRefRegex = new RegExp(`href="https://github\\.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-.*?"`)
+        const matchReleaseBadgeRef = updatedReadme.match(releaseBadgeRefRegex)
+
+        if (!matchReleaseBadgeRef) {
+            throw new Error(`Could not find release badge reference for ${repositoryCapitalized} in README.md`)
+        }
+
+        return updatedReadme.replace(
+            releaseBadgeRefRegex,
+            `href="https://github.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-${newVersion}"`
         )
     }
 

--- a/script/version-manager.ts
+++ b/script/version-manager.ts
@@ -12,106 +12,6 @@ type Repository = "visualization" | "analysis"
 type VersionType = "major" | "minor" | "patch"
 
 class VersionManager {
-    private validateRepository(repository: string): asserts repository is Repository {
-        const normalized = repository.toLowerCase()
-        if (normalized !== "visualization" && normalized !== "analysis") {
-            throw new Error(`Invalid repository: ${repository}. Must be either "Visualization" or "Analysis" (case insensitive)`)
-        }
-    }
-
-    private getNormalizedRepository(repository: string): Repository {
-        return repository.toLowerCase() as Repository
-    }
-
-    private validateVersionType(type: string): asserts type is VersionType {
-        if (type !== "major" && type !== "minor" && type !== "patch") {
-            throw new Error(`Invalid version type: ${type}. Must be one of: major, minor, patch`)
-        }
-    }
-
-    private validateFiles(repository: string) {
-        const normalizedRepo = this.getNormalizedRepository(repository)
-        if (normalizedRepo === "visualization") {
-            const visualizationFiles = ["visualization/package.json", "visualization/CHANGELOG.md"]
-            for (const file of visualizationFiles) {
-                if (!fs.existsSync(file)) {
-                    throw new Error(`Required file not found: ${file}`)
-                }
-            }
-        } else {
-            // Analysis repository
-            const analysisFiles = ["analysis/CHANGELOG.md", "analysis/gradle.properties", "analysis/node-wrapper/package.json"]
-            for (const file of analysisFiles) {
-                if (!fs.existsSync(file)) {
-                    throw new Error(`Required file not found: ${file}`)
-                }
-            }
-        }
-    }
-
-    private ensureDirectoryExists(dir: string) {
-        if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir, { recursive: true })
-        }
-    }
-
-    private updateReadme(repository: Repository, newVersion: string): void {
-        const readmePath = "README.md"
-
-        let updatedReadme = fs.readFileSync(readmePath, "utf8")
-        updatedReadme = this.replaceVersionBadge(repository, updatedReadme, newVersion)
-        updatedReadme = this.replaceReleaseBadge(repository, updatedReadme, newVersion)
-
-        fs.writeFileSync(readmePath, updatedReadme)
-    }
-
-    private replaceVersionBadge(repository: string, readme: string, newVersion: string): string {
-        const repositoryCapitalized = repository === "visualization" ? "Visualization" : "Analysis"
-
-        const versionBadgeRegex = new RegExp(`alt="${repositoryCapitalized} Version Badge" src="https://img\\.shields\\.io/badge/.*?-`)
-        const matchVersionBadge = readme.match(versionBadgeRegex)
-
-        if (!matchVersionBadge) {
-            throw new Error(`Could not find version badge for ${repositoryCapitalized} in README.md`)
-        }
-
-        return readme.replace(
-            versionBadgeRegex,
-            `alt="${repositoryCapitalized} Version Badge" src="https://img.shields.io/badge/${newVersion}-`
-        )
-    }
-
-    private replaceReleaseBadge(repository: string, readme: string, newVersion: string): string {
-        const repositoryAbbreviation = repository === "visualization" ? "vis" : "ana"
-        const repositoryCapitalized = repository === "visualization" ? "Visualization" : "Analysis"
-
-        const releaseBadgeRegex = new RegExp(
-            `alt="Release ${repositoryCapitalized} Badge" src="https://img\\.shields\\.io/github/check-runs/MaibornWolff/CodeCharta/${repositoryAbbreviation}-.*?\\?`
-        )
-        const matchReleaseBadge = readme.match(releaseBadgeRegex)
-
-        if (!matchReleaseBadge) {
-            throw new Error(`Could not find release badge for ${repositoryCapitalized} in README.md`)
-        }
-
-        const updatedReadme = readme.replace(
-            releaseBadgeRegex,
-            `alt="Release ${repositoryCapitalized} Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/${repositoryAbbreviation}-${newVersion}?`
-        )
-
-        const releaseBadgeRefRegex = new RegExp(`href="https://github\\.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-.*?"`)
-        const matchReleaseBadgeRef = updatedReadme.match(releaseBadgeRefRegex)
-
-        if (!matchReleaseBadgeRef) {
-            throw new Error(`Could not find release badge reference for ${repositoryCapitalized} in README.md`)
-        }
-
-        return updatedReadme.replace(
-            releaseBadgeRefRegex,
-            `href="https://github.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-${newVersion}"`
-        )
-    }
-
     public updateVersion(repository: string, type: string): string {
         try {
             // Validate inputs
@@ -213,6 +113,120 @@ ${unreleasedChangelogSection}`
         }
     }
 
+    public extractChangelog(repository: string, version?: string): string {
+        try {
+            this.validateRepository(repository)
+            const normalizedRepo = this.getNormalizedRepository(repository)
+            const changelogPath = `${normalizedRepo}/CHANGELOG.md`
+            const changelog = fs.readFileSync(changelogPath, "utf8")
+
+            return version ? this.extractChangelogSection(changelog, version) : this.extractChangelogSection(changelog, "unreleased")
+        } catch (error) {
+            console.error(`Error extracting changelog: ${error}`)
+            throw error
+        }
+    }
+
+    private validateRepository(repository: string): asserts repository is Repository {
+        const normalized = repository.toLowerCase()
+        if (normalized !== "visualization" && normalized !== "analysis") {
+            throw new Error(`Invalid repository: ${repository}. Must be either "Visualization" or "Analysis" (case insensitive)`)
+        }
+    }
+
+    private getNormalizedRepository(repository: string): Repository {
+        return repository.toLowerCase() as Repository
+    }
+
+    private validateVersionType(type: string): asserts type is VersionType {
+        if (type !== "major" && type !== "minor" && type !== "patch") {
+            throw new Error(`Invalid version type: ${type}. Must be one of: major, minor, patch`)
+        }
+    }
+
+    private validateFiles(repository: string) {
+        const normalizedRepo = this.getNormalizedRepository(repository)
+        if (normalizedRepo === "visualization") {
+            const visualizationFiles = ["visualization/package.json", "visualization/CHANGELOG.md"]
+            for (const file of visualizationFiles) {
+                if (!fs.existsSync(file)) {
+                    throw new Error(`Required file not found: ${file}`)
+                }
+            }
+        } else {
+            // Analysis repository
+            const analysisFiles = ["analysis/CHANGELOG.md", "analysis/gradle.properties", "analysis/node-wrapper/package.json"]
+            for (const file of analysisFiles) {
+                if (!fs.existsSync(file)) {
+                    throw new Error(`Required file not found: ${file}`)
+                }
+            }
+        }
+    }
+
+    private ensureDirectoryExists(dir: string) {
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true })
+        }
+    }
+
+    private updateReadme(repository: Repository, newVersion: string): void {
+        const readmePath = "README.md"
+
+        let updatedReadme = fs.readFileSync(readmePath, "utf8")
+        updatedReadme = this.replaceVersionBadge(repository, updatedReadme, newVersion)
+        updatedReadme = this.replaceReleaseBadge(repository, updatedReadme, newVersion)
+
+        fs.writeFileSync(readmePath, updatedReadme)
+    }
+
+    private replaceVersionBadge(repository: string, readme: string, newVersion: string): string {
+        const repositoryCapitalized = repository === "visualization" ? "Visualization" : "Analysis"
+
+        const versionBadgeRegex = new RegExp(`alt="${repositoryCapitalized} Version Badge" src="https://img\\.shields\\.io/badge/.*?-`)
+        const matchVersionBadge = versionBadgeRegex.exec(readme)
+
+        if (!matchVersionBadge) {
+            throw new Error(`Could not find version badge for ${repositoryCapitalized} in README.md`)
+        }
+
+        return readme.replace(
+            versionBadgeRegex,
+            `alt="${repositoryCapitalized} Version Badge" src="https://img.shields.io/badge/${newVersion}-`
+        )
+    }
+
+    private replaceReleaseBadge(repository: string, readme: string, newVersion: string): string {
+        const repositoryAbbreviation = repository === "visualization" ? "vis" : "ana"
+        const repositoryCapitalized = repository === "visualization" ? "Visualization" : "Analysis"
+
+        const releaseBadgeRegex = new RegExp(
+            `alt="Release ${repositoryCapitalized} Badge" src="https://img\\.shields\\.io/github/check-runs/MaibornWolff/CodeCharta/${repositoryAbbreviation}-.*?\\?`
+        )
+        const matchReleaseBadge = releaseBadgeRegex.exec(readme)
+
+        if (!matchReleaseBadge) {
+            throw new Error(`Could not find release badge for ${repositoryCapitalized} in README.md`)
+        }
+
+        const updatedReadme = readme.replace(
+            releaseBadgeRegex,
+            `alt="Release ${repositoryCapitalized} Badge" src="https://img.shields.io/github/check-runs/MaibornWolff/CodeCharta/${repositoryAbbreviation}-${newVersion}?`
+        )
+
+        const releaseBadgeRefRegex = new RegExp(`href="https://github\\.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-.*?"`)
+        const matchReleaseBadgeRef = releaseBadgeRefRegex.exec(updatedReadme)
+
+        if (!matchReleaseBadgeRef) {
+            throw new Error(`Could not find release badge reference for ${repositoryCapitalized} in README.md`)
+        }
+
+        return updatedReadme.replace(
+            releaseBadgeRefRegex,
+            `href="https://github.com/MaibornWolff/codecharta/tree/${repositoryAbbreviation}-${newVersion}"`
+        )
+    }
+
     private extractChangelogSection(changelog: string, version: string): string {
         const lines = changelog.split("\n")
         const startIndex = lines.findIndex(line => line.includes(`## [${version}]`))
@@ -240,20 +254,6 @@ ${unreleasedChangelogSection}`
         }
 
         return content
-    }
-
-    public extractChangelog(repository: string, version?: string): string {
-        try {
-            this.validateRepository(repository)
-            const normalizedRepo = this.getNormalizedRepository(repository)
-            const changelogPath = `${normalizedRepo}/CHANGELOG.md`
-            const changelog = fs.readFileSync(changelogPath, "utf8")
-
-            return version ? this.extractChangelogSection(changelog, version) : this.extractChangelogSection(changelog, "unreleased")
-        } catch (error) {
-            console.error(`Error extracting changelog: ${error}`)
-            throw error
-        }
     }
 }
 


### PR DESCRIPTION
# Badges in github readme were red because

Closes: #3951 

## Description

Badges in github readme were red because they also took into account the skipped runs of the release yml. I added shields.io and used custom badges on the release runs to fix this.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
