### PR TITLE
Fix/3988/Unhover updates map after clearing highlights

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+- Fix map highlighting not getting removed when unhovering the file extension distribution bar [#3991](https://github.com/MaibornWolff/codecharta/pull/3991)
+
 ## [1.135.1] - 2025-02-27
 
 ### Fixed 🐞

--- a/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.spec.ts
@@ -54,11 +54,11 @@ describe("CodeMapArrowService", () => {
             getMapMesh: jest.fn().mockReturnValue({
                 getMeshDescription: jest.fn().mockReturnValue({ getBuildingByPath: jest.fn() }),
                 clearHighlight: jest.fn(),
-                highlightBuilding: jest.fn(),
+                clearUnselectedBuildings: jest.fn(),
                 clearSelection: jest.fn(),
                 selectBuilding: jest.fn()
             }),
-            highlightBuildings: jest.fn(),
+            applyHighlights: jest.fn(),
             addBuildingToHighlightingList: jest.fn(),
             getSelectedBuilding: jest.fn().mockReturnValue({
                 value: "value"

--- a/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/arrow/codeMap.arrow.service.ts
@@ -177,13 +177,13 @@ export class CodeMapArrowService implements OnDestroy {
             }
             if (showOutgoingEdges && node.has(originNode.path)) {
                 this.addArrow(originNode, targetNode, true)
-                this.threeSceneService.highlightBuildings()
+                this.threeSceneService.applyHighlights()
                 // TODO: Check if the second part ot the second if case is actually necessary. Edges should
                 // always have valid origin and target paths. The test data is likely
                 // faulty and should be improved.
             } else if (showIncomingEdges && node.has(targetNode.path)) {
                 this.addArrow(originNode, targetNode, false)
-                this.threeSceneService.highlightBuildings()
+                this.threeSceneService.applyHighlights()
             }
         }
     }

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.spec.ts
@@ -163,7 +163,7 @@ describe("codeMapMouseEventService", () => {
             getHighlightedBuilding: jest.fn().mockReturnValue(CODE_MAP_BUILDING),
             getConstantHighlight: jest.fn().mockReturnValue(new Map()),
             addBuildingToHighlightingList: jest.fn(),
-            highlightBuildings: jest.fn(),
+            applyHighlights: jest.fn(),
             resetLabel: jest.fn()
         })()
     }
@@ -437,7 +437,7 @@ describe("codeMapMouseEventService", () => {
             codeMapMouseEventService.updateHovering()
 
             expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalled()
-            expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+            expect(threeSceneService.applyHighlights).toHaveBeenCalled()
             expect(threeSceneService.getLabelForHoveredNode).toHaveBeenCalled()
             expect(threeSceneService.animateLabel).toHaveBeenCalled()
             expect(document.body.style.cursor).toEqual(CursorType.Pointer)
@@ -454,7 +454,7 @@ describe("codeMapMouseEventService", () => {
             codeMapMouseEventService.updateHovering()
 
             expect(threeSceneService.addBuildingToHighlightingList).not.toHaveBeenCalled()
-            expect(threeSceneService.highlightBuildings).not.toHaveBeenCalled()
+            expect(threeSceneService.applyHighlights).not.toHaveBeenCalled()
             expect(document.body.style.cursor).toEqual(CursorType.Grabbing)
         })
 
@@ -469,7 +469,7 @@ describe("codeMapMouseEventService", () => {
             codeMapMouseEventService.updateHovering()
 
             expect(threeSceneService.addBuildingToHighlightingList).not.toHaveBeenCalled()
-            expect(threeSceneService.highlightBuildings).not.toHaveBeenCalled()
+            expect(threeSceneService.applyHighlights).not.toHaveBeenCalled()
             expect(document.body.style.cursor).toEqual(CursorType.Moving)
         })
 
@@ -789,7 +789,7 @@ describe("codeMapMouseEventService", () => {
             codeMapMouseEventService["hoverBuilding"](codeMapBuilding)
 
             expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalledWith(codeMapBuilding)
-            expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+            expect(threeSceneService.applyHighlights).toHaveBeenCalled()
         })
     })
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.mouseEvent.service.ts
@@ -419,7 +419,7 @@ export class CodeMapMouseEventService implements OnDestroy {
                 this.threeSceneService.addBuildingToHighlightingList(building)
             }
         }
-        this.threeSceneService.highlightBuildings()
+        this.threeSceneService.applyHighlights()
         if (updateStore) {
             this.store.dispatch(setHoveredNodeId({ value: hoveredBuilding.node.id }))
         }

--- a/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
+++ b/visualization/app/codeCharta/ui/codeMap/rendering/codeMapMesh.ts
@@ -95,7 +95,7 @@ export class CodeMapMesh {
         this.updateVertices()
     }
 
-    clearHighlight(selected: CodeMapBuilding) {
+    clearUnselectedBuildings(selected: CodeMapBuilding) {
         for (const currentBuilding of this.mapGeomDesc.buildings) {
             if (!this.isBuildingSelected(selected, currentBuilding)) {
                 this.setVertexColor(

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.spec.ts
@@ -54,7 +54,7 @@ describe("ThreeSceneService", () => {
             threeSceneService["mapMesh"].highlightBuilding = jest.fn()
             threeSceneService["threeRendererService"].render = jest.fn()
 
-            threeSceneService.highlightBuildings()
+            threeSceneService.applyHighlights()
 
             expect(threeSceneService["mapMesh"].highlightBuilding).toHaveBeenCalledWith(
                 threeSceneService["highlighted"],
@@ -184,13 +184,13 @@ describe("ThreeSceneService", () => {
     describe("highlightSingleBuilding", () => {
         it("should add a building to the highlighting list and call the highlight function", () => {
             threeSceneService.addBuildingToHighlightingList = jest.fn()
-            threeSceneService.highlightBuildings = jest.fn()
+            threeSceneService.applyHighlights = jest.fn()
             threeSceneService["highlighted"] = []
 
             threeSceneService.highlightSingleBuilding(CODE_MAP_BUILDING)
 
             expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalled()
-            expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+            expect(threeSceneService.applyHighlights).toHaveBeenCalled()
         })
     })
 
@@ -233,6 +233,14 @@ describe("ThreeSceneService", () => {
             threeSceneService.clearHighlight()
 
             expect(threeSceneService["highlighted"]).toHaveLength(0)
+        })
+    })
+
+    describe("applyClearHightlights", () => {
+        it("should call clearHightlight and render changes", () => {
+            threeSceneService.applyClearHightlights()
+
+            expect(threeSceneService["threeRendererService"].render).toHaveBeenCalled
         })
     })
 

--- a/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
+++ b/visualization/app/codeCharta/ui/codeMap/threeViewer/threeSceneService.ts
@@ -118,12 +118,17 @@ export class ThreeSceneService implements OnDestroy {
         return this.constantHighlight
     }
 
-    highlightBuildings() {
+    applyHighlights() {
         const state = this.state.getValue() as CcState
         this.getMapMesh().highlightBuilding(this.highlighted, this.selected, state, this.constantHighlight)
         if (this.mapGeometry.children[0]) {
             this.highlightMaterial(this.mapGeometry.children[0]["material"])
         }
+        this.threeRendererService.render()
+    }
+
+    applyClearHightlights() {
+        this.clearHighlight()
         this.threeRendererService.render()
     }
 
@@ -174,7 +179,7 @@ export class ThreeSceneService implements OnDestroy {
     highlightSingleBuilding(building: CodeMapBuilding) {
         this.highlighted = []
         this.addBuildingToHighlightingList(building)
-        this.highlightBuildings()
+        this.applyHighlights()
     }
 
     addBuildingToHighlightingList(building: CodeMapBuilding) {
@@ -183,12 +188,12 @@ export class ThreeSceneService implements OnDestroy {
 
     clearHoverHighlight() {
         this.highlighted = []
-        this.highlightBuildings()
+        this.applyHighlights()
     }
 
     clearHighlight() {
         if (this.getMapMesh()) {
-            this.getMapMesh().clearHighlight(this.selected)
+            this.getMapMesh().clearUnselectedBuildings(this.selected)
             this.highlighted = []
             this.constantHighlight.clear()
             if (this.mapGeometry.children[0]) {
@@ -205,7 +210,7 @@ export class ThreeSceneService implements OnDestroy {
 
         this.getMapMesh().selectBuilding(building, this.folderLabelColorSelected)
         this.selected = building
-        this.highlightBuildings()
+        this.applyHighlights()
 
         this.eventEmitter.emit("onBuildingSelected", { building: this.selected })
         if (this.mapGeometry.children[0]) {
@@ -380,7 +385,7 @@ export class ThreeSceneService implements OnDestroy {
         }
 
         if (this.highlighted.length > 0) {
-            this.highlightBuildings()
+            this.applyHighlights()
         }
         this.selected = null
         if (this.mapGeometry.children[0]) {

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -24,8 +24,12 @@ describe("fileExtensionBarComponent", () => {
                                 buildings: [CODE_MAP_BUILDING_TS_NODE]
                             })
                         }),
+                        threeRendererService: {
+                            render: jest.fn()
+                        },
                         addBuildingToHighlightingList: jest.fn(),
-                        highlightBuildings: jest.fn()
+                        applyHighlights: jest.fn(),
+                        applyClearHightlights: jest.fn()
                     }
                 },
                 provideMockStore({
@@ -70,10 +74,14 @@ describe("fileExtensionBarComponent", () => {
 
     it("should highlight buildings on hover", async () => {
         await render(FileExtensionBarComponent)
-        await userEvent.hover(screen.getByText("ts 100.00%"))
+        const fileExtensionElement = screen.getByText("ts 100.00%")
+        await userEvent.hover(fileExtensionElement)
 
         const threeSceneService = TestBed.inject<ThreeSceneService>(ThreeSceneService)
         expect(threeSceneService.addBuildingToHighlightingList).toHaveBeenCalledWith(CODE_MAP_BUILDING_TS_NODE)
-        expect(threeSceneService.highlightBuildings).toHaveBeenCalled()
+        expect(threeSceneService.applyHighlights).toHaveBeenCalled()
+
+        await userEvent.unhover(fileExtensionElement)
+        expect(threeSceneService.applyClearHightlights).toHaveBeenCalled()
     })
 })

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
@@ -47,11 +47,11 @@ export class FileExtensionBarComponent {
             }
         }
 
-        this.threeSceneService.highlightBuildings()
+        this.threeSceneService.applyHighlights()
     }
 
     onUnhoverFileExtensionBar() {
-        this.threeSceneService.clearHighlight()
+        this.threeSceneService.applyClearHightlights()
     }
 
     toggleShowDetails() {


### PR DESCRIPTION
### Fix Leaving the code distribution bar, leaves the code highlighted 

Closes: #3988

## Description

- adds a new function that calls the existing clear highlights and applies those changes via re-rendering 
- refactors some functions names that were unclear

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

