### PR TITLE
fix/4011/remove-unexpected-parent-folder

### DIFF
--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/coverage/strategies/JavaStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/importer/coverage/strategies/JavaStrategy.kt
@@ -62,7 +62,7 @@ class JavaStrategy : ImporterStrategy {
             val sourceFileName = classElement.getAttribute("sourcefilename")
             val fileNode = createFileNode(sourceFileName, classElement)
 
-            val path = PathFactory.fromFileSystemPath(className)
+            val path = PathFactory.fromFileSystemPath(className).parent
             projectBuilder.insertByPath(path, fileNode)
         }
     }

--- a/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/java/coverage.cc.json
+++ b/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/java/coverage.cc.json
@@ -21,130 +21,68 @@
                 "link": "",
                 "children": [
                   {
-                    "name": "Product$ProductDetail",
-                    "type": "Folder",
-                    "attributes": {},
+                    "name": "App.java",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 0.0,
+                      "instruction_coverage": 0.0,
+                      "complexity_coverage": 0.0,
+                      "method_coverage": 0.0,
+                      "class_coverage": 0.0
+                    },
                     "link": "",
-                    "children": [
-                      {
-                        "name": "Product.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 100.0,
-                          "instruction_coverage": 100.0,
-                          "complexity_coverage": 100.0,
-                          "method_coverage": 100.0,
-                          "class_coverage": 100.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
+                    "children": []
                   },
                   {
-                    "name": "App",
-                    "type": "Folder",
-                    "attributes": {},
+                    "name": "Order.java",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 85.71,
+                      "instruction_coverage": 93.75,
+                      "complexity_coverage": 75.0,
+                      "method_coverage": 75.0,
+                      "class_coverage": 50.0
+                    },
                     "link": "",
-                    "children": [
-                      {
-                        "name": "App.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 0.0,
-                          "instruction_coverage": 0.0,
-                          "complexity_coverage": 0.0,
-                          "method_coverage": 0.0,
-                          "class_coverage": 0.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
+                    "children": []
                   },
                   {
-                    "name": "Order",
-                    "type": "Folder",
-                    "attributes": {},
+                    "name": "Calculator.java",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 100.0,
+                      "instruction_coverage": 100.0,
+                      "complexity_coverage": 100.0,
+                      "method_coverage": 100.0,
+                      "class_coverage": 100.0
+                    },
                     "link": "",
-                    "children": [
-                      {
-                        "name": "Order.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 85.71,
-                          "instruction_coverage": 93.75,
-                          "complexity_coverage": 75.0,
-                          "method_coverage": 75.0,
-                          "class_coverage": 50.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
+                    "children": []
                   },
                   {
-                    "name": "Calculator",
-                    "type": "Folder",
-                    "attributes": {},
+                    "name": "User.java",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 100.0,
+                      "instruction_coverage": 100.0,
+                      "complexity_coverage": 100.0,
+                      "method_coverage": 100.0,
+                      "class_coverage": 100.0
+                    },
                     "link": "",
-                    "children": [
-                      {
-                        "name": "Calculator.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 100.0,
-                          "instruction_coverage": 100.0,
-                          "complexity_coverage": 100.0,
-                          "method_coverage": 100.0,
-                          "class_coverage": 100.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
+                    "children": []
                   },
                   {
-                    "name": "User",
-                    "type": "Folder",
-                    "attributes": {},
-                    "link": "",
-                    "children": [
-                      {
-                        "name": "User.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 100.0,
-                          "instruction_coverage": 100.0,
-                          "complexity_coverage": 100.0,
-                          "method_coverage": 100.0,
-                          "class_coverage": 100.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
-                  },
-                  {
-                    "name": "Product",
-                    "type": "Folder",
-                    "attributes": {},
-                    "link": "",
-                    "children": [
-                      {
-                        "name": "Product.java",
-                        "type": "File",
-                        "attributes": {
-                          "line_coverage": 100.0,
-                          "instruction_coverage": 100.0,
-                          "complexity_coverage": 100.0,
-                          "method_coverage": 100.0,
-                          "class_coverage": 100.0
-                        },
-                        "link": "",
-                        "children": []
-                      }
-                    ]
+                    "name": "Product.java",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 100.0,
+                      "instruction_coverage": 100.0,
+                      "complexity_coverage": 100.0,
+                      "method_coverage": 100.0,
+                      "class_coverage": 100.0
+                    },
+                    "children": []
                   }
                 ]
               }
@@ -208,5 +146,5 @@
     },
     "blacklist": []
   },
-  "checksum": "be16cfd827200deebed1ec786833a1b8"
+  "checksum": "b7400ba649b5818b25505f7f66d6d0e7"
 }

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/NodeJsonDeserializer.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/NodeJsonDeserializer.kt
@@ -1,4 +1,4 @@
-package model.src.main.kotlin.de.maibornwolff.codecharta.serialization
+package de.maibornwolff.codecharta.serialization
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializationContext

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/ProjectDeserializer.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/ProjectDeserializer.kt
@@ -9,7 +9,6 @@ import de.maibornwolff.codecharta.model.Node
 import de.maibornwolff.codecharta.model.Project
 import de.maibornwolff.codecharta.model.ProjectWrapper
 import de.maibornwolff.codecharta.util.Logger
-import model.src.main.kotlin.de.maibornwolff.codecharta.serialization.NodeJsonDeserializer
 import java.io.FileInputStream
 import java.io.InputStream
 import java.io.Reader

--- a/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/NodeJsonDeserializerTest.kt
+++ b/analysis/model/src/test/kotlin/de/maibornwolff/codecharta/serialization/NodeJsonDeserializerTest.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
 import de.maibornwolff.codecharta.model.MutableNode
 import de.maibornwolff.codecharta.model.NodeType
-import model.src.main.kotlin.de.maibornwolff.codecharta.serialization.NodeJsonDeserializer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith


### PR DESCRIPTION
# Fixes the coverage importer containing an extra parent folder for java

Closes: #4011

## Description

Fixes a bug that causes the coverage importer to include an extra parent folder for each individual file when using it on java/jacoco

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
