### PR TITLE
fix/4026/windows-cmd-ccsh-fix

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Removed Metric Gardener Support [#4004](https://github.com/MaibornWolff/codecharta/pull/4004)
 
+### Fixed 🐞
+
+- Fix ccsh visually breaking on windows cmd [#4027](https://github.com/MaibornWolff/codecharta/pull/4027)
+
 ## [1.132.0] - 2025-03-25
 
 ### Added 🚀

--- a/analysis/node-wrapper/binScripts/global/ccsh.cmd
+++ b/analysis/node-wrapper/binScripts/global/ccsh.cmd
@@ -7,4 +7,4 @@ EXIT /b
 SETLOCAL
 CALL :find_dp0
 
-endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\node_modules\codecharta-analysis\public\bin\ccsh.bat" %*
+"%dp0%\node_modules\codecharta-analysis\public\bin\ccsh.bat" %*

--- a/analysis/node-wrapper/binScripts/local/ccsh.cmd
+++ b/analysis/node-wrapper/binScripts/local/ccsh.cmd
@@ -7,4 +7,4 @@ EXIT /b
 SETLOCAL
 CALL :find_dp0
 
-endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\..\codecharta-analysis\public\bin\ccsh.bat" %*
+"%dp0%\..\codecharta-analysis\public\bin\ccsh.bat" %*


### PR DESCRIPTION
Remove cmd commands before delegating to ccsh.bat to avoid unexpected behavior on windows cmd (#4026)

# Fix ccsh visually breaking on windows cmd

Closes: #4026 

## Description

This PR fixes the ccsh tool on windows cmd which in its current state does weird cmd process termination. As a result, after executing the ccsh command one time the cmd terminal stays in a visually broken state. This PR removes the cmd process manipulation which leaves the terminal in a clean state after executing a ccsh command.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
