### PR TITLE
Feat/3923/multi file input basic

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+- Add support for multi file input in dialogs [#4030](https://github.com/MaibornWolff/codecharta/pull/4030)
+
 ### Changed
 
 - Removed Metric Gardener Support [#4004](https://github.com/MaibornWolff/codecharta/pull/4004)

--- a/analysis/analysers/exporters/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/exporters/csv/Dialog.kt
+++ b/analysis/analysers/exporters/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/exporters/csv/Dialog.kt
@@ -12,9 +12,10 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultFileFolderInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
+                multiple = true,
                 onInputReady = testCallback()
             )
 
@@ -31,8 +32,7 @@ class Dialog {
                     onInputReady = testCallback()
                 )
 
-            return listOfNotNull(
-                inputFileName,
+            return inputFileNames.split(",").map { it.trim() } + listOfNotNull(
                 "--output-file=$outputFileName",
                 "--depth-of-hierarchy=$maxHierarchy"
             )

--- a/analysis/analysers/filters/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/Dialog.kt
+++ b/analysis/analysers/filters/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/Dialog.kt
@@ -17,10 +17,11 @@ import java.io.File
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputDataName: String =
+            val inputFileNames: String =
                 session.promptDefaultFileFolderInput(
                     inputType = InputType.FOLDER_AND_FILE,
                     fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
+                    multiple = true,
                     onInputReady = testCallback()
                 )
 
@@ -96,8 +97,7 @@ class Dialog {
                     onInputReady = testCallback()
                 )
 
-            val basicMergeConfig = listOf(
-                inputDataName,
+            val basicMergeConfig = inputFileNames.split(",").map { it.trim() } + listOf(
                 "--add-missing=$addMissing",
                 "--recursive=${!leafFlag}",
                 "--leaf=$leafFlag",

--- a/analysis/analysers/filters/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/MergeFilterTest.kt
+++ b/analysis/analysers/filters/MergeFilter/src/test/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/MergeFilterTest.kt
@@ -533,17 +533,18 @@ class MergeFilterTest {
 
         @Test
         fun `should output into specified file`() {
-            val outPutFilePath = "$fatMergeTestFolder/largeOutputToFile.cc.json"
+            val outputFilePath = "$fatMergeTestFolder/largeOutputToFile.cc.json"
             CommandLine(MergeFilter()).execute(
                 testFilePath1,
                 testFilePath2,
                 "--large",
-                "-o=$outPutFilePath",
+                "-o=$outputFilePath",
                 "-nc"
             ).toString()
-            val outPutFile = File(outPutFilePath)
-            assertThat(outPutFile).exists()
-            val project = ProjectDeserializer.deserializeProject(outPutFile.inputStream())
+            val outputFile = File(outputFilePath)
+            assertThat(outputFile).exists()
+            val outputFileInputStream = outputFile.inputStream()
+            val project = ProjectDeserializer.deserializeProject(outputFileInputStream)
             val projectInput1 = ProjectDeserializer.deserializeProject(File(testFilePath1).inputStream())
             val projectInput2 = ProjectDeserializer.deserializeProject(File(testFilePath2).inputStream())
             assertThat(project.sizeOfEdges()).isEqualTo(2)
@@ -554,7 +555,8 @@ class MergeFilterTest {
             val outputProject2 = project.rootNode.children.first { it.name == "testProject" }
             assertThat(outputProject1.children.toString()).isEqualTo(projectInput1.rootNode.children.toString())
             assertThat(outputProject2.children.toString()).isEqualTo(projectInput2.rootNode.children.toString())
-            outPutFile.deleteOnExit()
+            outputFileInputStream.close()
+            outputFile.deleteOnExit()
         }
 
         @Test

--- a/analysis/analysers/importers/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/Dialog.kt
+++ b/analysis/analysers/importers/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/Dialog.kt
@@ -12,9 +12,10 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultFileFolderInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
+                multiple = true,
                 onInputReady = testCallback()
             )
 
@@ -48,8 +49,7 @@ class Dialog {
                 onInputReady = testCallback()
             )
 
-            return listOfNotNull(
-                inputFileName,
+            return inputFileNames.split(",").map { it.trim() } + listOfNotNull(
                 "--output-file=$outputFileName",
                 "--path-column-name=$pathColumnName",
                 "--delimiter=$delimiter",

--- a/analysis/analysers/importers/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/DialogTest.kt
+++ b/analysis/analysers/importers/CSVImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/DialogTest.kt
@@ -11,7 +11,6 @@ import de.maibornwolff.codecharta.analysers.importers.csv.Dialog.Companion.colle
 import io.mockk.every
 import io.mockk.mockkObject
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import picocli.CommandLine
@@ -82,34 +81,36 @@ class DialogTest {
         }
     }
 
-    @Disabled
     @Test
     fun `should output correct arguments when multiple files are provided`() {
-        // New multi input separated by comma, NotImplementedYet
-        val fileName = "in.csv"
-        val fileName2 = "in2.csv"
-        val fileName3 = "in3.csv"
+        val inputFileName2 = "${testResourceBaseFolder}csvimporter_different_path_column_name.csv"
         val outputFileName = "out.cc.json"
         val pathColumnName = "path"
-        val delimiter = ";"
         val pathSeparator = "/"
 
         mockkObject(Dialog.Companion)
 
         testSession { terminal ->
             val fileCallback: suspend RunScope.() -> Unit = {
+                terminal.type(inputFileName)
+                terminal.type(",")
+                terminal.type(inputFileName2)
                 terminal.press(Keys.ENTER)
             }
             val outFileCallback: suspend RunScope.() -> Unit = {
+                terminal.type(outputFileName)
                 terminal.press(Keys.ENTER)
             }
             val columnCallback: suspend RunScope.() -> Unit = {
+                terminal.type(pathColumnName)
                 terminal.press(Keys.ENTER)
             }
             val delimiterCallback: suspend RunScope.() -> Unit = {
+                terminal.press(Keys.RIGHT)
                 terminal.press(Keys.ENTER)
             }
             val separatorCallback: suspend RunScope.() -> Unit = {
+                terminal.type(pathSeparator)
                 terminal.press(Keys.ENTER)
             }
             val compressCallback: suspend RunScope.() -> Unit = {
@@ -133,12 +134,11 @@ class DialogTest {
             assertThat(parseResult.matchedOption("output-file").getValue<String>()).isEqualTo(outputFileName)
             assertThat(parseResult.matchedOption("path-column-name").getValue<String>())
                 .isEqualTo(pathColumnName)
-            assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(delimiter[0])
+            assertThat(parseResult.matchedOption("delimiter").getValue<Char>()).isEqualTo(',')
             assertThat(parseResult.matchedOption("path-separator").getValue<Char>()).isEqualTo(pathSeparator[0])
             assertThat(parseResult.matchedOption("not-compressed")).isNull()
-            assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(fileName)
-            assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(fileName2)
-            assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[2].name).isEqualTo(fileName3)
+            assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[0].name).isEqualTo(File(inputFileName).name)
+            assertThat(parseResult.matchedPositional(0).getValue<ArrayList<File>>()[1].name).isEqualTo(File(inputFileName2).name)
         }
     }
 

--- a/analysis/analysers/importers/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/codemaat/Dialog.kt
+++ b/analysis/analysers/importers/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/codemaat/Dialog.kt
@@ -12,9 +12,10 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultFileFolderInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
+                multiple = true,
                 onInputReady = testCallback()
             )
 
@@ -32,8 +33,7 @@ class Dialog {
                         onInputReady = testCallback()
                     )
 
-            return listOfNotNull(
-                inputFileName,
+            return inputFileNames.split(",").map { it.trim() } + listOfNotNull(
                 "--output-file=$outputFileName",
                 if (isCompressed) null else "--not-compressed"
             )

--- a/analysis/analysers/importers/CodeMaatImporter/src/test/resources/testFile.csv
+++ b/analysis/analysers/importers/CodeMaatImporter/src/test/resources/testFile.csv
@@ -1,0 +1,1 @@
+someTestFile

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JavaScriptStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JavaScriptStrategy.kt
@@ -54,7 +54,7 @@ class JavaScriptStrategy() : ImporterStrategy {
                         val file = File(filePath)
                         val fileName = file.name
                         val directoryPath = file.parent ?: ""
-                        val path = PathFactory.fromFileSystemPath(directoryPath)
+                        val path = PathFactory.fromFileSystemPath(directoryPath, File.separatorChar)
 
                         val lineCoverage = calculatePercentage(linesHit, linesFound)
                         val branchCoverage = calculatePercentage(branchesHit, branchesFound)

--- a/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporterTest.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporterTest.kt
@@ -59,7 +59,7 @@ class CoverageImporterTest {
         CommandLine(CoverageImporter()).execute(notExistingFile.path, "--language=javascript")
         System.setErr(originalErr)
 
-        assertThat(errContent.toString()).startsWith("java.io.FileNotFoundException: File not found: src/test/lcov.info")
+        assertThat(errContent.toString()).startsWith("java.io.FileNotFoundException: File not found: ${notExistingFile.path}")
     }
 
     @Test

--- a/analysis/analysers/importers/SourceMonitorImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sourcemonitor/Dialog.kt
+++ b/analysis/analysers/importers/SourceMonitorImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sourcemonitor/Dialog.kt
@@ -12,9 +12,10 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName = session.promptDefaultFileFolderInput(
+            val inputFileNames = session.promptDefaultFileFolderInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
+                multiple = true,
                 onInputReady = testCallback()
             )
 
@@ -29,8 +30,7 @@ class Dialog {
                 onInputReady = testCallback()
             )
 
-            return listOfNotNull(
-                inputFileName,
+            return inputFileNames.split(",").map { it.trim() } + listOfNotNull(
                 "--output-file=$outputFileName",
                 if (isCompressed) null else "--not-compressed"
             )

--- a/analysis/analysers/importers/SourceMonitorImporter/src/test/resources/testFile.csv
+++ b/analysis/analysers/importers/SourceMonitorImporter/src/test/resources/testFile.csv
@@ -1,0 +1,1 @@
+someTestFile

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -204,45 +204,49 @@ private fun getSelectedChoices(choices: List<String>, selection: List<Boolean>):
 fun Session.promptDefaultFileFolderInput(
     inputType: InputType,
     fileExtensionList: List<FileExtension>,
+    multiple: Boolean = false,
     onInputReady: suspend RunScope.() -> Unit
 ): String {
-    val messageFileExtension = "[${fileExtensionList.map { fileExtension -> fileExtension.extension }.joinToString(", ")}]"
+    val messageFileExtension = "[${fileExtensionList.joinToString(", ") { fileExtension -> fileExtension.extension }}]"
+    val pluralSuffix = if (multiple) "(s)" else ""
+
     val inputMessage: String =
         if (fileExtensionList.isEmpty()) {
             when (inputType) {
                 InputType.FOLDER -> {
-                    "folder"
+                    "folder$pluralSuffix"
                 }
                 InputType.FILE -> {
-                    "file"
+                    "file$pluralSuffix"
                 }
                 else -> {
-                    "folder or file"
+                    "folder$pluralSuffix or file$pluralSuffix"
                 }
             }
         } else {
             when (inputType) {
                 InputType.FOLDER -> {
-                    "folder of $messageFileExtension files"
+                    "folder$pluralSuffix of $messageFileExtension files"
                 }
                 InputType.FILE -> {
-                    "$messageFileExtension file"
+                    "$messageFileExtension file$pluralSuffix"
                 }
                 else -> {
-                    "folder or $messageFileExtension file"
+                    "folder$pluralSuffix or $messageFileExtension file$pluralSuffix"
                 }
             }
         }
     val currentWorkingDirectory = Paths.get("").toAbsolutePath().toString()
 
     return promptInput(
-        message = "What is the input $inputMessage",
+        message = "What ${if (multiple) "are" else "is"} the input $inputMessage",
         hint = currentWorkingDirectory,
         allowEmptyInput = false,
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
         inputValidator = InputValidator.isFileOrFolderValid(
             inputType,
-            fileExtensionList
+            fileExtensionList,
+            multiple = multiple
         ),
         onInputReady = onInputReady
     )

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -214,7 +214,8 @@ fun Session.promptDefaultFileFolderInput(
     val messageExtension: String
     if (multiple) {
         pluralSuffix = "(s)"
-        hintText = "input1.txt, input2.log, ..."
+        val sampleFileExtension = if (fileExtensionList.isEmpty()) "" else fileExtensionList.first().extension
+        hintText = "input1$sampleFileExtension, input2$sampleFileExtension, ..."
         messageExtension = " Enter multiple files comma separated."
     } else {
         pluralSuffix = ""

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -208,7 +208,19 @@ fun Session.promptDefaultFileFolderInput(
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     val messageFileExtension = "[${fileExtensionList.joinToString(", ") { fileExtension -> fileExtension.extension }}]"
-    val pluralSuffix = if (multiple) "(s)" else ""
+
+    val pluralSuffix: String
+    val hintText: String
+    val messageExtension: String
+    if (multiple) {
+        pluralSuffix = "(s)"
+        hintText = "input1.txt, input2.log, ..."
+        messageExtension = " Enter multiple files comma separated."
+    } else {
+        pluralSuffix = ""
+        hintText = Paths.get("").toAbsolutePath().toString()
+        messageExtension = ""
+    }
 
     val inputMessage: String =
         if (fileExtensionList.isEmpty()) {
@@ -236,11 +248,10 @@ fun Session.promptDefaultFileFolderInput(
                 }
             }
         }
-    val currentWorkingDirectory = Paths.get("").toAbsolutePath().toString()
 
     return promptInput(
-        message = "What ${if (multiple) "are" else "is"} the input $inputMessage",
-        hint = currentWorkingDirectory,
+        message = "What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
+        hint = hintText,
         allowEmptyInput = false,
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
         inputValidator = InputValidator.isFileOrFolderValid(

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidator.kt
@@ -11,23 +11,31 @@ class InputValidator {
             file.exists() && file.isFile && isFileCorrectType
         }
 
-        fun isFileOrFolderValid(inputType: InputType, fileExtensionList: List<FileExtension>): (String) -> Boolean = { input ->
-            val objectToVerify = File(input)
-            objectToVerify.exists() && when (inputType) {
-                InputType.FOLDER -> {
-                    objectToVerify.isDirectory
-                }
-                InputType.FILE -> {
-                    verifyFile(
-                        objectToVerify,
-                        fileExtensionList
-                    )
-                }
-                else -> {
-                    objectToVerify.isDirectory || verifyFile(
-                        objectToVerify,
-                        fileExtensionList
-                    )
+        fun isFileOrFolderValid(
+            inputType: InputType,
+            fileExtensionList: List<FileExtension>,
+            multiple: Boolean = false
+        ): (String) -> Boolean = { input ->
+            if (multiple) {
+                input.split(",").all { isFileOrFolderValid(inputType, fileExtensionList, false)(it.trim()) }
+            } else {
+                val objectToVerify = File(input)
+                objectToVerify.exists() && when (inputType) {
+                    InputType.FOLDER -> {
+                        objectToVerify.isDirectory
+                    }
+                    InputType.FILE -> {
+                        verifyFile(
+                            objectToVerify,
+                            fileExtensionList
+                        )
+                    }
+                    else -> {
+                        objectToVerify.isDirectory || verifyFile(
+                            objectToVerify,
+                            fileExtensionList
+                        )
+                    }
                 }
             }
         }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -15,7 +15,10 @@ import com.varabyte.kotterx.test.foundation.testSession
 import com.varabyte.kotterx.test.runtime.blockUntilRenderWhen
 import com.varabyte.kotterx.test.runtime.stripFormatting
 import com.varabyte.kotterx.test.terminal.assertMatches
+import de.maibornwolff.codecharta.serialization.FileExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class DialogProviderTest {
@@ -38,695 +41,802 @@ class DialogProviderTest {
             "element 3"
         )
 
-    // Tests for promptInput
+    @Nested
+    @DisplayName("promptInput > ")
+    inner class PromptInputTests {
+        // Tests for promptInput
 
-    @Test
-    fun `should correctly apply the text formatting when prompt is first displayed`() {
-        testSession { terminal ->
-            promptInput(testMessage, testHint, true, testInvalidInputMessage, onInputReady = {
-                terminal.assertMatches {
-                    bold {
-                        green { text("? ") }
-                        text(testMessage)
-                        black(isBright = true) { textLine("  $emptyInputAllowedMessage") }
+        @Test
+        fun `should correctly apply the text formatting when prompt is first displayed`() {
+            testSession { terminal ->
+                promptInput(testMessage, testHint, true, testInvalidInputMessage, onInputReady = {
+                    terminal.assertMatches {
+                        bold {
+                            green { text("? ") }
+                            text(testMessage)
+                            black(isBright = true) { textLine("  $emptyInputAllowedMessage") }
+                        }
+                        text("> ")
+                        black(isBright = true) {
+                            invert { text("${testHint[0]}") }
+                            text("${testHint.drop(1)} ")
+                        }
                     }
-                    text("> ")
-                    black(isBright = true) {
-                        invert { text("${testHint[0]}") }
-                        text("${testHint.drop(1)} ")
-                    }
-                }
-                terminal.press(Keys.ENTER)
-            })
-        }
-    }
-
-    @Test
-    fun `should return user input when no validity checker was specified`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptInput(testMessage, onInputReady = {
-                    terminal.type(testInput)
                     terminal.press(Keys.ENTER)
                 })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage",
-                "> $testInput ",
-                ""
-            )
-            assertThat(result).isEqualTo(testInput)
+            }
         }
-    }
 
-    @Test
-    fun `should return empty input when the option to allow empty input was set`() {
-        var result: String
+        @Test
+        fun `should return user input when no validity checker was specified`() {
+            var result: String
 
-        testSession { terminal ->
-            result =
-                promptInput(testMessage, allowEmptyInput = true, onInputReady = {
-                    terminal.press(Keys.ENTER)
+            testSession { terminal ->
+                result =
+                    promptInput(testMessage, onInputReady = {
+                        terminal.type(testInput)
+                        terminal.press(Keys.ENTER)
+                    })
 
-                    assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                        "? $testMessage  $emptyInputAllowedMessage",
-                        ">  ",
-                        ""
-                    )
-                })
-            assertThat(result).isEqualTo("")
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $testInput ",
+                    ""
+                )
+                assertThat(result).isEqualTo(testInput)
+            }
         }
-    }
 
-    @Test
-    fun `should not accept empty input and display warning message when empty input is not allowed`() {
-        testSession { terminal ->
-            promptInput(
-                testMessage,
-                allowEmptyInput = false,
-                onInputReady = {
-                    terminal.press(Keys.ENTER)
+        @Test
+        fun `should return empty input when the option to allow empty input was set`() {
+            var result: String
 
-                    blockUntilRenderWhen {
-                        terminal.resolveRerenders().stripFormatting() ==
-                            listOf(
-                                "? $testMessage  $emptyInputNotAllowedMessage",
-                                ">  ",
-                                ""
-                            )
-                    }
+            testSession { terminal ->
+                result =
+                    promptInput(testMessage, allowEmptyInput = true, onInputReady = {
+                        terminal.press(Keys.ENTER)
 
-                    terminal.type("irrelevant non empty input")
-                    terminal.press(Keys.ENTER)
-                }
-            )
+                        assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                            "? $testMessage  $emptyInputAllowedMessage",
+                            ">  ",
+                            ""
+                        )
+                    })
+                assertThat(result).isEqualTo("")
+            }
         }
-    }
 
-    @Test
-    fun `should return input when a validity checker was specified and input is valid`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptInput(testMessage, inputValidator = { true }, onInputReady = {
-                    terminal.type(testInput)
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(result).isEqualTo(testInput)
-        }
-    }
-
-    @Test
-    fun `should return empty input when option to allow empty input was set but the specified validity checker would not allow it`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptInput(testMessage, allowEmptyInput = true, inputValidator = { false }, onInputReady = {
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(result).isEqualTo("")
-        }
-    }
-
-    @Test
-    fun `should not accept input and display default warning message when input was invalid`() {
-        testSession { terminal ->
-            promptInput(
-                testMessage,
-                allowEmptyInput = false,
-                inputValidator = { input -> input.contains("accepted") },
-                onInputReady = {
-                    terminal.type("x")
-                    terminal.press(Keys.ENTER)
-
-                    blockUntilRenderWhen {
-                        terminal.resolveRerenders().stripFormatting() ==
-                            listOf(
-                                "? $testMessage  Input is invalid!",
-                                "> x ",
-                                ""
-                            )
-                    }
-
-                    terminal.type("accepted")
-                    terminal.press(Keys.ENTER)
-                }
-            )
-        }
-    }
-
-    @Test
-    fun `should not accept invalid input and display custom warning message when a custom invalid input message was specified`() {
-        testSession { terminal ->
-            promptInput(
-                testMessage,
-                allowEmptyInput = false,
-                invalidInputMessage = testInvalidInputMessage,
-                inputValidator = { input -> input.contains("accepted") },
-                onInputReady = {
-                    terminal.type("x")
-                    terminal.press(Keys.ENTER)
-
-                    blockUntilRenderWhen {
-                        terminal.resolveRerenders().stripFormatting() ==
-                            listOf(
-                                "? $testMessage  $testInvalidInputMessage",
-                                "> x ",
-                                ""
-                            )
-                    }
-
-                    terminal.type("accepted")
-                    terminal.press(Keys.ENTER)
-                }
-            )
-        }
-    }
-
-    // Tests for promptInputNumber (mostly covered by above tests already)
-
-    @Test
-    fun `should ignore all input characters that are not numbers`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptInputNumber(testMessage, onInputReady = {
-                    terminal.type("test 1, test 2; test 3.?/%!IV")
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(result).isEqualTo("123")
-        }
-    }
-
-    @Test
-    fun `should not accept input if invalid`() {
-        var rendered: List<String> = listOf()
-        testSession { terminal ->
-            val result =
-                promptInputNumber(
+        @Test
+        fun `should not accept empty input and display warning message when empty input is not allowed`() {
+            testSession { terminal ->
+                promptInput(
                     testMessage,
-                    invalidInputMessage = testInvalidInputMessage,
-                    inputValidator = InputValidator.isNumberGreaterThen(
-                        2
-                    ),
+                    allowEmptyInput = false,
                     onInputReady = {
-                        terminal.type("1")
                         terminal.press(Keys.ENTER)
 
                         blockUntilRenderWhen {
-                            rendered = terminal.resolveRerenders().stripFormatting()
-                            rendered.any { it.contains(testInvalidInputMessage) }
+                            terminal.resolveRerenders().stripFormatting() ==
+                                listOf(
+                                    "? $testMessage  $emptyInputNotAllowedMessage",
+                                    ">  ",
+                                    ""
+                                )
                         }
 
-                        terminal.press(Keys.BACKSPACE)
-                        terminal.type("3")
+                        terminal.type("irrelevant non empty input")
                         terminal.press(Keys.ENTER)
                     }
                 )
-
-            assertThat(rendered).isEqualTo(
-                listOf(
-                    "? $testMessage  $testInvalidInputMessage",
-                    "> 1 ",
-                    ""
-                )
-            )
-            assertThat(result).isEqualTo("3")
+            }
         }
-    }
 
-    @Test
-    fun `should accept empty number input`() {
-        testSession { terminal ->
-            val result = promptInputNumber(testMessage, allowEmptyInput = true, onInputReady = {
-                terminal.press(Keys.ENTER)
-            })
-            assertThat(result).isEqualTo("")
+        @Test
+        fun `should return input when a validity checker was specified and input is valid`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptInput(testMessage, inputValidator = { true }, onInputReady = {
+                        terminal.type(testInput)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(result).isEqualTo(testInput)
+            }
         }
-    }
 
-    @Test
-    fun `should accept empty input but still check if valid`() {
-        testSession { terminal ->
-            val result =
-                promptInputNumber(
+        @Test
+        fun `should return empty input when option to allow empty input was set but the specified validity checker would not allow it`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptInput(testMessage, allowEmptyInput = true, inputValidator = { false }, onInputReady = {
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(result).isEqualTo("")
+            }
+        }
+
+        @Test
+        fun `should not accept input and display default warning message when input was invalid`() {
+            testSession { terminal ->
+                promptInput(
                     testMessage,
-                    allowEmptyInput = true,
-                    inputValidator = InputValidator.isNumberGreaterThen(
-                        2
-                    ),
+                    allowEmptyInput = false,
+                    inputValidator = { input -> input.contains("accepted") },
                     onInputReady = {
-                        terminal.type("1")
+                        terminal.type("x")
                         terminal.press(Keys.ENTER)
-                        terminal.press(Keys.BACKSPACE)
+
+                        blockUntilRenderWhen {
+                            terminal.resolveRerenders().stripFormatting() ==
+                                listOf(
+                                    "? $testMessage  Input is invalid!",
+                                    "> x ",
+                                    ""
+                                )
+                        }
+
+                        terminal.type("accepted")
                         terminal.press(Keys.ENTER)
                     }
                 )
-
-            assertThat(result).isEqualTo("")
+            }
         }
-    }
 
-    // Tests for promptConfirm
+        @Test
+        fun `should not accept invalid input and display custom warning message when a custom invalid input message was specified`() {
+            testSession { terminal ->
+                promptInput(
+                    testMessage,
+                    allowEmptyInput = false,
+                    invalidInputMessage = testInvalidInputMessage,
+                    inputValidator = { input -> input.contains("accepted") },
+                    onInputReady = {
+                        terminal.type("x")
+                        terminal.press(Keys.ENTER)
 
-    @Test
-    fun `should correctly display all text formatting when prompt is first displayed`() {
-        testSession { terminal ->
-            promptConfirm(testMessage, testHint, onInputReady = {
-                terminal.assertMatches {
-                    bold {
-                        green { text("? ") }
-                        text(testMessage)
-                        black(isBright = true) { textLine("  $testHint") }
+                        blockUntilRenderWhen {
+                            terminal.resolveRerenders().stripFormatting() ==
+                                listOf(
+                                    "? $testMessage  $testInvalidInputMessage",
+                                    "> x ",
+                                    ""
+                                )
+                        }
+
+                        terminal.type("accepted")
+                        terminal.press(Keys.ENTER)
                     }
-                    text("> ")
-                    cyan { text("[Yes]") }
-                    textLine(" No ")
-                }
-                terminal.press(Keys.ENTER)
-            })
-        }
-    }
-
-    @Test
-    fun `should return true and display correct state when no arrow keys were pressed`() {
-        var result: Boolean
-
-        testSession { terminal ->
-            result =
-                promptConfirm(testMessage, onInputReady = {
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  arrow keys to change selection",
-                "> [Yes] No ",
-                ""
-            )
-            assertThat(result).isTrue()
-        }
-    }
-
-    @Test
-    fun `should return false and display correct state when right arrow key was pressed`() {
-        var result: Boolean
-
-        testSession { terminal ->
-            result =
-                promptConfirm(testMessage, testHint, onInputReady = {
-                    terminal.press(Keys.RIGHT)
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                ">  Yes [No]",
-                ""
-            )
-            assertThat(result).isFalse()
-        }
-    }
-
-    @Test
-    fun `should correctly return when arrow keys were pressed multiple times`() {
-        var result: Boolean
-
-        testSession { terminal ->
-            result =
-                promptConfirm(testMessage, onInputReady = {
-                    repeat(5) {
-                        terminal.press(Keys.RIGHT)
-                    }
-                    terminal.press(Keys.LEFT)
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(result).isTrue()
-        }
-    }
-
-    // Tests for promptList
-
-    @Test
-    fun `should display all list options that were specified in the correct format when prompt is first displayed`() {
-        testSession { terminal ->
-            promptList(testMessage, testChoices, testHint, onInputReady = {
-                terminal.assertMatches {
-                    bold {
-                        green { text("? ") }
-                        text(testMessage)
-                        black(isBright = true) { textLine("  $testHint") }
-                    }
-                    cyan(isBright = true) { text(" ❯ ") }
-                    cyan { textLine(testChoices[0]) }
-                    for (testItem in testChoices.drop(1)) {
-                        textLine("   $testItem")
-                    }
-                }
-                terminal.press(Keys.ENTER)
-            })
-        }
-    }
-
-    @Test
-    fun `should select the first list option when no arrow keys were pressed`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptList(testMessage, testChoices, onInputReady = {
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  arrow keys to move, ENTER to select",
-                " ❯ element 0",
-                "   element 1",
-                "   element 2",
-                "   element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(testChoices[0])
-        }
-    }
-
-    @Test
-    fun `should select the second list option when arrow down was pressed once after multiple up`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptList(testMessage, testChoices, onInputReady = {
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  arrow keys to move, ENTER to select",
-                "   element 0",
-                " ❯ element 1",
-                "   element 2",
-                "   element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(testChoices[1])
-        }
-    }
-
-    @Test
-    fun `should not go up if in first position`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptList(testMessage, testChoices, onInputReady = {
-                    repeat(5) {
-                        terminal.press(Keys.UP)
-                    }
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.UP)
-                    repeat(2) {
-                        terminal.press(Keys.DOWN)
-                    }
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  arrow keys to move, ENTER to select",
-                "   element 0",
-                "   element 1",
-                " ❯ element 2",
-                "   element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(testChoices[2])
-        }
-    }
-
-    @Test
-    fun `should select the last list option when arrow down was pressed more often than there are options`() {
-        var result: String
-
-        testSession { terminal ->
-            result =
-                promptList(testMessage, testChoices, onInputReady = {
-                    repeat(6) {
-                        terminal.press(Keys.DOWN)
-                    }
-                    terminal.press(Keys.ENTER)
-                })
-
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  arrow keys to move, ENTER to select",
-                "   element 0",
-                "   element 1",
-                "   element 2",
-                " ❯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(testChoices.last())
-        }
-    }
-
-    // Tests for promptCheckbox
-
-    @Test
-    fun `should display all checkbox options that were specified in the correct format when the first option is selected`() {
-        testSession { terminal ->
-            promptCheckbox(testMessage, testChoices, testHint, true, onInputReady = {
-                terminal.press(Keys.SPACE)
-                terminal.press(Keys.ENTER)
-            })
-            terminal.assertMatches {
-                bold {
-                    green { text("? ") }
-                    text(testMessage)
-                    black(isBright = true) { textLine("  $testHint  $emptySelectionAllowedMessage") }
-                }
-                cyan(isBright = true) { text(" ❯ ") }
-                green { text("◉ ") }
-                cyan { textLine(testChoices[0]) }
-                for (testItem in testChoices.drop(1)) {
-                    cyan(isBright = true) { text("   ") }
-                    textLine("◯ $testItem")
-                }
+                )
             }
         }
     }
 
-    @Test
-    fun `should return empty input when no input was selected and empty input is allowed`() {
-        var result: List<String>
-        val emptyList = listOf<String>()
+    @Nested
+    @DisplayName("promptInputNumber > ")
+    inner class PromptInputNumberTests {
+        // Tests for promptInputNumber (mostly covered by above tests already)
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, allowEmptyInput = true, onInputReady = {
+        @Test
+        fun `should ignore all input characters that are not numbers`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptInputNumber(testMessage, onInputReady = {
+                        terminal.type("test 1, test 2; test 3.?/%!IV")
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(result).isEqualTo("123")
+            }
+        }
+
+        @Test
+        fun `should not accept input if invalid`() {
+            var rendered: List<String> = listOf()
+            testSession { terminal ->
+                val result =
+                    promptInputNumber(
+                        testMessage,
+                        invalidInputMessage = testInvalidInputMessage,
+                        inputValidator = InputValidator.isNumberGreaterThen(
+                            2
+                        ),
+                        onInputReady = {
+                            terminal.type("1")
+                            terminal.press(Keys.ENTER)
+
+                            blockUntilRenderWhen {
+                                rendered = terminal.resolveRerenders().stripFormatting()
+                                rendered.any { it.contains(testInvalidInputMessage) }
+                            }
+
+                            terminal.press(Keys.BACKSPACE)
+                            terminal.type("3")
+                            terminal.press(Keys.ENTER)
+                        }
+                    )
+
+                assertThat(rendered).isEqualTo(
+                    listOf(
+                        "? $testMessage  $testInvalidInputMessage",
+                        "> 1 ",
+                        ""
+                    )
+                )
+                assertThat(result).isEqualTo("3")
+            }
+        }
+
+        @Test
+        fun `should accept empty number input`() {
+            testSession { terminal ->
+                val result = promptInputNumber(testMessage, allowEmptyInput = true, onInputReady = {
                     terminal.press(Keys.ENTER)
                 })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint  $emptySelectionAllowedMessage",
-                " ❯ ◯ element 0",
-                "   ◯ element 1",
-                "   ◯ element 2",
-                "   ◯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(emptyList)
+                assertThat(result).isEqualTo("")
+            }
+        }
+
+        @Test
+        fun `should accept empty input but still check if valid`() {
+            testSession { terminal ->
+                val result =
+                    promptInputNumber(
+                        testMessage,
+                        allowEmptyInput = true,
+                        inputValidator = InputValidator.isNumberGreaterThen(
+                            2
+                        ),
+                        onInputReady = {
+                            terminal.type("1")
+                            terminal.press(Keys.ENTER)
+                            terminal.press(Keys.BACKSPACE)
+                            terminal.press(Keys.ENTER)
+                        }
+                    )
+
+                assertThat(result).isEqualTo("")
+            }
         }
     }
 
-    @Test
-    fun `should not accept input and display hint when selection is empty and empty input is not allowed`() {
-        testSession { terminal ->
-            promptCheckbox(
-                testMessage,
-                testChoices,
-                testHint,
-                allowEmptyInput = false,
-                onInputReady = {
-                    terminal.press(Keys.ENTER)
+    @Nested
+    @DisplayName("promptConfirm > ")
+    inner class PromptConfirmTests {
+        // Tests for promptConfirm
 
-                    blockUntilRenderWhen {
-                        terminal.resolveRerenders().stripFormatting() ==
-                            listOf(
-                                "? $testMessage  $emptySelectionNotAllowedMessage",
-                                " ❯ ◯ element 0",
-                                "   ◯ element 1",
-                                "   ◯ element 2",
-                                "   ◯ element 3",
-                                ""
-                            )
+        @Test
+        fun `should correctly display all text formatting when prompt is first displayed`() {
+            testSession { terminal ->
+                promptConfirm(testMessage, testHint, onInputReady = {
+                    terminal.assertMatches {
+                        bold {
+                            green { text("? ") }
+                            text(testMessage)
+                            black(isBright = true) { textLine("  $testHint") }
+                        }
+                        text("> ")
+                        cyan { text("[Yes]") }
+                        textLine(" No ")
                     }
-
-                    terminal.press(Keys.SPACE)
-                    terminal.press(Keys.ENTER)
-                }
-            )
-        }
-    }
-
-    @Test
-    fun `should select the first checkbox option when no arrow keys were pressed`() {
-        var result: List<String>
-
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    terminal.press(Keys.SPACE)
                     terminal.press(Keys.ENTER)
                 })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                " ❯ ◉ element 0",
-                "   ◯ element 1",
-                "   ◯ element 2",
-                "   ◯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(listOf(testChoices[0]))
+            }
+        }
+
+        @Test
+        fun `should return true and display correct state when no arrow keys were pressed`() {
+            var result: Boolean
+
+            testSession { terminal ->
+                result =
+                    promptConfirm(testMessage, onInputReady = {
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  arrow keys to change selection",
+                    "> [Yes] No ",
+                    ""
+                )
+                assertThat(result).isTrue()
+            }
+        }
+
+        @Test
+        fun `should return false and display correct state when right arrow key was pressed`() {
+            var result: Boolean
+
+            testSession { terminal ->
+                result =
+                    promptConfirm(testMessage, testHint, onInputReady = {
+                        terminal.press(Keys.RIGHT)
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    ">  Yes [No]",
+                    ""
+                )
+                assertThat(result).isFalse()
+            }
+        }
+
+        @Test
+        fun `should correctly return when arrow keys were pressed multiple times`() {
+            var result: Boolean
+
+            testSession { terminal ->
+                result =
+                    promptConfirm(testMessage, onInputReady = {
+                        repeat(5) {
+                            terminal.press(Keys.RIGHT)
+                        }
+                        terminal.press(Keys.LEFT)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(result).isTrue()
+            }
         }
     }
 
-    @Test
-    fun `should select the second checkbox option when arrow down was pressed`() {
-        var result: List<String>
+    @Nested
+    @DisplayName("promptList > ")
+    inner class PromptListTests {
+        // Tests for promptList
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.SPACE)
+        @Test
+        fun `should display all list options that were specified in the correct format when prompt is first displayed`() {
+            testSession { terminal ->
+                promptList(testMessage, testChoices, testHint, onInputReady = {
+                    terminal.assertMatches {
+                        bold {
+                            green { text("? ") }
+                            text(testMessage)
+                            black(isBright = true) { textLine("  $testHint") }
+                        }
+                        cyan(isBright = true) { text(" ❯ ") }
+                        cyan { textLine(testChoices[0]) }
+                        for (testItem in testChoices.drop(1)) {
+                            textLine("   $testItem")
+                        }
+                    }
                     terminal.press(Keys.ENTER)
                 })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                "   ◯ element 0",
-                " ❯ ◉ element 1",
-                "   ◯ element 2",
-                "   ◯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(listOf(testChoices[1]))
+            }
         }
-    }
 
-    @Test
-    fun `should select the third checkbox option when space, arrow down and up was pressed mixed`() {
-        var result: List<String>
+        @Test
+        fun `should select the first list option when no arrow keys were pressed`() {
+            var result: String
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    terminal.press(Keys.SPACE)
-                    terminal.press(Keys.SPACE)
-                    repeat(5) {
+            testSession { terminal ->
+                result =
+                    promptList(testMessage, testChoices, onInputReady = {
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  arrow keys to move, ENTER to select",
+                    " ❯ element 0",
+                    "   element 1",
+                    "   element 2",
+                    "   element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(testChoices[0])
+            }
+        }
+
+        @Test
+        fun `should select the second list option when arrow down was pressed once after multiple up`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptList(testMessage, testChoices, onInputReady = {
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  arrow keys to move, ENTER to select",
+                    "   element 0",
+                    " ❯ element 1",
+                    "   element 2",
+                    "   element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(testChoices[1])
+            }
+        }
+
+        @Test
+        fun `should not go up if in first position`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptList(testMessage, testChoices, onInputReady = {
+                        repeat(5) {
+                            terminal.press(Keys.UP)
+                        }
+                        terminal.press(Keys.DOWN)
                         terminal.press(Keys.UP)
+                        repeat(2) {
+                            terminal.press(Keys.DOWN)
+                        }
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  arrow keys to move, ENTER to select",
+                    "   element 0",
+                    "   element 1",
+                    " ❯ element 2",
+                    "   element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(testChoices[2])
+            }
+        }
+
+        @Test
+        fun `should select the last list option when arrow down was pressed more often than there are options`() {
+            var result: String
+
+            testSession { terminal ->
+                result =
+                    promptList(testMessage, testChoices, onInputReady = {
+                        repeat(6) {
+                            terminal.press(Keys.DOWN)
+                        }
+                        terminal.press(Keys.ENTER)
+                    })
+
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  arrow keys to move, ENTER to select",
+                    "   element 0",
+                    "   element 1",
+                    "   element 2",
+                    " ❯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(testChoices.last())
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("promptCheckbox > ")
+    inner class PromptCheckboxTest {
+        // Tests for promptCheckbox
+
+        @Test
+        fun `should display all checkbox options that were specified in the correct format when the first option is selected`() {
+            testSession { terminal ->
+                promptCheckbox(testMessage, testChoices, testHint, true, onInputReady = {
+                    terminal.press(Keys.SPACE)
+                    terminal.press(Keys.ENTER)
+                })
+                terminal.assertMatches {
+                    bold {
+                        green { text("? ") }
+                        text(testMessage)
+                        black(isBright = true) { textLine("  $testHint  $emptySelectionAllowedMessage") }
                     }
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.UP)
-                    repeat(2) {
-                        terminal.press(Keys.DOWN)
+                    cyan(isBright = true) { text(" ❯ ") }
+                    green { text("◉ ") }
+                    cyan { textLine(testChoices[0]) }
+                    for (testItem in testChoices.drop(1)) {
+                        cyan(isBright = true) { text("   ") }
+                        textLine("◯ $testItem")
                     }
-                    repeat(3) {
+                }
+            }
+        }
+
+        @Test
+        fun `should return empty input when no input was selected and empty input is allowed`() {
+            var result: List<String>
+            val emptyList = listOf<String>()
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, allowEmptyInput = true, onInputReady = {
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint  $emptySelectionAllowedMessage",
+                    " ❯ ◯ element 0",
+                    "   ◯ element 1",
+                    "   ◯ element 2",
+                    "   ◯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(emptyList)
+            }
+        }
+
+        @Test
+        fun `should not accept input and display hint when selection is empty and empty input is not allowed`() {
+            testSession { terminal ->
+                promptCheckbox(
+                    testMessage,
+                    testChoices,
+                    testHint,
+                    allowEmptyInput = false,
+                    onInputReady = {
+                        terminal.press(Keys.ENTER)
+
+                        blockUntilRenderWhen {
+                            terminal.resolveRerenders().stripFormatting() ==
+                                listOf(
+                                    "? $testMessage  $emptySelectionNotAllowedMessage",
+                                    " ❯ ◯ element 0",
+                                    "   ◯ element 1",
+                                    "   ◯ element 2",
+                                    "   ◯ element 3",
+                                    ""
+                                )
+                        }
+
                         terminal.press(Keys.SPACE)
+                        terminal.press(Keys.ENTER)
                     }
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                "   ◯ element 0",
-                "   ◯ element 1",
-                " ❯ ◉ element 2",
-                "   ◯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(listOf(testChoices[2]))
+                )
+            }
         }
-    }
 
-    @Test
-    fun `should select last checkbox option when arrow down was pressed more often than there are options`() {
-        var result: List<String>
+        @Test
+        fun `should select the first checkbox option when no arrow keys were pressed`() {
+            var result: List<String>
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    repeat(6) {
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
+                        terminal.press(Keys.SPACE)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    " ❯ ◉ element 0",
+                    "   ◯ element 1",
+                    "   ◯ element 2",
+                    "   ◯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(listOf(testChoices[0]))
+            }
+        }
+
+        @Test
+        fun `should select the second checkbox option when arrow down was pressed`() {
+            var result: List<String>
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
                         terminal.press(Keys.DOWN)
-                    }
-                    terminal.press(Keys.SPACE)
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                "   ◯ element 0",
-                "   ◯ element 1",
-                "   ◯ element 2",
-                " ❯ ◉ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(listOf(testChoices.last()))
+                        terminal.press(Keys.SPACE)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    "   ◯ element 0",
+                    " ❯ ◉ element 1",
+                    "   ◯ element 2",
+                    "   ◯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(listOf(testChoices[1]))
+            }
+        }
+
+        @Test
+        fun `should select the third checkbox option when space, arrow down and up was pressed mixed`() {
+            var result: List<String>
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
+                        terminal.press(Keys.SPACE)
+                        terminal.press(Keys.SPACE)
+                        repeat(5) {
+                            terminal.press(Keys.UP)
+                        }
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.UP)
+                        repeat(2) {
+                            terminal.press(Keys.DOWN)
+                        }
+                        repeat(3) {
+                            terminal.press(Keys.SPACE)
+                        }
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    "   ◯ element 0",
+                    "   ◯ element 1",
+                    " ❯ ◉ element 2",
+                    "   ◯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(listOf(testChoices[2]))
+            }
+        }
+
+        @Test
+        fun `should select last checkbox option when arrow down was pressed more often than there are options`() {
+            var result: List<String>
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
+                        repeat(6) {
+                            terminal.press(Keys.DOWN)
+                        }
+                        terminal.press(Keys.SPACE)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    "   ◯ element 0",
+                    "   ◯ element 1",
+                    "   ◯ element 2",
+                    " ❯ ◉ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(listOf(testChoices.last()))
+            }
+        }
+
+        @Test
+        fun `should select correct element when selection was made and cursor was moved afterwards`() {
+            var result: List<String>
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.SPACE)
+                        terminal.press(Keys.UP)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    "   ◯ element 0",
+                    " ❯ ◯ element 1",
+                    "   ◉ element 2",
+                    "   ◯ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(listOf(testChoices[2]))
+            }
+        }
+
+        @Test
+        fun `should return all selected options when multiple were selected`() {
+            var result: List<String>
+            val elemsToSelect = listOf(testChoices[0], testChoices[1], testChoices[3])
+
+            testSession { terminal ->
+                result =
+                    promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
+                        terminal.press(Keys.SPACE)
+
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.SPACE)
+
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.DOWN)
+                        terminal.press(Keys.SPACE)
+
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage  $testHint",
+                    "   ◉ element 0",
+                    "   ◉ element 1",
+                    "   ◯ element 2",
+                    " ❯ ◉ element 3",
+                    ""
+                )
+                assertThat(result).isEqualTo(elemsToSelect)
+            }
         }
     }
 
-    @Test
-    fun `should select correct element when selection was made and cursor was moved afterwards`() {
-        var result: List<String>
+    @Nested
+    @DisplayName("defaultFileOrFolderInput > ")
+    inner class DefaultFileOrFolderInputTests {
+        // defaultFileOrFolderInput
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.SPACE)
-                    terminal.press(Keys.UP)
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                "   ◯ element 0",
-                " ❯ ◯ element 1",
-                "   ◉ element 2",
-                "   ◯ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(listOf(testChoices[2]))
+        @Test
+        fun `should prompt file type correctly`() {
+            var result: String
+            val testFilePath = "src/test/resources"
+            val inputFileName = "$testFilePath/valid.log"
+            val testMessage = "What is the input file."
+
+            testSession { terminal ->
+                result =
+                    promptDefaultFileFolderInput(InputType.FILE, listOf(), onInputReady = {
+                        terminal.type(inputFileName)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $inputFileName ",
+                    ""
+                )
+
+                assertThat(result).isEqualTo(inputFileName)
+            }
         }
-    }
 
-    @Test
-    fun `should return all selected options when multiple were selected`() {
-        var result: List<String>
-        val elemsToSelect = listOf(testChoices[0], testChoices[1], testChoices[3])
+        @Test
+        fun `should prompt file extensions correctly`() {
+            var result: String
+            val testFilePath = "src/test/resources"
+            val inputFileName = "$testFilePath/validExtension.cc.json"
+            val testMessage = "What is the input [.cc.json] file."
 
-        testSession { terminal ->
-            result =
-                promptCheckbox(testMessage, testChoices, testHint, onInputReady = {
-                    terminal.press(Keys.SPACE)
+            testSession { terminal ->
+                result =
+                    promptDefaultFileFolderInput(InputType.FILE, listOf(FileExtension.CCJSON), onInputReady = {
+                        terminal.type(inputFileName)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $inputFileName ",
+                    ""
+                )
 
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.SPACE)
+                assertThat(result).isEqualTo(inputFileName)
+            }
+        }
 
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.DOWN)
-                    terminal.press(Keys.SPACE)
+        @Test
+        fun `should prompt plural if multiple is set`() {
+            var result: String
+            val testFilePath = "src/test/resources"
+            val inputFileName = "$testFilePath/valid.log"
+            val testMessage = "What are the input file(s). Enter multiple files comma separated."
+            val multiTestHint = "input1.txt, input2.log, ..."
 
-                    terminal.press(Keys.ENTER)
-                })
-            assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
-                "? $testMessage  $testHint",
-                "   ◉ element 0",
-                "   ◉ element 1",
-                "   ◯ element 2",
-                " ❯ ◉ element 3",
-                ""
-            )
-            assertThat(result).isEqualTo(elemsToSelect)
+            testSession { terminal ->
+                result =
+                    promptDefaultFileFolderInput(InputType.FILE, listOf(), multiple = true, onInputReady = {
+                        terminal.assertMatches {
+                            bold {
+                                green { text("? ") }
+                                textLine(testMessage)
+                            }
+                            text("> ")
+                            black(isBright = true) {
+                                invert { text(multiTestHint[0]) }
+                                text("${multiTestHint.drop(1)} ")
+                            }
+                        }
+                        terminal.type(inputFileName)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $inputFileName ",
+                    ""
+                )
+
+                assertThat(result).isEqualTo(inputFileName)
+            }
         }
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -810,11 +810,46 @@ class DialogProviderTest {
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/valid.log"
             val testMessage = "What are the input file(s). Enter multiple files comma separated."
-            val multiTestHint = "input1.txt, input2.log, ..."
+            val multiTestHint = "input1, input2, ..."
 
             testSession { terminal ->
                 result =
                     promptDefaultFileFolderInput(InputType.FILE, listOf(), multiple = true, onInputReady = {
+                        terminal.assertMatches {
+                            bold {
+                                green { text("? ") }
+                                textLine(testMessage)
+                            }
+                            text("> ")
+                            black(isBright = true) {
+                                invert { text(multiTestHint[0]) }
+                                text("${multiTestHint.drop(1)} ")
+                            }
+                        }
+                        terminal.type(inputFileName)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $inputFileName ",
+                    ""
+                )
+
+                assertThat(result).isEqualTo(inputFileName)
+            }
+        }
+
+        @Test
+        fun `should prompt plural if multiple is set with file extension`() {
+            var result: String
+            val testFilePath = "src/test/resources"
+            val inputFileName = "$testFilePath/validExtension.cc.json"
+            val testMessage = "What are the input [.cc.json] file(s). Enter multiple files comma separated."
+            val multiTestHint = "input1.cc.json, input2.cc.json, ..."
+
+            testSession { terminal ->
+                result =
+                    promptDefaultFileFolderInput(InputType.FILE, listOf(FileExtension.CCJSON), multiple = true, onInputReady = {
                         terminal.assertMatches {
                             bold {
                                 green { text("? ") }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidatorTest.kt
@@ -36,6 +36,44 @@ class InputValidatorTest {
         )
     }
 
+    private fun provideMultipleFileOrFolderInput(): List<Arguments> {
+        val validLog = "src/test/resources/valid.log"
+        val validExtension = "src/test/resources/validExtension.cc.json"
+        val invalidTxt = "src/test/resources/invalid.txt"
+        val doesNotExist = "src/test/resources/doesNotExist.log"
+        val resourceFolder = "src/test/resources"
+        val notExistingFolder = "src/test/resources/doesNotExistFolder"
+
+        return listOf(
+            Arguments.of(InputType.FILE, listOf<FileExtension>(), validLog, true),
+            Arguments.of(InputType.FILE, listOf<FileExtension>(), "$validLog, $validExtension", true),
+            Arguments.of(InputType.FILE, listOf(FileExtension.CCJSON), "$validExtension, $validExtension", true),
+            Arguments.of(InputType.FILE, listOf(FileExtension.CCJSON), invalidTxt, false),
+            Arguments.of(InputType.FILE, listOf(FileExtension.CCJSON), "$validExtension, $invalidTxt", false),
+            Arguments.of(InputType.FILE, listOf<FileExtension>(), doesNotExist, false),
+            Arguments.of(InputType.FILE, listOf<FileExtension>(), "$validExtension, $doesNotExist", false),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf<FileExtension>(), resourceFolder, true),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf<FileExtension>(), "$resourceFolder, $resourceFolder", true),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf<FileExtension>(), "$resourceFolder, $validExtension, $doesNotExist", false),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf<FileExtension>(), notExistingFolder, false),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf<FileExtension>(), "$resourceFolder, $notExistingFolder", false),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), validExtension, true),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), "$resourceFolder, $validExtension", true),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), invalidTxt, false),
+            Arguments.of(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), "$notExistingFolder, $invalidTxt", false),
+            Arguments.of(
+                InputType.FOLDER_AND_FILE,
+                listOf(FileExtension.CCJSON),
+                "$validExtension, $notExistingFolder, $invalidTxt",
+                false
+            ),
+            Arguments.of(InputType.FOLDER, listOf<FileExtension>(), invalidTxt, false),
+            Arguments.of(InputType.FOLDER, listOf<FileExtension>(), "$resourceFolder, $invalidTxt", false),
+            Arguments.of(InputType.FOLDER, listOf<FileExtension>(), resourceFolder, true),
+            Arguments.of(InputType.FOLDER, listOf<FileExtension>(), "$resourceFolder, $resourceFolder", true)
+        )
+    }
+
     private fun provideNumbersForVerification(): List<Arguments> {
         return listOf(
             Arguments.of(0, 1, true),
@@ -76,5 +114,17 @@ class InputValidatorTest {
         assertThat(
             InputValidator.isNumberGreaterThen(baseNumber)(inputNumber.toString())
         ).isEqualTo(expectedValidation)
+    }
+
+    @ParameterizedTest
+    @DisplayName("fileOrFolderValid(multiple) > should return true if all inputs are valid")
+    @MethodSource("provideMultipleFileOrFolderInput")
+    fun `should return expectedOutput for multiple files and folders`(
+        inputType: InputType,
+        fileExtensionList: List<FileExtension>,
+        path: String,
+        expectedValidation: Boolean
+    ) {
+        assertThat(InputValidator.isFileOrFolderValid(inputType, fileExtensionList, multiple = true)(path)).isEqualTo(expectedValidation)
     }
 }

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/PathFactory.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/model/PathFactory.kt
@@ -6,7 +6,7 @@ object PathFactory {
             path.split(pathSeparator).dropLastWhile {
                 it.isEmpty()
             }.filter {
-                !it.isEmpty()
+                it.isNotEmpty()
             }
         )
     }


### PR DESCRIPTION
### Kotter Extension: Multi File Input (Basic)

This adds a basic support for multi file input to the Dialogs of our analysers. 
Multiple files can be used as input, by chaining them together with a comma `,`.

Issue: #3923

## Description

Adds multi file input to the dialogs of the five analysers that support it.
Updates convenience file input function to support multi file input.
Updates input validator for dialogs, to enable recursive file input checks.
Includes tests for (non-)plural versions of the convenience dialog input.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed. (Further updates in #3923)
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- - Fixed issue in merge filter where an output file would not get deleted after the test is finished 
- - Fixed issue in JavaScriptStrategy of CoverageImporter where windows paths would not get split correctly
- - Fixed issue in CoverageImporter test where an error would include an unix specific path (not adaptive to windows)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
