### PR TITLE
Feat/4017/pipeable-output

### DIFF
--- a/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/AnalyserInterface.kt
+++ b/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/AnalyserInterface.kt
@@ -17,4 +17,10 @@ interface AnalyserInterface : Callable<Unit?> {
     fun getAnalyserDescription(): String {
         return description
     }
+
+    // print 12 invisible characters so signal to other parsers that execution has started
+    fun logExecutionStartedSyncSignal() {
+        val syncFlag = "\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E"
+        print(syncFlag)
+    }
 }

--- a/analysis/analysers/PipeableAnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/pipeableanalyserinterface/PipeableAnalyserInterface.kt
+++ b/analysis/analysers/PipeableAnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/pipeableanalyserinterface/PipeableAnalyserInterface.kt
@@ -1,7 +1,0 @@
-package de.maibornwolff.codecharta.analysers.pipeableanalyserinterface
-
-interface PipeableAnalyserInterface {
-    fun logPipeableAnalyserSyncSignal(syncSignal: PipeableAnalyserSyncFlag) {
-        print(syncSignal.value)
-    }
-}

--- a/analysis/analysers/PipeableAnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/pipeableanalyserinterface/PipeableAnalyserSyncFlag.kt
+++ b/analysis/analysers/PipeableAnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/pipeableanalyserinterface/PipeableAnalyserSyncFlag.kt
@@ -1,5 +1,0 @@
-package de.maibornwolff.codecharta.analysers.pipeableanalyserinterface
-
-enum class PipeableAnalyserSyncFlag(val value: String) {
-    SYNC_FLAG("\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E")
-}

--- a/analysis/analysers/importers/CoverageImporter/build.gradle.kts
+++ b/analysis/analysers/importers/CoverageImporter/build.gradle.kts
@@ -2,7 +2,6 @@ dependencies {
     implementation(project(":model"))
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
     implementation(project(":analysers:filters:MergeFilter"))
 
     implementation(libs.picocli)

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporter.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporter.kt
@@ -4,7 +4,6 @@ import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInte
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserInterface
 import de.maibornwolff.codecharta.analysers.analyserinterface.util.CodeChartaConstants
 import de.maibornwolff.codecharta.analysers.filters.mergefilter.MergeFilter
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.model.ProjectBuilder
@@ -30,7 +29,7 @@ class CoverageImporter(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     @CommandLine.Option(
         names = ["-l", "--language"],
         description = ["Specify the language of the coverage report (e.g., javascript, typescript, js, ts)"],

--- a/analysis/analysers/importers/TokeiImporter/build.gradle.kts
+++ b/analysis/analysers/importers/TokeiImporter/build.gradle.kts
@@ -2,7 +2,6 @@ dependencies {
     implementation(project(":model"))
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
 
     implementation(libs.picocli)
     implementation(libs.boon)

--- a/analysis/analysers/importers/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/tokei/TokeiImporter.kt
+++ b/analysis/analysers/importers/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/tokei/TokeiImporter.kt
@@ -8,8 +8,6 @@ import de.maibornwolff.codecharta.analysers.analyserinterface.util.CodeChartaCon
 import de.maibornwolff.codecharta.analysers.importers.tokei.strategy.ImporterStrategy
 import de.maibornwolff.codecharta.analysers.importers.tokei.strategy.TokeiInnerStrategy
 import de.maibornwolff.codecharta.analysers.importers.tokei.strategy.TokeiTwelveStrategy
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserSyncFlag
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.model.AttributeType
@@ -38,7 +36,7 @@ class TokeiImporter(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     private val attributeTypes =
         AttributeTypes(type = "nodes").add("rloc", AttributeType.ABSOLUTE).add("loc", AttributeType.ABSOLUTE)
             .add("empty_lines", AttributeType.ABSOLUTE).add("comment_lines", AttributeType.ABSOLUTE)
@@ -86,7 +84,7 @@ class TokeiImporter(
 
     @Throws(IOException::class)
     override fun call(): Unit? {
-        logPipeableAnalyserSyncSignal(PipeableAnalyserSyncFlag.SYNC_FLAG)
+        logExecutionStartedSyncSignal()
 
         projectBuilder = ProjectBuilder()
         val root = getInput() ?: return null

--- a/analysis/analysers/parsers/GitLogParser/build.gradle.kts
+++ b/analysis/analysers/parsers/GitLogParser/build.gradle.kts
@@ -3,7 +3,6 @@ dependencies {
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:filters:MergeFilter"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
 
     implementation(libs.commons.lang3)
     implementation(libs.picocli)

--- a/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/GitLogParser.kt
+++ b/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/GitLogParser.kt
@@ -11,8 +11,6 @@ import de.maibornwolff.codecharta.analysers.parsers.gitlog.parser.LogParserStrat
 import de.maibornwolff.codecharta.analysers.parsers.gitlog.parser.git.GitLogNumstatRawParserStrategy
 import de.maibornwolff.codecharta.analysers.parsers.gitlog.subcommands.LogScanCommand
 import de.maibornwolff.codecharta.analysers.parsers.gitlog.subcommands.RepoScanCommand
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserSyncFlag
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.model.Project
@@ -39,7 +37,7 @@ class GitLogParser(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     private val inputFormatNames = GIT_LOG_NUMSTAT_RAW_REVERSED
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
@@ -98,7 +96,7 @@ class GitLogParser(
 
     @Throws(IOException::class)
     override fun call(): Unit? {
-        logPipeableAnalyserSyncSignal(PipeableAnalyserSyncFlag.SYNC_FLAG)
+        logExecutionStartedSyncSignal()
         return null
     }
 

--- a/analysis/analysers/parsers/RawTextParser/build.gradle.kts
+++ b/analysis/analysers/parsers/RawTextParser/build.gradle.kts
@@ -3,7 +3,6 @@ dependencies {
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:filters:MergeFilter"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
 
     implementation(libs.picocli)
     implementation(libs.json)

--- a/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/RawTextParser.kt
+++ b/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/RawTextParser.kt
@@ -3,8 +3,6 @@ package de.maibornwolff.codecharta.analysers.parsers.rawtext
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserInterface
 import de.maibornwolff.codecharta.analysers.analyserinterface.util.CodeChartaConstants
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserSyncFlag
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
@@ -29,7 +27,7 @@ class RawTextParser(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
 
@@ -99,7 +97,7 @@ class RawTextParser(
 
     @Throws(IOException::class)
     override fun call(): Unit? {
-        logPipeableAnalyserSyncSignal(PipeableAnalyserSyncFlag.SYNC_FLAG)
+        logExecutionStartedSyncSignal()
 
         if (!InputHelper.isInputValidAndNotNull(arrayOf(inputFile), canInputContainFolders = true)) {
             throw IllegalArgumentException("Input invalid file for RawTextParser, stopping execution...")

--- a/analysis/analysers/parsers/SVNLogParser/build.gradle.kts
+++ b/analysis/analysers/parsers/SVNLogParser/build.gradle.kts
@@ -3,7 +3,6 @@ dependencies {
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:filters:MergeFilter"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
 
     implementation(libs.commons.lang3)
     implementation(libs.picocli)

--- a/analysis/analysers/parsers/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/svnlog/SVNLogParser.kt
+++ b/analysis/analysers/parsers/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/svnlog/SVNLogParser.kt
@@ -9,8 +9,6 @@ import de.maibornwolff.codecharta.analysers.parsers.svnlog.converter.ProjectConv
 import de.maibornwolff.codecharta.analysers.parsers.svnlog.input.metrics.MetricsFactory
 import de.maibornwolff.codecharta.analysers.parsers.svnlog.parser.LogParserStrategy
 import de.maibornwolff.codecharta.analysers.parsers.svnlog.parser.svn.SVNLogParserStrategy
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserSyncFlag
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.model.Project
@@ -37,7 +35,7 @@ class SVNLogParser(
     private val input: InputStream = System.`in`,
     private val output: PrintStream = System.out,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["displays this help and exits"])
     private var help = false
 
@@ -110,7 +108,7 @@ class SVNLogParser(
 
     @Throws(IOException::class)
     override fun call(): Unit? {
-        logPipeableAnalyserSyncSignal(PipeableAnalyserSyncFlag.SYNC_FLAG)
+        logExecutionStartedSyncSignal()
 
         if (!InputHelper.isInputValidAndNotNull(arrayOf(file), canInputContainFolders = false)) {
             throw IllegalArgumentException("Input invalid file for SVNLogParser, stopping execution...")

--- a/analysis/analysers/parsers/SourceCodeParser/build.gradle.kts
+++ b/analysis/analysers/parsers/SourceCodeParser/build.gradle.kts
@@ -3,7 +3,6 @@ dependencies {
     implementation(project(":dialogProvider"))
     implementation(project(":analysers:filters:MergeFilter"))
     implementation(project(":analysers:AnalyserInterface"))
-    implementation(project(":analysers:PipeableAnalyserInterface"))
 
     implementation(libs.picocli)
     implementation(libs.sonar.java.plugin)

--- a/analysis/analysers/parsers/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/sourcecode/SourceCodeParser.kt
+++ b/analysis/analysers/parsers/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/sourcecode/SourceCodeParser.kt
@@ -6,8 +6,6 @@ import de.maibornwolff.codecharta.analysers.analyserinterface.util.CodeChartaCon
 import de.maibornwolff.codecharta.analysers.parsers.sourcecode.metricwriters.CSVMetricWriter
 import de.maibornwolff.codecharta.analysers.parsers.sourcecode.metricwriters.JSONMetricWriter
 import de.maibornwolff.codecharta.analysers.parsers.sourcecode.metricwriters.MetricWriter
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserInterface
-import de.maibornwolff.codecharta.analysers.pipeableanalyserinterface.PipeableAnalyserSyncFlag
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.serialization.FileExtension
@@ -38,7 +36,7 @@ class SourceCodeParser(
     private val output: PrintStream,
     private val input: InputStream = System.`in`,
     private val error: PrintStream = System.err
-) : AnalyserInterface, PipeableAnalyserInterface, AttributeGenerator {
+) : AnalyserInterface, AttributeGenerator {
     // we need this constructor because ccsh requires an empty constructor
     constructor() : this(System.out)
 
@@ -116,7 +114,7 @@ class SourceCodeParser(
 
     @Throws(IOException::class)
     override fun call(): Unit? {
-        logPipeableAnalyserSyncSignal(PipeableAnalyserSyncFlag.SYNC_FLAG)
+        logExecutionStartedSyncSignal()
 
         require(InputHelper.isInputValidAndNotNull(arrayOf(file), canInputContainFolders = true)) {
             "Input invalid file for SourceCodeParser, stopping execution..."


### PR DESCRIPTION
# Integrate the pipeable interface into the normal analyser interface

Closes: #4017

## Description

The functionality to send a sync flag that indicates that an analyser has started its execution has been moved from its own interface to the analyser interface

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
