### PR TITLE
feat/4040/dotnet-coverage-importer

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Added 🚀
 
 - Add support for multi file input in dialogs [#4030](https://github.com/MaibornWolff/codecharta/pull/4030)
+- Add support for the coverage importer for:
+  - Coverlet (Dotnet) [#4042](https://github.com/MaibornWolff/codecharta/pull/4042)
 
 ### Changed
 

--- a/analysis/analysers/importers/CoverageImporter/README.md
+++ b/analysis/analysers/importers/CoverageImporter/README.md
@@ -18,10 +18,11 @@ The CoverageImporter generates visualisation data from a coverage report generat
 
 ## Supported Coverage Report Languages/Formats
 
-| Language                | Command                                                 | Default Report File |
-|-------------------------|---------------------------------------------------------|---------------------|
-| JavaScript / TypeScript | `javascript/typescript, javascript, typescript, js, ts` | lcov.info           |
-| Java                    | `java`                                                  | jacoco.xml          |
+| Language                | Command                                                 | Default Report File    |
+|-------------------------|---------------------------------------------------------|------------------------|
+| JavaScript / TypeScript | `javascript/typescript, javascript, typescript, js, ts` | lcov.info              |
+| Java                    | `java`                                                  | jacoco.xml             |
+| C#                      | `csharp, dotnet`                                        | coverage.cobertura.xml |
 
 ## Usage and Parameters
 

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporter.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/CoverageImporter.kt
@@ -84,6 +84,8 @@ class CoverageImporter(
 
     @Throws(IOException::class)
     override fun call() {
+        logExecutionStartedSyncSignal()
+
         val languageInput = language.lowercase(Locale.getDefault())
 
         require(isLanguageForLanguageInputSupported(languageInput)) { "Unsupported language: $languageInput" }

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/LanguageRepository.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/LanguageRepository.kt
@@ -1,5 +1,6 @@
 package de.maibornwolff.codecharta.analysers.importers.coverage
 
+import de.maibornwolff.codecharta.analysers.importers.coverage.strategies.DotnetStrategy
 import de.maibornwolff.codecharta.analysers.importers.coverage.strategies.ImporterStrategy
 import de.maibornwolff.codecharta.analysers.importers.coverage.strategies.JavaScriptStrategy
 import de.maibornwolff.codecharta.analysers.importers.coverage.strategies.JavaStrategy
@@ -36,12 +37,23 @@ internal enum class Language(
             CoverageAttributes.METHOD_COVERAGE,
             CoverageAttributes.CLASS_COVERAGE
         )
+    ),
+    CSHARP(
+        "csharp",
+        DotnetStrategy(),
+        listOf(FileExtension.XML),
+        "coverage.cobertura.xml",
+        listOf(
+            CoverageAttributes.LINE_COVERAGE,
+            CoverageAttributes.BRANCH_COVERAGE
+        )
     )
 }
 
 private val languageChoicesToLanguage = mapOf(
     "javascript/typescript" to Language.JAVASCRIPT,
-    "java" to Language.JAVA
+    "java" to Language.JAVA,
+    "csharp/dotnet" to Language.CSHARP
 )
 
 private val languageInputToLanguage = mapOf(
@@ -49,7 +61,9 @@ private val languageInputToLanguage = mapOf(
     "typescript" to Language.JAVASCRIPT,
     "js" to Language.JAVASCRIPT,
     "ts" to Language.JAVASCRIPT,
-    "java" to Language.JAVA
+    "java" to Language.JAVA,
+    "csharp" to Language.CSHARP,
+    "dotnet" to Language.CSHARP
 )
 
 internal fun getLanguageChoices(): List<String> {

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
@@ -1,0 +1,115 @@
+package de.maibornwolff.codecharta.analysers.importers.coverage.strategies
+
+import de.maibornwolff.codecharta.analysers.importers.coverage.CoverageAttributes
+import de.maibornwolff.codecharta.model.MutableNode
+import de.maibornwolff.codecharta.model.NodeType
+import de.maibornwolff.codecharta.model.PathFactory
+import de.maibornwolff.codecharta.model.ProjectBuilder
+import de.maibornwolff.codecharta.progresstracker.ParsingUnit
+import de.maibornwolff.codecharta.progresstracker.ProgressTracker
+import de.maibornwolff.codecharta.util.Logger
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import java.io.PrintStream
+
+class DotnetStrategy : ImporterStrategy {
+    override val progressTracker: ProgressTracker = ProgressTracker()
+    override var totalTrackingItems: Long = 0
+    override val parsingUnit: ParsingUnit = ParsingUnit.Packages
+
+    override fun addNodesToProjectBuilder(coverageFile: File, projectBuilder: ProjectBuilder, error: PrintStream) {
+        try {
+            val document: Document = parseXML(coverageFile.absolutePath)
+
+            val packageElements = document.getElementsByTagName("package")
+
+            if (packageElements.length == 0) {
+                error.println("The coverage report file does not contain any package elements.")
+                return
+            }
+            totalTrackingItems = packageElements.length.toLong()
+            updateProgress(0)
+
+            for (packageIndex in 0 until packageElements.length) {
+                val packageElement = packageElements.item(packageIndex) as Element
+                processPackageElement(packageElement, projectBuilder)
+                updateProgress(packageIndex.toLong() + 1)
+            }
+        } catch (e: Exception) {
+            error.println("Error while parsing XML file: ${e.message}")
+            return
+        }
+    }
+
+    private fun processPackageElement(packageElement: Element, projectBuilder: ProjectBuilder) {
+        val seenFiles = mutableMapOf<String, MutableNode>()
+        val classElements = packageElement.getElementsByTagName("class")
+        for (classIndex in 0 until classElements.length) {
+            val classElement = classElements.item(classIndex) as Element
+            val filePath = classElement.getAttribute("filename")
+            if (filePath in seenFiles.keys) {
+                val existingNode = seenFiles[filePath]
+                updateFileNode(existingNode!!, classElement)
+            } else {
+                val fileName = extractFileNameFromPath(filePath)
+                seenFiles[filePath] = createFileNode(fileName, classElement)
+            }
+        }
+
+        for (seenFile in seenFiles) {
+            val filePath = seenFile.key
+            val fileNode = seenFile.value
+
+            val path = PathFactory.fromFileSystemPath(filePath).parent
+            projectBuilder.insertByPath(path, fileNode)
+        }
+    }
+
+    private fun extractFileNameFromPath(path: String): String {
+        val lastUnixPathSeparator = path.lastIndexOf('/')
+        val lastWindowsPathSeparator = path.lastIndexOf('\\')
+
+        val lastPathSeparatorIndex = maxOf(lastUnixPathSeparator, lastWindowsPathSeparator)
+
+        if (path[lastPathSeparatorIndex] != File.separatorChar) {
+            Logger.warn { "Non-native file paths detected in coverage report! This might result in an incorrect cc.json" }
+        }
+
+        return if (lastPathSeparatorIndex >= 0) {
+            path.substring(lastPathSeparatorIndex + 1)
+        } else {
+            path
+        }
+    }
+
+    private fun createFileNode(fileName: String, classElement: Element): MutableNode {
+        val lineCoverage = classElement.getAttribute("line-rate").toDouble()
+        val branchCoverage = classElement.getAttribute("branch-rate").toDouble()
+
+        val attributes = mutableMapOf(
+            CoverageAttributes.LINE_COVERAGE.attributeName to lineCoverage,
+            CoverageAttributes.BRANCH_COVERAGE.attributeName to branchCoverage
+        )
+
+        return MutableNode(
+            name = fileName,
+            type = NodeType.File,
+            attributes = attributes
+        )
+    }
+
+    private fun updateFileNode(fileNode: MutableNode, classElement: Element) {
+        val newElementLineCoverage = classElement.getAttribute("line-rate").toDouble()
+        val newElementBranchCoverage = classElement.getAttribute("branch-rate").toDouble()
+
+        val existingLineCoverage = fileNode.attributes[CoverageAttributes.LINE_COVERAGE.attributeName] as Double
+        val existingBranchCoverage = fileNode.attributes[CoverageAttributes.BRANCH_COVERAGE.attributeName] as Double
+
+        val updatedAttributes = fileNode.attributes.toMutableMap()
+        updatedAttributes[CoverageAttributes.LINE_COVERAGE.attributeName] = existingLineCoverage + newElementLineCoverage
+        updatedAttributes[CoverageAttributes.BRANCH_COVERAGE.attributeName] = existingBranchCoverage + newElementBranchCoverage
+
+        fileNode.attributes = updatedAttributes
+    }
+}

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
@@ -84,8 +84,8 @@ class DotnetStrategy : ImporterStrategy {
     }
 
     private fun createFileNode(fileName: String, classElement: Element): MutableNode {
-        val lineCoverage = classElement.getAttribute("line-rate").toDouble()
-        val branchCoverage = classElement.getAttribute("branch-rate").toDouble()
+        val lineCoverage = classElement.getAttribute("line-rate").toDouble() * 100
+        val branchCoverage = classElement.getAttribute("branch-rate").toDouble() * 100
 
         val attributes = mutableMapOf(
             CoverageAttributes.LINE_COVERAGE.attributeName to lineCoverage,
@@ -100,8 +100,8 @@ class DotnetStrategy : ImporterStrategy {
     }
 
     private fun updateFileNode(fileNode: MutableNode, classElement: Element) {
-        val newElementLineCoverage = classElement.getAttribute("line-rate").toDouble()
-        val newElementBranchCoverage = classElement.getAttribute("branch-rate").toDouble()
+        val newElementLineCoverage = classElement.getAttribute("line-rate").toDouble() * 100
+        val newElementBranchCoverage = classElement.getAttribute("branch-rate").toDouble() * 100
 
         val existingLineCoverage = fileNode.attributes[CoverageAttributes.LINE_COVERAGE.attributeName] as Double
         val existingBranchCoverage = fileNode.attributes[CoverageAttributes.BRANCH_COVERAGE.attributeName] as Double

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategy.kt
@@ -72,15 +72,13 @@ class DotnetStrategy : ImporterStrategy {
 
         val lastPathSeparatorIndex = maxOf(lastUnixPathSeparator, lastWindowsPathSeparator)
 
+        if (lastPathSeparatorIndex < 0) return path
+
         if (path[lastPathSeparatorIndex] != File.separatorChar) {
-            Logger.warn { "Non-native file paths detected in coverage report! This might result in an incorrect cc.json" }
+            Logger.warn { "Non-native file paths detected in coverage report! This might result in an incorrect cc.json file" }
         }
 
-        return if (lastPathSeparatorIndex >= 0) {
-            path.substring(lastPathSeparatorIndex + 1)
-        } else {
-            path
-        }
+        return path.substring(lastPathSeparatorIndex + 1)
     }
 
     private fun createFileNode(fileName: String, classElement: Element): MutableNode {

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/ImporterStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/ImporterStrategy.kt
@@ -3,8 +3,13 @@ package de.maibornwolff.codecharta.analysers.importers.coverage.strategies
 import de.maibornwolff.codecharta.model.ProjectBuilder
 import de.maibornwolff.codecharta.progresstracker.ParsingUnit
 import de.maibornwolff.codecharta.progresstracker.ProgressTracker
+import org.w3c.dom.Document
+import org.xml.sax.InputSource
 import java.io.File
+import java.io.FileInputStream
 import java.io.PrintStream
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
 
 interface ImporterStrategy {
     val progressTracker: ProgressTracker
@@ -27,5 +32,14 @@ interface ImporterStrategy {
         } else {
             100.0
         }
+    }
+
+    fun parseXML(filePath: String): Document {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+
+        val builder: DocumentBuilder = factory.newDocumentBuilder()
+        return builder.parse(InputSource(FileInputStream(filePath)))
     }
 }

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JavaStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JavaStrategy.kt
@@ -9,12 +9,8 @@ import de.maibornwolff.codecharta.progresstracker.ParsingUnit
 import de.maibornwolff.codecharta.progresstracker.ProgressTracker
 import org.w3c.dom.Document
 import org.w3c.dom.Element
-import org.xml.sax.InputSource
 import java.io.File
-import java.io.FileInputStream
 import java.io.PrintStream
-import javax.xml.parsers.DocumentBuilder
-import javax.xml.parsers.DocumentBuilderFactory
 
 class JavaStrategy : ImporterStrategy {
     override val progressTracker: ProgressTracker = ProgressTracker()
@@ -43,15 +39,6 @@ class JavaStrategy : ImporterStrategy {
             error.println("Error while parsing XML file: ${e.message}")
             return
         }
-    }
-
-    private fun parseXML(filePath: String): Document {
-        val factory = DocumentBuilderFactory.newInstance()
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-
-        val builder: DocumentBuilder = factory.newDocumentBuilder()
-        return builder.parse(InputSource(FileInputStream(filePath)))
     }
 
     private fun processPackageElement(packageElement: Element, projectBuilder: ProjectBuilder) {

--- a/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategyTest.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategyTest.kt
@@ -43,7 +43,7 @@ class DotnetStrategyTest {
 
     @Test
     fun `should handle report without packages gracefully and print error`() {
-        val noPackagesReportFilePath = "src/test/resources/languages/dotnet/no_packages.cobertura.xml"
+        val noPackagesReportFilePath = "src/test/resources/languages/csharp/no_packages.cobertura.xml"
         val expectedRootNode = MutableNode("root", NodeType.Folder)
         val projectBuilder = ProjectBuilder()
         val errorStreamContent = ByteArrayOutputStream()

--- a/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategyTest.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/test/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/DotnetStrategyTest.kt
@@ -1,0 +1,56 @@
+package de.maibornwolff.codecharta.analysers.importers.coverage.strategies
+
+import de.maibornwolff.codecharta.model.MutableNode
+import de.maibornwolff.codecharta.model.NodeType
+import de.maibornwolff.codecharta.model.ProjectBuilder
+import de.maibornwolff.codecharta.serialization.ProjectDeserializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+class DotnetStrategyTest {
+    private val testReportFilePath = "src/test/resources/languages/csharp/coverage.cobertura.xml"
+    private val expectedOutputPath = "src/test/resources/languages/csharp/coverage.cc.json"
+
+    @Test
+    fun `should correctly import coverage report and build project structure`() {
+        val projectBuilder = ProjectBuilder()
+
+        DotnetStrategy().addNodesToProjectBuilder(File(testReportFilePath), projectBuilder, System.err)
+
+        val project = projectBuilder.build()
+        val expectedProject = ProjectDeserializer.deserializeProject(File(expectedOutputPath).inputStream())
+
+        assertThat(
+            project
+        ).usingRecursiveComparison().ignoringFields("attributeDescriptors", "attributeTypes", "blacklist").isEqualTo(expectedProject)
+    }
+
+    @Test
+    fun `should handle empty report files gracefully and print error`() {
+        val emptyReportFilePath = "src/test/resources/languages/csharp/empty.cobertura.xml"
+        val expectedRootNode = MutableNode("root", NodeType.Folder)
+        val projectBuilder = ProjectBuilder()
+        val errorStreamContent = ByteArrayOutputStream()
+
+        DotnetStrategy().addNodesToProjectBuilder(File(emptyReportFilePath), projectBuilder, PrintStream(errorStreamContent))
+
+        assertThat(projectBuilder.rootNode.toString()).isEqualTo(expectedRootNode.toString())
+        assertThat(errorStreamContent.toString()).contains("Error while parsing XML file:")
+    }
+
+    @Test
+    fun `should handle report without packages gracefully and print error`() {
+        val noPackagesReportFilePath = "src/test/resources/languages/dotnet/no_packages.cobertura.xml"
+        val expectedRootNode = MutableNode("root", NodeType.Folder)
+        val projectBuilder = ProjectBuilder()
+        val errorStreamContent = ByteArrayOutputStream()
+
+        DotnetStrategy().addNodesToProjectBuilder(File(noPackagesReportFilePath), projectBuilder, PrintStream(errorStreamContent))
+
+        assertThat(projectBuilder.rootNode.toString()).isEqualTo(expectedRootNode.toString())
+        assertThat(errorStreamContent.toString()).contains("The coverage report file does not contain any package elements.")
+    }
+}

--- a/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cc.json
+++ b/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cc.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "584ef24e6e3d59fb0a20a6772eab60d3",
+  "checksum": "c09699276517861a3c45495d8b644afa",
   "data": {
     "projectName": "",
     "nodes": [
@@ -20,7 +20,7 @@
                 "type": "File",
                 "attributes": {
                   "line_coverage": 0.0,
-                  "branch_coverage": 1.0
+                  "branch_coverage": 100.0
                 },
                 "link": "",
                 "children": []
@@ -35,8 +35,8 @@
                     "name": "TasksController.cs",
                     "type": "File",
                     "attributes": {
-                      "line_coverage": 0.925,
-                      "branch_coverage": 1.0
+                      "line_coverage": 92.5,
+                      "branch_coverage": 100.0
                     },
                     "link": "",
                     "children": []
@@ -61,8 +61,8 @@
                     "name": "TaskRepository.cs",
                     "type": "File",
                     "attributes": {
-                      "line_coverage": 0.9677,
-                      "branch_coverage": 0.5
+                      "line_coverage": 96.77,
+                      "branch_coverage": 50.0
                     },
                     "link": "",
                     "children": []
@@ -79,8 +79,8 @@
                     "name": "ApplicationDbContext.cs",
                     "type": "File",
                     "attributes": {
-                      "line_coverage": 1.0,
-                      "branch_coverage": 1.0
+                      "line_coverage": 100.0,
+                      "branch_coverage": 100.0
                     },
                     "link": "",
                     "children": []
@@ -111,8 +111,8 @@
                         "name": "TaskHelpers.cs",
                         "type": "File",
                         "attributes": {
-                          "line_coverage": 0.9375,
-                          "branch_coverage": 0.8332999999999999
+                          "line_coverage": 93.75,
+                          "branch_coverage": 83.33
                         },
                         "link": "",
                         "children": []
@@ -131,8 +131,8 @@
                     "name": "TaskService.cs",
                     "type": "File",
                     "attributes": {
-                      "line_coverage": 1.0,
-                      "branch_coverage": 1.0
+                      "line_coverage": 100.0,
+                      "branch_coverage": 100.0
                     },
                     "link": "",
                     "children": []
@@ -149,8 +149,8 @@
                     "name": "Task.cs",
                     "type": "File",
                     "attributes": {
-                      "line_coverage": 1.0,
-                      "branch_coverage": 1.0
+                      "line_coverage": 100.0,
+                      "branch_coverage": 100.0
                     },
                     "link": "",
                     "children": []

--- a/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cc.json
+++ b/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cc.json
@@ -1,0 +1,193 @@
+{
+  "checksum": "584ef24e6e3d59fb0a20a6772eab60d3",
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "link": "",
+        "children": [
+          {
+            "name": "SampleApp.Api",
+            "type": "Folder",
+            "attributes": {},
+            "link": "",
+            "children": [
+              {
+                "name": "Program.cs",
+                "type": "File",
+                "attributes": {
+                  "line_coverage": 0.0,
+                  "branch_coverage": 1.0
+                },
+                "link": "",
+                "children": []
+              },
+              {
+                "name": "Controllers",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "TasksController.cs",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 0.925,
+                      "branch_coverage": 1.0
+                    },
+                    "link": "",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "SampleApp.Data",
+            "type": "Folder",
+            "attributes": {},
+            "link": "",
+            "children": [
+              {
+                "name": "Repositories",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "TaskRepository.cs",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 0.9677,
+                      "branch_coverage": 0.5
+                    },
+                    "link": "",
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "ApplicationDbContext.cs",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 1.0,
+                      "branch_coverage": 1.0
+                    },
+                    "link": "",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "SampleApp.Core",
+            "type": "Folder",
+            "attributes": {},
+            "link": "",
+            "children": [
+              {
+                "name": "Utils",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "Helpers",
+                    "type": "Folder",
+                    "attributes": {},
+                    "link": "",
+                    "children": [
+                      {
+                        "name": "TaskHelpers.cs",
+                        "type": "File",
+                        "attributes": {
+                          "line_coverage": 0.9375,
+                          "branch_coverage": 0.8332999999999999
+                        },
+                        "link": "",
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Services",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "TaskService.cs",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 1.0,
+                      "branch_coverage": 1.0
+                    },
+                    "link": "",
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "name": "Models",
+                "type": "Folder",
+                "attributes": {},
+                "link": "",
+                "children": [
+                  {
+                    "name": "Task.cs",
+                    "type": "File",
+                    "attributes": {
+                      "line_coverage": 1.0,
+                      "branch_coverage": 1.0
+                    },
+                    "link": "",
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.3",
+    "edges": [],
+    "attributeTypes": {
+      "nodes": {
+        "line_coverage": "relative",
+        "branch_coverage": "relative"
+      }
+    },
+    "attributeDescriptors": {
+      "line_coverage": {
+        "title": "Line Coverage",
+        "description": "Percentage of lines covered by tests",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "",
+        "direction": 1
+      },
+      "branch_coverage": {
+        "title": "Branch Coverage",
+        "description": "Percentage of branches covered by tests",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "",
+        "direction": 1
+      }
+    },
+    "blacklist": []
+  }
+}

--- a/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cobertura.xml
+++ b/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/coverage.cobertura.xml
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8201" branch-rate="0.6875" version="1.9" timestamp="1744712956" lines-covered="114" lines-valid="139" branches-covered="11" branches-valid="16">
+    <sources>
+        <source>/Users/testuser/path/to/testproject/</source>
+    </sources>
+    <packages>
+        <package name="SampleApp.Api" line-rate="0.6165999999999999" branch-rate="0.6666" complexity="13">
+            <classes>
+                <class name="Program" filename="SampleApp.Api/Program.cs" line-rate="0" branch-rate="0" complexity="2">
+                    <methods>
+                        <method name="&lt;Main&gt;$" signature="(System.String[])" line-rate="0" branch-rate="0" complexity="2">
+                            <lines>
+                                <line number="7" hits="0" branch="False" />
+                                <line number="10" hits="0" branch="False" />
+                                <line number="12" hits="0" branch="False" />
+                                <line number="13" hits="0" branch="False" />
+                                <line number="16" hits="0" branch="False" />
+                                <line number="17" hits="0" branch="False" />
+                                <line number="20" hits="0" branch="False" />
+                                <line number="21" hits="0" branch="False" />
+                                <line number="23" hits="0" branch="False" />
+                                <line number="26" hits="0" branch="True" condition-coverage="0% (0/2)">
+                                    <conditions>
+                                        <condition number="133" type="jump" coverage="0%" />
+                                    </conditions>
+                                </line>
+                                <line number="27" hits="0" branch="False" />
+                                <line number="28" hits="0" branch="False" />
+                                <line number="29" hits="0" branch="False" />
+                                <line number="30" hits="0" branch="False" />
+                                <line number="32" hits="0" branch="False" />
+                                <line number="34" hits="0" branch="False" />
+                                <line number="36" hits="0" branch="False" />
+                                <line number="38" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="7" hits="0" branch="False" />
+                        <line number="10" hits="0" branch="False" />
+                        <line number="12" hits="0" branch="False" />
+                        <line number="13" hits="0" branch="False" />
+                        <line number="16" hits="0" branch="False" />
+                        <line number="17" hits="0" branch="False" />
+                        <line number="20" hits="0" branch="False" />
+                        <line number="21" hits="0" branch="False" />
+                        <line number="23" hits="0" branch="False" />
+                        <line number="26" hits="0" branch="True" condition-coverage="0% (0/2)">
+                            <conditions>
+                                <condition number="133" type="jump" coverage="0%" />
+                            </conditions>
+                        </line>
+                        <line number="27" hits="0" branch="False" />
+                        <line number="28" hits="0" branch="False" />
+                        <line number="29" hits="0" branch="False" />
+                        <line number="30" hits="0" branch="False" />
+                        <line number="32" hits="0" branch="False" />
+                        <line number="34" hits="0" branch="False" />
+                        <line number="36" hits="0" branch="False" />
+                        <line number="38" hits="0" branch="False" />
+                    </lines>
+                </class>
+                <class name="WeatherForecast" filename="SampleApp.Api/Program.cs" line-rate="0" branch-rate="1" complexity="2">
+                    <methods>
+                        <method name="get_Date" signature="()" line-rate="0" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="40" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_TemperatureF" signature="()" line-rate="0" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="40" hits="0" branch="False" />
+                        <line number="42" hits="0" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Api.Controllers.TasksController" filename="SampleApp.Api/Controllers/TasksController.cs" line-rate="0.925" branch-rate="1" complexity="9">
+                    <methods>
+                        <method name="GetAllTasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="21" hits="1" branch="False" />
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                                <line number="24" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTaskById" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="28" hits="2" branch="False" />
+                                <line number="30" hits="2" branch="False" />
+                                <line number="31" hits="2" branch="False" />
+                                <line number="32" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                                <line number="35" hits="1" branch="False" />
+                                <line number="36" hits="1" branch="False" />
+                                <line number="38" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="CreateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="False" />
+                                <line number="44" hits="1" branch="False" />
+                                <line number="45" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="UpdateTask" signature="(System.Int32,SampleApp.Core.Models.Task)" line-rate="0.7" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="49" hits="2" branch="False" />
+                                <line number="50" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="15" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="51" hits="1" branch="False" />
+                                <line number="54" hits="1" branch="False" />
+                                <line number="55" hits="1" branch="False" />
+                                <line number="56" hits="1" branch="False" />
+                                <line number="58" hits="0" branch="False" />
+                                <line number="59" hits="0" branch="False" />
+                                <line number="60" hits="0" branch="False" />
+                                <line number="62" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="DeleteTask" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="66" hits="2" branch="False" />
+                                <line number="67" hits="2" branch="False" />
+                                <line number="68" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="20" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="69" hits="1" branch="False" />
+                                <line number="71" hits="1" branch="False" />
+                                <line number="72" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTasksByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="76" hits="1" branch="False" />
+                                <line number="77" hits="1" branch="False" />
+                                <line number="78" hits="1" branch="False" />
+                                <line number="79" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Core.Services.ITaskService)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="14" hits="9" branch="False" />
+                                <line number="15" hits="9" branch="False" />
+                                <line number="16" hits="9" branch="False" />
+                                <line number="17" hits="9" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="21" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="24" hits="1" branch="False" />
+                        <line number="28" hits="2" branch="False" />
+                        <line number="30" hits="2" branch="False" />
+                        <line number="31" hits="2" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="35" hits="1" branch="False" />
+                        <line number="36" hits="1" branch="False" />
+                        <line number="38" hits="2" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="False" />
+                        <line number="44" hits="1" branch="False" />
+                        <line number="45" hits="1" branch="False" />
+                        <line number="49" hits="2" branch="False" />
+                        <line number="50" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="15" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="51" hits="1" branch="False" />
+                        <line number="54" hits="1" branch="False" />
+                        <line number="55" hits="1" branch="False" />
+                        <line number="56" hits="1" branch="False" />
+                        <line number="58" hits="0" branch="False" />
+                        <line number="59" hits="0" branch="False" />
+                        <line number="60" hits="0" branch="False" />
+                        <line number="62" hits="2" branch="False" />
+                        <line number="66" hits="2" branch="False" />
+                        <line number="67" hits="2" branch="False" />
+                        <line number="68" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="20" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="69" hits="1" branch="False" />
+                        <line number="71" hits="1" branch="False" />
+                        <line number="72" hits="2" branch="False" />
+                        <line number="76" hits="1" branch="False" />
+                        <line number="77" hits="1" branch="False" />
+                        <line number="78" hits="1" branch="False" />
+                        <line number="79" hits="1" branch="False" />
+                        <line number="14" hits="9" branch="False" />
+                        <line number="15" hits="9" branch="False" />
+                        <line number="16" hits="9" branch="False" />
+                        <line number="17" hits="9" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="SampleApp.Data" line-rate="0.9714" branch-rate="0.5" complexity="11">
+            <classes>
+                <class name="SampleApp.Data.Repositories.TaskRepository" filename="SampleApp.Data/Repositories/TaskRepository.cs" line-rate="0.9677" branch-rate="0.5" complexity="9">
+                    <methods>
+                        <method name="Create" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="19" hits="1" branch="False" />
+                                <line number="20" hits="1" branch="False" />
+                                <line number="21" hits="1" branch="False" />
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="Delete" signature="(System.Int32)" line-rate="0.875" branch-rate="0.5" complexity="2">
+                            <lines>
+                                <line number="26" hits="1" branch="False" />
+                                <line number="27" hits="1" branch="False" />
+                                <line number="28" hits="1" branch="True" condition-coverage="50% (1/2)">
+                                    <conditions>
+                                        <condition number="39" type="jump" coverage="50%" />
+                                    </conditions>
+                                </line>
+                                <line number="29" hits="0" branch="False" />
+                                <line number="31" hits="1" branch="False" />
+                                <line number="32" hits="1" branch="False" />
+                                <line number="33" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetAll" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="37" hits="1" branch="False" />
+                                <line number="38" hits="1" branch="False" />
+                                <line number="39" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetById" signature="(System.Int32)" line-rate="1" branch-rate="0.5" complexity="2">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="True" condition-coverage="50% (1/2)">
+                                    <conditions>
+                                        <condition number="33" type="jump" coverage="50%" />
+                                    </conditions>
+                                </line>
+                                <line number="44" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="47" hits="1" branch="False" />
+                                <line number="48" hits="1" branch="False" />
+                                <line number="49" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="Update" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="52" hits="1" branch="False" />
+                                <line number="53" hits="1" branch="False" />
+                                <line number="54" hits="1" branch="False" />
+                                <line number="55" hits="1" branch="False" />
+                                <line number="56" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Data.Context.ApplicationDbContext)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="13" hits="6" branch="False" />
+                                <line number="14" hits="6" branch="False" />
+                                <line number="15" hits="6" branch="False" />
+                                <line number="16" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="19" hits="1" branch="False" />
+                        <line number="20" hits="1" branch="False" />
+                        <line number="21" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="26" hits="1" branch="False" />
+                        <line number="27" hits="1" branch="False" />
+                        <line number="28" hits="1" branch="True" condition-coverage="50% (1/2)">
+                            <conditions>
+                                <condition number="39" type="jump" coverage="50%" />
+                            </conditions>
+                        </line>
+                        <line number="29" hits="0" branch="False" />
+                        <line number="31" hits="1" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="33" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="37" hits="1" branch="False" />
+                        <line number="38" hits="1" branch="False" />
+                        <line number="39" hits="1" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="True" condition-coverage="50% (1/2)">
+                            <conditions>
+                                <condition number="33" type="jump" coverage="50%" />
+                            </conditions>
+                        </line>
+                        <line number="44" hits="1" branch="False" />
+                        <line number="47" hits="1" branch="False" />
+                        <line number="48" hits="1" branch="False" />
+                        <line number="49" hits="1" branch="False" />
+                        <line number="52" hits="1" branch="False" />
+                        <line number="53" hits="1" branch="False" />
+                        <line number="54" hits="1" branch="False" />
+                        <line number="55" hits="1" branch="False" />
+                        <line number="56" hits="1" branch="False" />
+                        <line number="13" hits="6" branch="False" />
+                        <line number="14" hits="6" branch="False" />
+                        <line number="15" hits="6" branch="False" />
+                        <line number="16" hits="6" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Data.Context.ApplicationDbContext" filename="SampleApp.Data/Context/ApplicationDbContext.cs" line-rate="1" branch-rate="1" complexity="2">
+                    <methods>
+                        <method name="get_Tasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="13" hits="20" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(Microsoft.EntityFrameworkCore.DbContextOptions`1&lt;SampleApp.Data.Context.ApplicationDbContext&gt;)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="9" hits="6" branch="False" />
+                                <line number="10" hits="6" branch="False" />
+                                <line number="11" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="13" hits="20" branch="False" />
+                        <line number="9" hits="6" branch="False" />
+                        <line number="10" hits="6" branch="False" />
+                        <line number="11" hits="6" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="SampleApp.Core" line-rate="0.9772" branch-rate="0.8332999999999999" complexity="20">
+            <classes>
+                <class name="SampleApp.Core.Utils.Helpers.TaskHelpers" filename="SampleApp.Core/Utils/Helpers/TaskHelpers.cs" line-rate="0.9375" branch-rate="0.8332999999999999" complexity="7">
+                    <methods>
+                        <method name="IsTaskOverdue" signature="(System.DateTime)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="6" hits="2" branch="False" />
+                                <line number="7" hits="2" branch="False" />
+                                <line number="8" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetPriorityLabel" signature="(SampleApp.Core.Models.Priority)" line-rate="0.8887999999999999" branch-rate="0.75" complexity="4">
+                            <lines>
+                                <line number="11" hits="3" branch="False" />
+                                <line number="12" hits="3" branch="True" condition-coverage="75% (3/4)">
+                                    <conditions>
+                                        <condition number="6" type="switch" coverage="75%" />
+                                    </conditions>
+                                </line>
+                                <line number="13" hits="3" branch="False" />
+                                <line number="14" hits="1" branch="False" />
+                                <line number="15" hits="1" branch="False" />
+                                <line number="16" hits="1" branch="False" />
+                                <line number="17" hits="0" branch="False" />
+                                <line number="18" hits="3" branch="False" />
+                                <line number="19" hits="3" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="CalculateDaysRemaining" signature="(System.DateTime)" line-rate="1" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="22" hits="2" branch="False" />
+                                <line number="23" hits="2" branch="False" />
+                                <line number="24" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="23" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="25" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="6" hits="2" branch="False" />
+                        <line number="7" hits="2" branch="False" />
+                        <line number="8" hits="2" branch="False" />
+                        <line number="11" hits="3" branch="False" />
+                        <line number="12" hits="3" branch="True" condition-coverage="75% (3/4)">
+                            <conditions>
+                                <condition number="6" type="switch" coverage="75%" />
+                            </conditions>
+                        </line>
+                        <line number="13" hits="3" branch="False" />
+                        <line number="14" hits="1" branch="False" />
+                        <line number="15" hits="1" branch="False" />
+                        <line number="16" hits="1" branch="False" />
+                        <line number="17" hits="0" branch="False" />
+                        <line number="18" hits="3" branch="False" />
+                        <line number="19" hits="3" branch="False" />
+                        <line number="22" hits="2" branch="False" />
+                        <line number="23" hits="2" branch="False" />
+                        <line number="24" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="23" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="25" hits="2" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Core.Services.TaskService" filename="SampleApp.Core/Services/TaskService.cs" line-rate="1" branch-rate="1" complexity="7">
+                    <methods>
+                        <method name="CreateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="17" hits="1" branch="False" />
+                                <line number="18" hits="1" branch="False" />
+                                <line number="19" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="DeleteTask" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                                <line number="24" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetAllTasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="27" hits="1" branch="False" />
+                                <line number="28" hits="1" branch="False" />
+                                <line number="29" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTaskById" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="32" hits="1" branch="False" />
+                                <line number="33" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTasksByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="37" hits="1" branch="False" />
+                                <line number="38" hits="1" branch="False" />
+                                <line number="39" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="UpdateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="False" />
+                                <line number="44" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Core.Repositories.ITaskRepository)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="11" hits="6" branch="False" />
+                                <line number="12" hits="6" branch="False" />
+                                <line number="13" hits="6" branch="False" />
+                                <line number="14" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="17" hits="1" branch="False" />
+                        <line number="18" hits="1" branch="False" />
+                        <line number="19" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="24" hits="1" branch="False" />
+                        <line number="27" hits="1" branch="False" />
+                        <line number="28" hits="1" branch="False" />
+                        <line number="29" hits="1" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="33" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="37" hits="1" branch="False" />
+                        <line number="38" hits="1" branch="False" />
+                        <line number="39" hits="1" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="False" />
+                        <line number="44" hits="1" branch="False" />
+                        <line number="11" hits="6" branch="False" />
+                        <line number="12" hits="6" branch="False" />
+                        <line number="13" hits="6" branch="False" />
+                        <line number="14" hits="6" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Core.Models.Task" filename="SampleApp.Core/Models/Task.cs" line-rate="1" branch-rate="1" complexity="6">
+                    <methods>
+                        <method name="get_Id" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="5" hits="26" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Title" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="6" hits="62" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Description" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="7" hits="29" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_IsCompleted" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="8" hits="5" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_DueDate" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="9" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Priority" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="10" hits="18" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="5" hits="26" branch="False" />
+                        <line number="6" hits="62" branch="False" />
+                        <line number="7" hits="29" branch="False" />
+                        <line number="8" hits="5" branch="False" />
+                        <line number="9" hits="1" branch="False" />
+                        <line number="10" hits="18" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/no_packages.cobertura.xml
+++ b/analysis/analysers/importers/CoverageImporter/src/test/resources/languages/csharp/no_packages.cobertura.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8201" branch-rate="0.6875" version="1.9" timestamp="1744712956" lines-covered="114" lines-valid="139" branches-covered="11" branches-valid="16">
+    <sources>
+        <source>/Users/testuser/path/to/testproject/</source>
+    </sources>
+    <packages>
+
+    </packages>
+</coverage>

--- a/analysis/test/data/codecharta/coverageReports/coverage.cobertura.xml
+++ b/analysis/test/data/codecharta/coverageReports/coverage.cobertura.xml
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8201" branch-rate="0.6875" version="1.9" timestamp="1744712956" lines-covered="114" lines-valid="139" branches-covered="11" branches-valid="16">
+    <sources>
+        <source>/Users/testuser/path/to/testproject/</source>
+    </sources>
+    <packages>
+        <package name="SampleApp.Api" line-rate="0.6165999999999999" branch-rate="0.6666" complexity="13">
+            <classes>
+                <class name="Program" filename="SampleApp.Api/Program.cs" line-rate="0" branch-rate="0" complexity="2">
+                    <methods>
+                        <method name="&lt;Main&gt;$" signature="(System.String[])" line-rate="0" branch-rate="0" complexity="2">
+                            <lines>
+                                <line number="7" hits="0" branch="False" />
+                                <line number="10" hits="0" branch="False" />
+                                <line number="12" hits="0" branch="False" />
+                                <line number="13" hits="0" branch="False" />
+                                <line number="16" hits="0" branch="False" />
+                                <line number="17" hits="0" branch="False" />
+                                <line number="20" hits="0" branch="False" />
+                                <line number="21" hits="0" branch="False" />
+                                <line number="23" hits="0" branch="False" />
+                                <line number="26" hits="0" branch="True" condition-coverage="0% (0/2)">
+                                    <conditions>
+                                        <condition number="133" type="jump" coverage="0%" />
+                                    </conditions>
+                                </line>
+                                <line number="27" hits="0" branch="False" />
+                                <line number="28" hits="0" branch="False" />
+                                <line number="29" hits="0" branch="False" />
+                                <line number="30" hits="0" branch="False" />
+                                <line number="32" hits="0" branch="False" />
+                                <line number="34" hits="0" branch="False" />
+                                <line number="36" hits="0" branch="False" />
+                                <line number="38" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="7" hits="0" branch="False" />
+                        <line number="10" hits="0" branch="False" />
+                        <line number="12" hits="0" branch="False" />
+                        <line number="13" hits="0" branch="False" />
+                        <line number="16" hits="0" branch="False" />
+                        <line number="17" hits="0" branch="False" />
+                        <line number="20" hits="0" branch="False" />
+                        <line number="21" hits="0" branch="False" />
+                        <line number="23" hits="0" branch="False" />
+                        <line number="26" hits="0" branch="True" condition-coverage="0% (0/2)">
+                            <conditions>
+                                <condition number="133" type="jump" coverage="0%" />
+                            </conditions>
+                        </line>
+                        <line number="27" hits="0" branch="False" />
+                        <line number="28" hits="0" branch="False" />
+                        <line number="29" hits="0" branch="False" />
+                        <line number="30" hits="0" branch="False" />
+                        <line number="32" hits="0" branch="False" />
+                        <line number="34" hits="0" branch="False" />
+                        <line number="36" hits="0" branch="False" />
+                        <line number="38" hits="0" branch="False" />
+                    </lines>
+                </class>
+                <class name="WeatherForecast" filename="SampleApp.Api/Program.cs" line-rate="0" branch-rate="1" complexity="2">
+                    <methods>
+                        <method name="get_Date" signature="()" line-rate="0" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="40" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_TemperatureF" signature="()" line-rate="0" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="0" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="40" hits="0" branch="False" />
+                        <line number="42" hits="0" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Api.Controllers.TasksController" filename="SampleApp.Api/Controllers/TasksController.cs" line-rate="0.925" branch-rate="1" complexity="9">
+                    <methods>
+                        <method name="GetAllTasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="21" hits="1" branch="False" />
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                                <line number="24" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTaskById" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="28" hits="2" branch="False" />
+                                <line number="30" hits="2" branch="False" />
+                                <line number="31" hits="2" branch="False" />
+                                <line number="32" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                                <line number="35" hits="1" branch="False" />
+                                <line number="36" hits="1" branch="False" />
+                                <line number="38" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="CreateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="False" />
+                                <line number="44" hits="1" branch="False" />
+                                <line number="45" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="UpdateTask" signature="(System.Int32,SampleApp.Core.Models.Task)" line-rate="0.7" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="49" hits="2" branch="False" />
+                                <line number="50" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="15" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="51" hits="1" branch="False" />
+                                <line number="54" hits="1" branch="False" />
+                                <line number="55" hits="1" branch="False" />
+                                <line number="56" hits="1" branch="False" />
+                                <line number="58" hits="0" branch="False" />
+                                <line number="59" hits="0" branch="False" />
+                                <line number="60" hits="0" branch="False" />
+                                <line number="62" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="DeleteTask" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="66" hits="2" branch="False" />
+                                <line number="67" hits="2" branch="False" />
+                                <line number="68" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="20" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="69" hits="1" branch="False" />
+                                <line number="71" hits="1" branch="False" />
+                                <line number="72" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTasksByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="76" hits="1" branch="False" />
+                                <line number="77" hits="1" branch="False" />
+                                <line number="78" hits="1" branch="False" />
+                                <line number="79" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Core.Services.ITaskService)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="14" hits="9" branch="False" />
+                                <line number="15" hits="9" branch="False" />
+                                <line number="16" hits="9" branch="False" />
+                                <line number="17" hits="9" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="21" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="24" hits="1" branch="False" />
+                        <line number="28" hits="2" branch="False" />
+                        <line number="30" hits="2" branch="False" />
+                        <line number="31" hits="2" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="35" hits="1" branch="False" />
+                        <line number="36" hits="1" branch="False" />
+                        <line number="38" hits="2" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="False" />
+                        <line number="44" hits="1" branch="False" />
+                        <line number="45" hits="1" branch="False" />
+                        <line number="49" hits="2" branch="False" />
+                        <line number="50" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="15" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="51" hits="1" branch="False" />
+                        <line number="54" hits="1" branch="False" />
+                        <line number="55" hits="1" branch="False" />
+                        <line number="56" hits="1" branch="False" />
+                        <line number="58" hits="0" branch="False" />
+                        <line number="59" hits="0" branch="False" />
+                        <line number="60" hits="0" branch="False" />
+                        <line number="62" hits="2" branch="False" />
+                        <line number="66" hits="2" branch="False" />
+                        <line number="67" hits="2" branch="False" />
+                        <line number="68" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="20" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="69" hits="1" branch="False" />
+                        <line number="71" hits="1" branch="False" />
+                        <line number="72" hits="2" branch="False" />
+                        <line number="76" hits="1" branch="False" />
+                        <line number="77" hits="1" branch="False" />
+                        <line number="78" hits="1" branch="False" />
+                        <line number="79" hits="1" branch="False" />
+                        <line number="14" hits="9" branch="False" />
+                        <line number="15" hits="9" branch="False" />
+                        <line number="16" hits="9" branch="False" />
+                        <line number="17" hits="9" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="SampleApp.Data" line-rate="0.9714" branch-rate="0.5" complexity="11">
+            <classes>
+                <class name="SampleApp.Data.Repositories.TaskRepository" filename="SampleApp.Data/Repositories/TaskRepository.cs" line-rate="0.9677" branch-rate="0.5" complexity="9">
+                    <methods>
+                        <method name="Create" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="19" hits="1" branch="False" />
+                                <line number="20" hits="1" branch="False" />
+                                <line number="21" hits="1" branch="False" />
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="Delete" signature="(System.Int32)" line-rate="0.875" branch-rate="0.5" complexity="2">
+                            <lines>
+                                <line number="26" hits="1" branch="False" />
+                                <line number="27" hits="1" branch="False" />
+                                <line number="28" hits="1" branch="True" condition-coverage="50% (1/2)">
+                                    <conditions>
+                                        <condition number="39" type="jump" coverage="50%" />
+                                    </conditions>
+                                </line>
+                                <line number="29" hits="0" branch="False" />
+                                <line number="31" hits="1" branch="False" />
+                                <line number="32" hits="1" branch="False" />
+                                <line number="33" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetAll" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="37" hits="1" branch="False" />
+                                <line number="38" hits="1" branch="False" />
+                                <line number="39" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetById" signature="(System.Int32)" line-rate="1" branch-rate="0.5" complexity="2">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="True" condition-coverage="50% (1/2)">
+                                    <conditions>
+                                        <condition number="33" type="jump" coverage="50%" />
+                                    </conditions>
+                                </line>
+                                <line number="44" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="47" hits="1" branch="False" />
+                                <line number="48" hits="1" branch="False" />
+                                <line number="49" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="Update" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="52" hits="1" branch="False" />
+                                <line number="53" hits="1" branch="False" />
+                                <line number="54" hits="1" branch="False" />
+                                <line number="55" hits="1" branch="False" />
+                                <line number="56" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Data.Context.ApplicationDbContext)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="13" hits="6" branch="False" />
+                                <line number="14" hits="6" branch="False" />
+                                <line number="15" hits="6" branch="False" />
+                                <line number="16" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="19" hits="1" branch="False" />
+                        <line number="20" hits="1" branch="False" />
+                        <line number="21" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="26" hits="1" branch="False" />
+                        <line number="27" hits="1" branch="False" />
+                        <line number="28" hits="1" branch="True" condition-coverage="50% (1/2)">
+                            <conditions>
+                                <condition number="39" type="jump" coverage="50%" />
+                            </conditions>
+                        </line>
+                        <line number="29" hits="0" branch="False" />
+                        <line number="31" hits="1" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="33" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="37" hits="1" branch="False" />
+                        <line number="38" hits="1" branch="False" />
+                        <line number="39" hits="1" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="True" condition-coverage="50% (1/2)">
+                            <conditions>
+                                <condition number="33" type="jump" coverage="50%" />
+                            </conditions>
+                        </line>
+                        <line number="44" hits="1" branch="False" />
+                        <line number="47" hits="1" branch="False" />
+                        <line number="48" hits="1" branch="False" />
+                        <line number="49" hits="1" branch="False" />
+                        <line number="52" hits="1" branch="False" />
+                        <line number="53" hits="1" branch="False" />
+                        <line number="54" hits="1" branch="False" />
+                        <line number="55" hits="1" branch="False" />
+                        <line number="56" hits="1" branch="False" />
+                        <line number="13" hits="6" branch="False" />
+                        <line number="14" hits="6" branch="False" />
+                        <line number="15" hits="6" branch="False" />
+                        <line number="16" hits="6" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Data.Context.ApplicationDbContext" filename="SampleApp.Data/Context/ApplicationDbContext.cs" line-rate="1" branch-rate="1" complexity="2">
+                    <methods>
+                        <method name="get_Tasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="13" hits="20" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(Microsoft.EntityFrameworkCore.DbContextOptions`1&lt;SampleApp.Data.Context.ApplicationDbContext&gt;)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="9" hits="6" branch="False" />
+                                <line number="10" hits="6" branch="False" />
+                                <line number="11" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="13" hits="20" branch="False" />
+                        <line number="9" hits="6" branch="False" />
+                        <line number="10" hits="6" branch="False" />
+                        <line number="11" hits="6" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="SampleApp.Core" line-rate="0.9772" branch-rate="0.8332999999999999" complexity="20">
+            <classes>
+                <class name="SampleApp.Core.Utils.Helpers.TaskHelpers" filename="SampleApp.Core/Utils/Helpers/TaskHelpers.cs" line-rate="0.9375" branch-rate="0.8332999999999999" complexity="7">
+                    <methods>
+                        <method name="IsTaskOverdue" signature="(System.DateTime)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="6" hits="2" branch="False" />
+                                <line number="7" hits="2" branch="False" />
+                                <line number="8" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetPriorityLabel" signature="(SampleApp.Core.Models.Priority)" line-rate="0.8887999999999999" branch-rate="0.75" complexity="4">
+                            <lines>
+                                <line number="11" hits="3" branch="False" />
+                                <line number="12" hits="3" branch="True" condition-coverage="75% (3/4)">
+                                    <conditions>
+                                        <condition number="6" type="switch" coverage="75%" />
+                                    </conditions>
+                                </line>
+                                <line number="13" hits="3" branch="False" />
+                                <line number="14" hits="1" branch="False" />
+                                <line number="15" hits="1" branch="False" />
+                                <line number="16" hits="1" branch="False" />
+                                <line number="17" hits="0" branch="False" />
+                                <line number="18" hits="3" branch="False" />
+                                <line number="19" hits="3" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="CalculateDaysRemaining" signature="(System.DateTime)" line-rate="1" branch-rate="1" complexity="2">
+                            <lines>
+                                <line number="22" hits="2" branch="False" />
+                                <line number="23" hits="2" branch="False" />
+                                <line number="24" hits="2" branch="True" condition-coverage="100% (2/2)">
+                                    <conditions>
+                                        <condition number="23" type="jump" coverage="100%" />
+                                    </conditions>
+                                </line>
+                                <line number="25" hits="2" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="6" hits="2" branch="False" />
+                        <line number="7" hits="2" branch="False" />
+                        <line number="8" hits="2" branch="False" />
+                        <line number="11" hits="3" branch="False" />
+                        <line number="12" hits="3" branch="True" condition-coverage="75% (3/4)">
+                            <conditions>
+                                <condition number="6" type="switch" coverage="75%" />
+                            </conditions>
+                        </line>
+                        <line number="13" hits="3" branch="False" />
+                        <line number="14" hits="1" branch="False" />
+                        <line number="15" hits="1" branch="False" />
+                        <line number="16" hits="1" branch="False" />
+                        <line number="17" hits="0" branch="False" />
+                        <line number="18" hits="3" branch="False" />
+                        <line number="19" hits="3" branch="False" />
+                        <line number="22" hits="2" branch="False" />
+                        <line number="23" hits="2" branch="False" />
+                        <line number="24" hits="2" branch="True" condition-coverage="100% (2/2)">
+                            <conditions>
+                                <condition number="23" type="jump" coverage="100%" />
+                            </conditions>
+                        </line>
+                        <line number="25" hits="2" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Core.Services.TaskService" filename="SampleApp.Core/Services/TaskService.cs" line-rate="1" branch-rate="1" complexity="7">
+                    <methods>
+                        <method name="CreateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="17" hits="1" branch="False" />
+                                <line number="18" hits="1" branch="False" />
+                                <line number="19" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="DeleteTask" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="22" hits="1" branch="False" />
+                                <line number="23" hits="1" branch="False" />
+                                <line number="24" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetAllTasks" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="27" hits="1" branch="False" />
+                                <line number="28" hits="1" branch="False" />
+                                <line number="29" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTaskById" signature="(System.Int32)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="32" hits="1" branch="False" />
+                                <line number="33" hits="1" branch="False" />
+                                <line number="34" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="GetTasksByPriority" signature="(SampleApp.Core.Models.Priority)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="37" hits="1" branch="False" />
+                                <line number="38" hits="1" branch="False" />
+                                <line number="39" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="UpdateTask" signature="(SampleApp.Core.Models.Task)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="42" hits="1" branch="False" />
+                                <line number="43" hits="1" branch="False" />
+                                <line number="44" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name=".ctor" signature="(SampleApp.Core.Repositories.ITaskRepository)" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="11" hits="6" branch="False" />
+                                <line number="12" hits="6" branch="False" />
+                                <line number="13" hits="6" branch="False" />
+                                <line number="14" hits="6" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="17" hits="1" branch="False" />
+                        <line number="18" hits="1" branch="False" />
+                        <line number="19" hits="1" branch="False" />
+                        <line number="22" hits="1" branch="False" />
+                        <line number="23" hits="1" branch="False" />
+                        <line number="24" hits="1" branch="False" />
+                        <line number="27" hits="1" branch="False" />
+                        <line number="28" hits="1" branch="False" />
+                        <line number="29" hits="1" branch="False" />
+                        <line number="32" hits="1" branch="False" />
+                        <line number="33" hits="1" branch="False" />
+                        <line number="34" hits="1" branch="False" />
+                        <line number="37" hits="1" branch="False" />
+                        <line number="38" hits="1" branch="False" />
+                        <line number="39" hits="1" branch="False" />
+                        <line number="42" hits="1" branch="False" />
+                        <line number="43" hits="1" branch="False" />
+                        <line number="44" hits="1" branch="False" />
+                        <line number="11" hits="6" branch="False" />
+                        <line number="12" hits="6" branch="False" />
+                        <line number="13" hits="6" branch="False" />
+                        <line number="14" hits="6" branch="False" />
+                    </lines>
+                </class>
+                <class name="SampleApp.Core.Models.Task" filename="SampleApp.Core/Models/Task.cs" line-rate="1" branch-rate="1" complexity="6">
+                    <methods>
+                        <method name="get_Id" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="5" hits="26" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Title" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="6" hits="62" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Description" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="7" hits="29" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_IsCompleted" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="8" hits="5" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_DueDate" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="9" hits="1" branch="False" />
+                            </lines>
+                        </method>
+                        <method name="get_Priority" signature="()" line-rate="1" branch-rate="1" complexity="1">
+                            <lines>
+                                <line number="10" hits="18" branch="False" />
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="5" hits="26" branch="False" />
+                        <line number="6" hits="62" branch="False" />
+                        <line number="7" hits="29" branch="False" />
+                        <line number="8" hits="5" branch="False" />
+                        <line number="9" hits="1" branch="False" />
+                        <line number="10" hits="18" branch="False" />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/analysis/test/golden_test.sh
+++ b/analysis/test/golden_test.sh
@@ -156,6 +156,13 @@ check_coverageimporter_java() {
     validate "${ACTUAL_JAVA_COVERAGE_JSON}"
 }
 
+check_coverageimporter_csharp() {
+    echo " ---- expect CoverageImporter to produce valid cc.json file for csharp"
+    ACTUAL_CSHARP_COVERAGE_JSON="${TEMP_DIR}/actual_coverageimporter_csharp.cc.json"
+    "${CCSH}" coverageimport "${DATA}/coverageReports/coverage.cobertura.xml" --language=csharp -o "${ACTUAL_CSHARP_COVERAGE_JSON}" -nc
+    validate "${ACTUAL_CSHARP_COVERAGE_JSON}"
+}
+
 check_coverageimporter() {
     echo " -- expect CoverageImporter to produce valid cc.json files for all supported languages"
     check_coverageimporter_javascript


### PR DESCRIPTION
# Coverage importer for c#

Closes: #4040

## Description

Adds a coverage importer for dotnet and c# that supports reports generated by coverlet in the cobertura.xml format

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
