### PR TITLE
fix(analysis): remove all edges from custom view configs (#4056)

### DIFF
--- a/visualization/app/codeCharta/util/customConfigBuilder.ts
+++ b/visualization/app/codeCharta/util/customConfigBuilder.ts
@@ -126,7 +126,6 @@ function initializeFileSettings(target: CustomConfig) {
 
 function deepMapOneToOther<T>(source: CcState, target: T) {
     for (const [key, value] of Object.entries(source)) {
-        console.log("mapping key:", key)
         // if a property of source is missing, we don't want to copy it into target.
         if (!Object.prototype.hasOwnProperty.call(target, key)) {
             continue

--- a/visualization/app/codeCharta/util/customConfigBuilder.ts
+++ b/visualization/app/codeCharta/util/customConfigBuilder.ts
@@ -39,6 +39,7 @@ export function buildCustomConfigFromState(
 
     // Override the default state settings with the stored CustomConfig values
     deepMapOneToOther(state, customConfig.stateSettings)
+    customConfig.stateSettings.fileSettings.edges = []
 
     customConfig.id = md5(JSON.stringify(customConfig, stateObjectReplacer))
     return customConfig
@@ -125,6 +126,7 @@ function initializeFileSettings(target: CustomConfig) {
 
 function deepMapOneToOther<T>(source: CcState, target: T) {
     for (const [key, value] of Object.entries(source)) {
+        console.log("mapping key:", key)
         // if a property of source is missing, we don't want to copy it into target.
         if (!Object.prototype.hasOwnProperty.call(target, key)) {
             continue


### PR DESCRIPTION
# Custom configs no longer include edges

Closes: #4056

## Description

For larger maps with lots of edges the custom config json files were often multiple mb large due to the edges.
Therefore the edges were removed (this should not change any functionality)

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
