### PR TITLE
Feat/3923/auto complete

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
 - Add new UnifiedParser that is based on treesitter and works without external tools [#4070](https://github.com/MaibornWolff/codecharta/pull/4070)
   - It currently supports:
     - Typescript
     - Kotlin
+- Add auto-completing file input to all interactive dialogs [#4081](https://github.com/MaibornWolff/codecharta/pull/4081)
 
 ## [1.133.0] - 2025-05-19
 

--- a/analysis/analysers/exporters/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/exporters/csv/Dialog.kt
+++ b/analysis/analysers/exporters/CSVExporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/exporters/csv/Dialog.kt
@@ -4,7 +4,7 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptInputNumber
 import de.maibornwolff.codecharta.serialization.FileExtension
@@ -12,7 +12,7 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileNames: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
                 multiple = true,

--- a/analysis/analysers/filters/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/edgefilter/Dialog.kt
+++ b/analysis/analysers/filters/EdgeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/edgefilter/Dialog.kt
@@ -4,7 +4,7 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 import de.maibornwolff.codecharta.util.Logger
@@ -12,7 +12,7 @@ import de.maibornwolff.codecharta.util.Logger
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
                 onInputReady = testCallback()

--- a/analysis/analysers/filters/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/Dialog.kt
+++ b/analysis/analysers/filters/MergeFilter/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/mergefilter/Dialog.kt
@@ -7,7 +7,7 @@ import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.InputValidator
 import de.maibornwolff.codecharta.dialogProvider.promptCheckbox
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptInputNumber
 import de.maibornwolff.codecharta.dialogProvider.promptList
@@ -18,7 +18,7 @@ class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             val inputFileNames: String =
-                session.promptDefaultFileFolderInput(
+                session.promptDefaultDirectoryAssistedInput(
                     inputType = InputType.FOLDER_AND_FILE,
                     fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
                     multiple = true,

--- a/analysis/analysers/filters/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/structuremodifier/Dialog.kt
+++ b/analysis/analysers/filters/StructureModifier/src/main/kotlin/de/maibornwolff/codecharta/analysers/filters/structuremodifier/Dialog.kt
@@ -4,7 +4,7 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptInputNumber
 import de.maibornwolff.codecharta.dialogProvider.promptList
@@ -14,7 +14,7 @@ class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             val inputFileName: String =
-                session.promptDefaultFileFolderInput(
+                session.promptDefaultDirectoryAssistedInput(
                     inputType = InputType.FILE,
                     fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
                     onInputReady = testCallback()

--- a/analysis/analysers/importers/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/Dialog.kt
+++ b/analysis/analysers/importers/CSVImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/csv/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileNames: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
                 multiple = true,

--- a/analysis/analysers/importers/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/codemaat/Dialog.kt
+++ b/analysis/analysers/importers/CodeMaatImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/codemaat/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileNames: String = session.promptDefaultFileFolderInput(
+            val inputFileNames: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
                 multiple = true,

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/Dialog.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/Dialog.kt
@@ -5,7 +5,7 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptList
 import java.util.Locale
@@ -21,7 +21,7 @@ class Dialog {
 
             val format = getFormatByName(formatChoice)
 
-            val reportFile: String = session.promptDefaultFileFolderInput(
+            val reportFile: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(format.fileExtension),
                 onInputReady = testCallback()

--- a/analysis/analysers/importers/SourceMonitorImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sourcemonitor/Dialog.kt
+++ b/analysis/analysers/importers/SourceMonitorImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sourcemonitor/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileNames = session.promptDefaultFileFolderInput(
+            val inputFileNames = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CSV),
                 multiple = true,

--- a/analysis/analysers/importers/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/tokei/Dialog.kt
+++ b/analysis/analysers/importers/TokeiImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/tokei/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 InputType.FILE,
                 listOf(FileExtension.JSON),
                 onInputReady = testCallback()

--- a/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
+++ b/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
@@ -3,27 +3,25 @@ package de.maibornwolff.codecharta.analysers.parsers.gitlog.subcommands
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
-import de.maibornwolff.codecharta.dialogProvider.InputValidator
-import de.maibornwolff.codecharta.dialogProvider.promptInput
+import de.maibornwolff.codecharta.dialogProvider.InputType
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 
 class LogScanDialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             print("You can generate this file with: git log --numstat --raw --topo-order --reverse -m > git.log")
-            val gitLogFile = session.promptInput(
-                message = "What is the git.log file that has to be parsed?",
-                hint = "git.log",
-                allowEmptyInput = false,
-                inputValidator = InputValidator.isInputAnExistingFile(),
+            val gitLogFile = session.promptDefaultDirectoryAssistedInput(
+                inputType = InputType.FILE,
+                fileExtensionList = listOf(),
+                multiple = false,
                 onInputReady = testCallback()
             )
 
             print("You can generate this file with: git ls-files > file-name-list.txt")
-            val gitLsFile = session.promptInput(
-                message = "What is the path to the file name list?",
-                hint = "file-name-list.txt",
-                allowEmptyInput = false,
-                inputValidator = InputValidator.isInputAnExistingFile(),
+            val gitLsFile = session.promptDefaultDirectoryAssistedInput(
+                inputType = InputType.FILE,
+                fileExtensionList = listOf(),
+                multiple = false,
                 onInputReady = testCallback()
             )
 

--- a/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
+++ b/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
@@ -15,6 +15,7 @@ class LogScanDialog {
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(),
                 multiple = false,
+                postMessageText = " (Git Log)",
                 onInputReady = testCallback()
             )
 
@@ -23,6 +24,7 @@ class LogScanDialog {
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(),
                 multiple = false,
+                postMessageText = " (File Name List)",
                 onInputReady = testCallback()
             )
 

--- a/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
+++ b/analysis/analysers/parsers/GitLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/gitlog/subcommands/LogScanDialog.kt
@@ -4,12 +4,13 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
+import de.maibornwolff.codecharta.dialogProvider.displayInfo
 import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 
 class LogScanDialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            print("You can generate this file with: git log --numstat --raw --topo-order --reverse -m > git.log")
+            session.displayInfo("You can generate this file with: git log --numstat --raw --topo-order --reverse -m > git.log")
             val gitLogFile = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(),
@@ -17,7 +18,7 @@ class LogScanDialog {
                 onInputReady = testCallback()
             )
 
-            print("You can generate this file with: git ls-files > file-name-list.txt")
+            session.displayInfo("You can generate this file with: git ls-files > file-name-list.txt")
             val gitLsFile = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(),

--- a/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/Dialog.kt
+++ b/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptInputNumber
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName = session.promptDefaultFileFolderInput(
+            val inputFileName = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(),
                 onInputReady = testCallback()

--- a/analysis/analysers/parsers/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/svnlog/Dialog.kt
+++ b/analysis/analysers/parsers/SVNLogParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/svnlog/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             println("You can generate this file with: svn log --verbose > svn.log")
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(),
                 onInputReady = testCallback()

--- a/analysis/analysers/parsers/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/sourcecode/Dialog.kt
+++ b/analysis/analysers/parsers/SourceCodeParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/sourcecode/Dialog.kt
@@ -5,14 +5,14 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptList
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(),
                 onInputReady = testCallback()

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/Dialog.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/Dialog.kt
@@ -5,7 +5,7 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptConfirm
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInput
 import de.maibornwolff.codecharta.dialogProvider.promptList
 
@@ -44,7 +44,7 @@ class Dialog {
         }
 
         private fun inputFileQuestion(session: Session): String {
-            return session.promptDefaultFileFolderInput(
+            return session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FOLDER_AND_FILE,
                 fileExtensionList = listOf(),
                 onInputReady = testCallback()

--- a/analysis/analysers/tools/InspectionTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/inspection/Dialog.kt
+++ b/analysis/analysers/tools/InspectionTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/inspection/Dialog.kt
@@ -4,14 +4,14 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.dialogProvider.promptInputNumber
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            val inputFileName: String = session.promptDefaultFileFolderInput(
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
                 onInputReady = testCallback()

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -5,20 +5,30 @@ import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
 import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.promptInputComplete
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             print("Which file do you want to validate?")
-            val inputFileName: String = session.promptDefaultFileFolderInput(
-                inputType = InputType.FILE,
-                fileExtensionList = listOf(
-                    FileExtension.CCJSON,
-                    FileExtension.CCGZ
-                ),
+            val inputFileName: String = session.promptInputComplete(
+                message = "Validate file",
+                hint = "someInput",
+                allowEmptyInput = false,
+                invalidInputMessage = "Input Invalid",
                 onInputReady = testCallback()
             )
+
+
+//                session.promptDefaultFileFolderInput(
+//                inputType = InputType.FILE,
+//                fileExtensionList = listOf(
+//                    FileExtension.CCJSON,
+//                    FileExtension.CCGZ
+//                ),
+//                onInputReady = testCallback()
+//            )
 
             return listOf(inputFileName)
         }

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -3,8 +3,9 @@ package de.maibornwolff.codecharta.analysers.tools.validation
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
+import de.maibornwolff.codecharta.dialogProvider.DialogDirectoryProvider
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptDefaultFileFolderInput
+import de.maibornwolff.codecharta.dialogProvider.InputValidator
 import de.maibornwolff.codecharta.dialogProvider.promptInputComplete
 import de.maibornwolff.codecharta.serialization.FileExtension
 
@@ -14,12 +15,10 @@ class Dialog {
             print("Which file do you want to validate?")
             val inputFileName: String = session.promptInputComplete(
                 message = "Validate file",
-                hint = "someInput",
-                allowEmptyInput = false,
-                invalidInputMessage = "Input Invalid",
+                inputValidator = InputValidator.isFileOrFolderValid(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCGZ)),
+                dialogDirectoryProvider = DialogDirectoryProvider(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON)),
                 onInputReady = testCallback()
             )
-
 
 //                session.promptDefaultFileFolderInput(
 //                inputType = InputType.FILE,

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -15,8 +15,8 @@ class Dialog {
             print("Which file do you want to validate?")
             val inputFileName: String = session.promptInputComplete(
                 message = "Validate file",
-                inputValidator = InputValidator.isFileOrFolderValid(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCGZ)),
-                dialogDirectoryProvider = DialogDirectoryProvider(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON)),
+                inputValidator = InputValidator.isFileOrFolderValid(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCGZ), true),
+                dialogDirectoryProvider = DialogDirectoryProvider(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON), true),
                 onInputReady = testCallback()
             )
 

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -3,29 +3,20 @@ package de.maibornwolff.codecharta.analysers.tools.validation
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
-import de.maibornwolff.codecharta.dialogProvider.DirectoryNavigator
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.promptInputDirectoryAssisted
+import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             print("Which file do you want to validate?")
-            val inputFileName: String = session.promptInputDirectoryAssisted(
-                message = "Validate file",
-                directoryNavigator = DirectoryNavigator(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON), true),
+            val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
+                inputType = InputType.FILE,
+                fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),
+                multiple = false,
                 onInputReady = testCallback()
             )
-
-//                session.promptDefaultFileFolderInput(
-//                inputType = InputType.FILE,
-//                fileExtensionList = listOf(
-//                    FileExtension.CCJSON,
-//                    FileExtension.CCGZ
-//                ),
-//                onInputReady = testCallback()
-//            )
 
             return listOf(inputFileName)
         }

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -4,13 +4,14 @@ import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
 import de.maibornwolff.codecharta.dialogProvider.InputType
+import de.maibornwolff.codecharta.dialogProvider.displayInfo
 import de.maibornwolff.codecharta.dialogProvider.promptDefaultDirectoryAssistedInput
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
-            print("Which file do you want to validate?")
+            session.displayInfo("Validate whether a file is CodeCharta conform")
             val inputFileName: String = session.promptDefaultDirectoryAssistedInput(
                 inputType = InputType.FILE,
                 fileExtensionList = listOf(FileExtension.CCJSON, FileExtension.CCGZ),

--- a/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
+++ b/analysis/analysers/tools/ValidationTool/src/main/kotlin/de/maibornwolff/codecharta/analysers/tools/validation/Dialog.kt
@@ -3,20 +3,18 @@ package de.maibornwolff.codecharta.analysers.tools.validation
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.analysers.analyserinterface.AnalyserDialogInterface
-import de.maibornwolff.codecharta.dialogProvider.DialogDirectoryProvider
+import de.maibornwolff.codecharta.dialogProvider.DirectoryNavigator
 import de.maibornwolff.codecharta.dialogProvider.InputType
-import de.maibornwolff.codecharta.dialogProvider.InputValidator
-import de.maibornwolff.codecharta.dialogProvider.promptInputComplete
+import de.maibornwolff.codecharta.dialogProvider.promptInputDirectoryAssisted
 import de.maibornwolff.codecharta.serialization.FileExtension
 
 class Dialog {
     companion object : AnalyserDialogInterface {
         override fun collectAnalyserArgs(session: Session): List<String> {
             print("Which file do you want to validate?")
-            val inputFileName: String = session.promptInputComplete(
+            val inputFileName: String = session.promptInputDirectoryAssisted(
                 message = "Validate file",
-                inputValidator = InputValidator.isFileOrFolderValid(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCGZ), true),
-                dialogDirectoryProvider = DialogDirectoryProvider(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON), true),
+                directoryNavigator = DirectoryNavigator(InputType.FILE, listOf(FileExtension.CCJSON, FileExtension.CCJSON), true),
                 onInputReady = testCallback()
             )
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
@@ -21,12 +21,13 @@ class DialogDirectoryProvider(
         this.prepareMatches("")
     }
 
-    fun updateCurrentFolder(currentInput: String) {
+    private fun updateCurrentFolder(currentInput: String) {
         if (currentInput.isEmpty()) {
             currentDirectory = Paths.get("")
             return
         }
-        if (currentInput.last() == '\\' || currentInput.last() == '/') {
+        val unifiedInput = currentInput.replace("\\","/").replaceAfterLast("/", "", "")
+        if (unifiedInput.isNotEmpty()) {
             val folder = Paths.get(currentInput)
             currentDirectory = if (folder.isDirectory()) folder else currentDirectory
             return
@@ -47,15 +48,15 @@ class DialogDirectoryProvider(
             path.toString().startsWith(currentInput) &&
                 (path.isDirectory() || (InputValidator.verifyFile(path.toFile(), fileExtensions)))
         }
-        if (possibleMatches.size == 1) {
+        return if (possibleMatches.size == 1) {
             val match = possibleMatches.first()
             if (possibleMatches.first().isDirectory()) {
-                return match.toString() + systemSeparator
+                match.toString() + systemSeparator
             } else {
-                return match.toString()
+                match.toString()
             }
         } else {
-            return ""
+            ""
         }
     }
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
@@ -1,0 +1,28 @@
+package de.maibornwolff.codecharta.dialogProvider
+
+import de.maibornwolff.codecharta.serialization.FileExtension
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class DialogDirectoryProvider(
+    val inputType: InputType,
+    val fileExtensions: List<FileExtension>
+    ) {
+
+    val systemSeparator = File.separatorChar
+    var currentFolder = Paths.get("")
+
+
+
+    fun updateMatches(): List<Path> {
+
+
+    // return list of possible matches, specifically folders and files with fitting extension
+    }
+
+    fun formatMatches(validMatches: List<Path>): String {
+        // return up to two lines of results, with (x more) at the end. To be displayed below the input
+    }
+
+}

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
@@ -13,11 +13,11 @@ class DialogDirectoryProvider(
     private val fileExtensions: List<FileExtension>
 ) {
     private val systemSeparator = File.separatorChar
-    var currentDirectory: Path = Paths.get("")
-    var currentDirectoryContent = listOf<Path>()
+    private var currentDirectory: Path = Paths.get("")
+    private var currentDirectoryContent = listOf<Path>()
     private var possibleDirectories = listOf<Path>()
     private var possibleFiles = listOf<Path>()
-    private val TARGET_LINE_LENGTH = 120
+    private val targetLineLength = 120
 
     init {
         this.prepareMatches("")
@@ -52,46 +52,46 @@ class DialogDirectoryProvider(
     }
 
     fun getMatches(): String {
-        val currentEntries = mutableListOf<String>()
-        var minimumSize = 0
+        val currentMatches = mutableListOf<String>()
+        var paddedSize = 0
 
         val totalMatches = possibleDirectories.size + possibleFiles.size
 
         possibleDirectories.forEach {
             val dirName = it.toFile().name
             val nameLength = dirName.length + 1
-            if (!checkPossibleEntry(currentEntries.size, minimumSize, nameLength, TARGET_LINE_LENGTH*2)) {
-                currentEntries.add("(${currentEntries.size}/$totalMatches)")
-                return finalizeOutputString(currentEntries, minimumSize )
+            if (!checkPossibleEntry(currentMatches.size, paddedSize, nameLength)) {
+                currentMatches.add("(${currentMatches.size}/$totalMatches)")
+                return finalizeOutputString(currentMatches, paddedSize)
             }
-            currentEntries.add(dirName + systemSeparator)
-            minimumSize = max(nameLength, minimumSize)
+            currentMatches.add(dirName + systemSeparator)
+            paddedSize = max(nameLength, paddedSize)
         }
 
         possibleFiles.forEach {
             val fileName = it.toFile().name
             val nameLength = fileName.length
-            if (!checkPossibleEntry(currentEntries.size, minimumSize, nameLength, TARGET_LINE_LENGTH*2)) {
-                currentEntries.add("(${currentEntries.size}/$totalMatches)")
-                return finalizeOutputString(currentEntries, minimumSize)
+            if (!checkPossibleEntry(currentMatches.size, paddedSize, nameLength)) {
+                currentMatches.add("(${currentMatches.size}/$totalMatches)")
+                return finalizeOutputString(currentMatches, paddedSize)
             }
-            currentEntries.add(fileName)
-            minimumSize = max(nameLength, minimumSize)
+            currentMatches.add(fileName)
+            paddedSize = max(nameLength, paddedSize)
         }
 
-        return finalizeOutputString(currentEntries, minimumSize)
+        return finalizeOutputString(currentMatches, paddedSize)
     }
 
-    fun checkPossibleEntry(entryCount: Int, entrySize: Int, newEntrySize: Int, maxLineLength: Int): Boolean {
-        return (entryCount + 1) * max(entrySize, newEntrySize) < maxLineLength
+    private fun checkPossibleEntry(entryCount: Int, entrySize: Int, newEntrySize: Int): Boolean {
+        return (entryCount + 1) * max(entrySize, newEntrySize) < targetLineLength * 2
     }
 
-    fun finalizeOutputString(folders: List<String>, minimumSize: Int): String {
-        val paddedEntries = folders.map { it.padEnd(minimumSize) }
+    fun finalizeOutputString(entries: List<String>, minimumSize: Int): String {
+        val paddedEntries = entries.map { it.padEnd(minimumSize) }
         var outputString = ""
         var secondLine = false
         paddedEntries.forEach {
-            if (!secondLine && it.length + outputString.length > TARGET_LINE_LENGTH) {
+            if (!secondLine && it.length + outputString.length > targetLineLength) {
                 outputString += "${it.trimEnd()}\n"
                 secondLine = true
             } else {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProvider.kt
@@ -12,8 +12,8 @@ class DialogDirectoryProvider(
     private val fileExtensions: List<FileExtension>
 ) {
     private val systemSeparator = File.separatorChar
-    private var currentDirectory: Path = Paths.get("")
-    private var currentDirectoryContent = listOf<Path>()
+    var currentDirectory: Path = Paths.get("")
+    var currentDirectoryContent = listOf<Path>()
     private var possibleDirectories = listOf<Path>()
     private var possibleFiles = listOf<Path>()
 
@@ -26,12 +26,10 @@ class DialogDirectoryProvider(
             currentDirectory = Paths.get("")
             return
         }
+
         val unifiedInput = currentInput.replace("\\","/").replaceAfterLast("/", "", "")
-        if (unifiedInput.isNotEmpty()) {
-            val folder = Paths.get(currentInput)
-            currentDirectory = if (folder.isDirectory()) folder else currentDirectory
-            return
-        }
+        val folder = Paths.get(unifiedInput)
+        currentDirectory = if (folder.isDirectory()) folder else currentDirectory
     }
 
     fun prepareMatches(currentInput: String) {
@@ -43,21 +41,12 @@ class DialogDirectoryProvider(
         }.filter { it.toString().startsWith(currentInput) }
     }
 
-    fun getHint(currentInput: String): String {
+    fun getHints(): Array<String> {
         val possibleMatches = currentDirectoryContent.filter { path ->
-            path.toString().startsWith(currentInput) &&
                 (path.isDirectory() || (InputValidator.verifyFile(path.toFile(), fileExtensions)))
-        }
-        return if (possibleMatches.size == 1) {
-            val match = possibleMatches.first()
-            if (possibleMatches.first().isDirectory()) {
-                match.toString() + systemSeparator
-            } else {
-                match.toString()
-            }
-        } else {
-            ""
-        }
+        }.map { if (it.isDirectory()) it.toString()+systemSeparator else it.toString() }
+
+        return possibleMatches.toTypedArray()
     }
 
     fun getMatches(): String {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -11,12 +11,8 @@ import com.varabyte.kotter.foundation.text.green
 import com.varabyte.kotter.foundation.text.red
 import com.varabyte.kotter.foundation.text.text
 import com.varabyte.kotter.foundation.text.textLine
+import com.varabyte.kotter.foundation.text.white
 import com.varabyte.kotter.runtime.MainRenderScope
-import java.nio.file.Path
-import java.nio.file.Paths
-import kotlin.io.path.isDirectory
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.listDirectoryEntries
 
 fun MainRenderScope.drawInput(
     message: String,
@@ -42,15 +38,13 @@ fun MainRenderScope.drawInput(
 
 fun MainRenderScope.drawInputWithInfo(
     message: String,
-    hint: String,
     isInputValid: Boolean,
     allowEmptyInput: Boolean,
-    invalidInputMessage: String,
     lastInputEmpty: Boolean,
-    lastInput: String,
-    allowedExtension: String = ".cc.json"
+    invalidInputMessage: String,
+    subtextInfo: String,
+    hint: String
 ) {
-    var inputCompleter = Completions("")
     bold {
         green { text("? ") }
         text(message)
@@ -61,70 +55,17 @@ fun MainRenderScope.drawInputWithInfo(
         }
     }
 
-
-    // Get input
-    // Check if input is directory or file with allowed extension
-    // if dir -> listDirectoryEntries
-    // else use last valid result and filter by
-
-    val currentPosition = try {
-        Paths.get(lastInput)
-    } catch (e: Exception) {
-        Paths.get(lastInput.substringBeforeLast("/"))
-    }
-    textLine(currentPosition.toString())
-    if(currentPosition.isDirectory()) {
-        lastGood = currentPosition.listDirectoryEntries()
-        inputCompleter = Completions(*lastGood.map { it.toString() }.toTypedArray())
-    }
-    val floatingInput = lastInput.substringAfterLast("/")
-    val possibleMatches = lastGood.filter { it.startsWith(floatingInput) && ( it.isDirectory() || ( it.isRegularFile()) && it.endsWith(allowedExtension) ) }
-//    val filter = if (lastInput.isEmpty() ) "*" else lastInput + "*"
-//    val currentFolders = cwd.listDirectoryEntries(filter).filter { it.isDirectory() }
-//    if (currentFolders.size == 1) {
-//        inputCompleter = Completions(currentFolders.first().toString()+ "/")
-//    }
-
-
-    val someResults = getSomeEntries(possibleMatches)
-
     text("> ")
-    input(inputCompleter, initialText = "")
-    textLine("")
+    white {
+        input(Completions(hint), initialText = "")
+    }
+
+    text("\n")
 
     black(isBright = true) {
-        textLine(someResults)
+        text(subtextInfo)
     }
-
 }
-
-fun getSomeEntries(paths: List<Path>, charLimit : Int = 120): String {
-    var usedChars = 0
-    var secondLine = false
-    var availableFolders = ""
-    paths.forEach {
-        val pathLength = it.toString().length
-        if (usedChars + pathLength > charLimit) {
-            if (secondLine) {
-                return availableFolders
-            } else {
-                secondLine = true
-                if (pathLength > charLimit) {
-                    return availableFolders
-                } else {
-                    availableFolders += "\n" + "${it}/ "
-                    usedChars = pathLength
-                }
-            }
-        } else {
-            availableFolders += "${it}/ "
-            usedChars += pathLength
-        }
-    }
-    return availableFolders
-}
-
-
 
 fun MainRenderScope.drawConfirm(message: String, hint: String, choice: Boolean) {
     bold {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.codecharta.dialogProvider
 
 import com.varabyte.kotter.foundation.collections.LiveList
 import com.varabyte.kotter.foundation.input.Completions
+import com.varabyte.kotter.foundation.input.InputCompleter
 import com.varabyte.kotter.foundation.input.input
 import com.varabyte.kotter.foundation.text.black
 import com.varabyte.kotter.foundation.text.bold
@@ -11,6 +12,11 @@ import com.varabyte.kotter.foundation.text.red
 import com.varabyte.kotter.foundation.text.text
 import com.varabyte.kotter.foundation.text.textLine
 import com.varabyte.kotter.runtime.MainRenderScope
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
 
 fun MainRenderScope.drawInput(
     message: String,
@@ -18,7 +24,8 @@ fun MainRenderScope.drawInput(
     isInputValid: Boolean,
     allowEmptyInput: Boolean,
     invalidInputMessage: String,
-    lastInputEmpty: Boolean
+    lastInputEmpty: Boolean,
+    inputCompleter: InputCompleter
 ) {
     bold {
         green { text("? ") }
@@ -30,8 +37,94 @@ fun MainRenderScope.drawInput(
         }
     }
     text("> ")
-    input(Completions(hint), initialText = "")
+    input(inputCompleter, initialText = "")
 }
+
+fun MainRenderScope.drawInputWithInfo(
+    message: String,
+    hint: String,
+    isInputValid: Boolean,
+    allowEmptyInput: Boolean,
+    invalidInputMessage: String,
+    lastInputEmpty: Boolean,
+    lastInput: String,
+    allowedExtension: String = ".cc.json"
+) {
+    var inputCompleter = Completions("")
+    bold {
+        green { text("? ") }
+        text(message)
+        if (isInputValid) {
+            black(isBright = true) { textLine(if (allowEmptyInput) "  Empty input is allowed" else "") }
+        } else {
+            red { textLine(if (lastInputEmpty) "  Empty input is not allowed!" else "  $invalidInputMessage") }
+        }
+    }
+
+
+    // Get input
+    // Check if input is directory or file with allowed extension
+    // if dir -> listDirectoryEntries
+    // else use last valid result and filter by
+
+    val currentPosition = try {
+        Paths.get(lastInput)
+    } catch (e: Exception) {
+        Paths.get(lastInput.substringBeforeLast("/"))
+    }
+    textLine(currentPosition.toString())
+    if(currentPosition.isDirectory()) {
+        lastGood = currentPosition.listDirectoryEntries()
+        inputCompleter = Completions(*lastGood.map { it.toString() }.toTypedArray())
+    }
+    val floatingInput = lastInput.substringAfterLast("/")
+    val possibleMatches = lastGood.filter { it.startsWith(floatingInput) && ( it.isDirectory() || ( it.isRegularFile()) && it.endsWith(allowedExtension) ) }
+//    val filter = if (lastInput.isEmpty() ) "*" else lastInput + "*"
+//    val currentFolders = cwd.listDirectoryEntries(filter).filter { it.isDirectory() }
+//    if (currentFolders.size == 1) {
+//        inputCompleter = Completions(currentFolders.first().toString()+ "/")
+//    }
+
+
+    val someResults = getSomeEntries(possibleMatches)
+
+    text("> ")
+    input(inputCompleter, initialText = "")
+    textLine("")
+
+    black(isBright = true) {
+        textLine(someResults)
+    }
+
+}
+
+fun getSomeEntries(paths: List<Path>, charLimit : Int = 120): String {
+    var usedChars = 0
+    var secondLine = false
+    var availableFolders = ""
+    paths.forEach {
+        val pathLength = it.toString().length
+        if (usedChars + pathLength > charLimit) {
+            if (secondLine) {
+                return availableFolders
+            } else {
+                secondLine = true
+                if (pathLength > charLimit) {
+                    return availableFolders
+                } else {
+                    availableFolders += "\n" + "${it}/ "
+                    usedChars = pathLength
+                }
+            }
+        } else {
+            availableFolders += "${it}/ "
+            usedChars += pathLength
+        }
+    }
+    return availableFolders
+}
+
+
 
 fun MainRenderScope.drawConfirm(message: String, hint: String, choice: Boolean) {
     bold {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -14,50 +14,30 @@ import com.varabyte.kotter.runtime.MainRenderScope
 
 fun MainRenderScope.drawInput(
     message: String,
-    hint: String,
     isInputValid: Boolean,
     allowEmptyInput: Boolean,
     invalidInputMessage: String,
-    lastInputEmpty: Boolean
-) {
-    bold {
-        green { text("? ") }
-        text(message)
-        if (isInputValid) {
-            black(isBright = true) { textLine(if (allowEmptyInput) "  Empty input is allowed" else "") }
-        } else {
-            red { textLine(if (lastInputEmpty) "  Empty input is not allowed!" else "  $invalidInputMessage") }
-        }
-    }
-    text("> ")
-    input(Completions(hint), initialText = "")
-}
-
-fun MainRenderScope.drawInputWithSubInputText(
-    message: String,
-    isInputValid: Boolean,
-    allowEmptyInput: Boolean,
     lastInputEmpty: Boolean,
-    invalidInputMessage: String,
-    subInputText: String,
-    vararg hint: String
+    vararg hint: String,
+    displaySubInputText: Boolean = false,
+    subInputText: String = ""
 ) {
     bold {
-        green { text("? ") }
-        text(message)
+        this.green { this.text("? ") }
+        this.text(message)
         if (isInputValid) {
-            black(isBright = true) { textLine(if (allowEmptyInput) "  Empty input is allowed" else "") }
+            this.black(isBright = true) { this.textLine(if (allowEmptyInput) "  Empty input is allowed" else "") }
         } else {
-            red { textLine(if (lastInputEmpty) "  Empty input is not allowed!" else "  $invalidInputMessage") }
+            this.red { this.textLine(if (lastInputEmpty) "  Empty input is not allowed!" else "  $invalidInputMessage") }
         }
     }
-
     text("> ")
-
     input(Completions(*hint, ignoreCase = false), initialText = "")
-    text("\n")
-    black(isBright = true) {
-        text(subInputText)
+    if (displaySubInputText) {
+        text("\n")
+        black(isBright = true) {
+            text(subInputText)
+        }
     }
 }
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -2,7 +2,6 @@ package de.maibornwolff.codecharta.dialogProvider
 
 import com.varabyte.kotter.foundation.collections.LiveList
 import com.varabyte.kotter.foundation.input.Completions
-import com.varabyte.kotter.foundation.input.InputCompleter
 import com.varabyte.kotter.foundation.input.input
 import com.varabyte.kotter.foundation.text.black
 import com.varabyte.kotter.foundation.text.bold
@@ -19,8 +18,7 @@ fun MainRenderScope.drawInput(
     isInputValid: Boolean,
     allowEmptyInput: Boolean,
     invalidInputMessage: String,
-    lastInputEmpty: Boolean,
-    inputCompleter: InputCompleter
+    lastInputEmpty: Boolean
 ) {
     bold {
         green { text("? ") }
@@ -32,7 +30,7 @@ fun MainRenderScope.drawInput(
         }
     }
     text("> ")
-    input(inputCompleter, initialText = "")
+    input(Completions(hint), initialText = "")
 }
 
 fun MainRenderScope.drawInputWithSubInputText(

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -11,8 +11,6 @@ import com.varabyte.kotter.foundation.text.green
 import com.varabyte.kotter.foundation.text.red
 import com.varabyte.kotter.foundation.text.text
 import com.varabyte.kotter.foundation.text.textLine
-import com.varabyte.kotter.foundation.text.white
-import com.varabyte.kotter.foundation.text.yellow
 import com.varabyte.kotter.runtime.MainRenderScope
 
 fun MainRenderScope.drawInput(
@@ -43,10 +41,7 @@ fun MainRenderScope.drawInputWithInfo(
     allowEmptyInput: Boolean,
     lastInputEmpty: Boolean,
     invalidInputMessage: String,
-    subtextInfo: String,
-    debugInfo1: String,
-    debugInfo2: String,
-    debugInfo3: String,
+    subInputText: String,
     vararg hint: String
 ) {
     bold {
@@ -62,18 +57,9 @@ fun MainRenderScope.drawInputWithInfo(
     text("> ")
 
     input(Completions(*hint), initialText = "")
-
     text("\n")
-    text("\n")
-
     black(isBright = true) {
-            text(subtextInfo)
-        }
-    text("\n")
-    white {
-        textLine(debugInfo1)
-        textLine(debugInfo2)
-        textLine(debugInfo3)
+        text(subInputText)
     }
 }
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -54,7 +54,7 @@ fun MainRenderScope.drawInputWithSubInputText(
 
     text("> ")
 
-    input(Completions(*hint), initialText = "")
+    input(Completions(*hint, ignoreCase = false), initialText = "")
     text("\n")
     black(isBright = true) {
         text(subInputText)

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -12,6 +12,7 @@ import com.varabyte.kotter.foundation.text.red
 import com.varabyte.kotter.foundation.text.text
 import com.varabyte.kotter.foundation.text.textLine
 import com.varabyte.kotter.foundation.text.white
+import com.varabyte.kotter.foundation.text.yellow
 import com.varabyte.kotter.runtime.MainRenderScope
 
 fun MainRenderScope.drawInput(
@@ -60,15 +61,15 @@ fun MainRenderScope.drawInputWithInfo(
 
     text("> ")
 
-        input(Completions(*hint), initialText = "")
+    input(Completions(*hint), initialText = "")
 
-
+    text("\n")
     text("\n")
 
     black(isBright = true) {
-        text(subtextInfo)
-        text("\n")
-    }
+            text(subtextInfo)
+        }
+    text("\n")
     white {
         textLine(debugInfo1)
         textLine(debugInfo2)

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -35,7 +35,7 @@ fun MainRenderScope.drawInput(
     input(inputCompleter, initialText = "")
 }
 
-fun MainRenderScope.drawInputWithInfo(
+fun MainRenderScope.drawInputWithSubInputText(
     message: String,
     isInputValid: Boolean,
     allowEmptyInput: Boolean,

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDrawing.kt
@@ -43,7 +43,10 @@ fun MainRenderScope.drawInputWithInfo(
     lastInputEmpty: Boolean,
     invalidInputMessage: String,
     subtextInfo: String,
-    hint: String
+    debugInfo1: String,
+    debugInfo2: String,
+    debugInfo3: String,
+    vararg hint: String
 ) {
     bold {
         green { text("? ") }
@@ -56,14 +59,20 @@ fun MainRenderScope.drawInputWithInfo(
     }
 
     text("> ")
-    white {
-        input(Completions(hint), initialText = "")
-    }
+
+        input(Completions(*hint), initialText = "")
+
 
     text("\n")
 
     black(isBright = true) {
         text(subtextInfo)
+        text("\n")
+    }
+    white {
+        textLine(debugInfo1)
+        textLine(debugInfo2)
+        textLine(debugInfo3)
     }
 }
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -13,7 +13,6 @@ import com.varabyte.kotter.foundation.liveVarOf
 import com.varabyte.kotter.foundation.runUntilSignal
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
-import com.varabyte.kotter.runtime.terminal.TerminalSize
 import de.maibornwolff.codecharta.serialization.FileExtension
 import java.nio.file.Paths
 
@@ -65,13 +64,8 @@ fun Session.promptInputComplete(
 ): String {
     var lastUserInput = ""
     var isInputValid by liveVarOf(true)
-    var subtextInfo = dialogDirectoryProvider.getMatches()
-    var hint = dialogDirectoryProvider.getHints()
-    var initialSizeH = TerminalSize.Default.height.toString()
-    var initialSizeW = TerminalSize.Default.width.toString()
-    var d1 = ""
-    var d2 = initialSizeH
-    var d3 = initialSizeW
+    var subInfoText = dialogDirectoryProvider.getMatches()
+    var hints = dialogDirectoryProvider.getHints()
     section {
         drawInputWithInfo(
             message = message,
@@ -79,11 +73,8 @@ fun Session.promptInputComplete(
             allowEmptyInput = false,
             lastInputEmpty = lastUserInput.isEmpty(),
             invalidInputMessage = invalidInputMessage,
-            subtextInfo,
-            d1,
-            d2,
-            d3,
-            *hint
+            subInfoText,
+            *hints
         )
     }.runUntilSignal {
         onKeyPressed {
@@ -95,11 +86,8 @@ fun Session.promptInputComplete(
             isInputValid = true
             lastUserInput = input
             dialogDirectoryProvider.prepareMatches(input)
-            subtextInfo = dialogDirectoryProvider.getMatches()
-            hint = dialogDirectoryProvider.getHints()
-            d1 = dialogDirectoryProvider.currentDirectory.toString()
-            d2 = ""
-            d3 = TerminalSize.Unbounded.width.toString()
+            subInfoText = dialogDirectoryProvider.getMatches()
+            hints = dialogDirectoryProvider.getHints()
         }
         onInputEntered {
             if (inputValidator(input) && input.isNotEmpty()) {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -13,6 +13,7 @@ import com.varabyte.kotter.foundation.liveVarOf
 import com.varabyte.kotter.foundation.runUntilSignal
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
+import com.varabyte.kotter.runtime.terminal.TerminalSize
 import de.maibornwolff.codecharta.serialization.FileExtension
 import java.nio.file.Paths
 
@@ -66,9 +67,11 @@ fun Session.promptInputComplete(
     var isInputValid by liveVarOf(true)
     var subtextInfo = dialogDirectoryProvider.getMatches()
     var hint = dialogDirectoryProvider.getHints()
+    var initialSizeH = TerminalSize.Default.height.toString()
+    var initialSizeW = TerminalSize.Default.width.toString()
     var d1 = ""
-    var d2 = ""
-    var d3 = ""
+    var d2 = initialSizeH
+    var d3 = initialSizeW
     section {
         drawInputWithInfo(
             message = message,
@@ -95,8 +98,8 @@ fun Session.promptInputComplete(
             subtextInfo = dialogDirectoryProvider.getMatches()
             hint = dialogDirectoryProvider.getHints()
             d1 = dialogDirectoryProvider.currentDirectory.toString()
-            d2 = dialogDirectoryProvider.getHints().joinToString()
-            d3 = dialogDirectoryProvider.getMatches().length.toString()
+            d2 = ""
+            d3 = TerminalSize.Unbounded.width.toString()
         }
         onInputEntered {
             if (inputValidator(input) && input.isNotEmpty()) {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -65,7 +65,10 @@ fun Session.promptInputComplete(
     var lastUserInput = ""
     var isInputValid by liveVarOf(true)
     var subtextInfo = dialogDirectoryProvider.getMatches()
-    var hint = dialogDirectoryProvider.getHint("")
+    var hint = dialogDirectoryProvider.getHints()
+    var d1 = ""
+    var d2 = ""
+    var d3 = ""
     section {
         drawInputWithInfo(
             message = message,
@@ -74,7 +77,10 @@ fun Session.promptInputComplete(
             lastInputEmpty = lastUserInput.isEmpty(),
             invalidInputMessage = invalidInputMessage,
             subtextInfo,
-            hint
+            d1,
+            d2,
+            d3,
+            *hint
         )
     }.runUntilSignal {
         onKeyPressed {
@@ -86,8 +92,11 @@ fun Session.promptInputComplete(
             isInputValid = true
             lastUserInput = input
             dialogDirectoryProvider.prepareMatches(input)
-            hint = dialogDirectoryProvider.getHint(input)
             subtextInfo = dialogDirectoryProvider.getMatches()
+            hint = dialogDirectoryProvider.getHints()
+            d1 = dialogDirectoryProvider.currentDirectory.toString()
+            d2 = dialogDirectoryProvider.getHints().joinToString()
+            d3 = dialogDirectoryProvider.getMatches().length.toString()
         }
         onInputEntered {
             if (inputValidator(input) && input.isNotEmpty()) {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -55,25 +55,24 @@ fun Session.promptInput(
     return lastUserInput
 }
 
-fun Session.promptInputComplete(
+fun Session.promptInputDirectoryAssisted(
     message: String,
     invalidInputMessage: String = DEFAULT_INVALID_INPUT_MESSAGE,
-    inputValidator: (String) -> Boolean = { true },
-    dialogDirectoryProvider: DialogDirectoryProvider,
+    directoryNavigator: DirectoryNavigator,
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     var lastUserInput = ""
     var isInputValid by liveVarOf(true)
-    var subInfoText = dialogDirectoryProvider.getMatches()
-    var hints = dialogDirectoryProvider.getHints()
+    var subInputText = directoryNavigator.getMatches()
+    var hints = directoryNavigator.getHints()
     section {
-        drawInputWithInfo(
+        drawInputWithSubInputText(
             message = message,
             isInputValid = isInputValid,
             allowEmptyInput = false,
             lastInputEmpty = lastUserInput.isEmpty(),
             invalidInputMessage = invalidInputMessage,
-            subInfoText,
+            subInputText,
             *hints
         )
     }.runUntilSignal {
@@ -85,12 +84,12 @@ fun Session.promptInputComplete(
         onInputChanged {
             isInputValid = true
             lastUserInput = input
-            dialogDirectoryProvider.prepareMatches(input)
-            subInfoText = dialogDirectoryProvider.getMatches()
-            hints = dialogDirectoryProvider.getHints()
+            directoryNavigator.prepareMatches(input)
+            subInputText = directoryNavigator.getMatches()
+            hints = directoryNavigator.getHints()
         }
         onInputEntered {
-            if (inputValidator(input) && input.isNotEmpty()) {
+            if (directoryNavigator.validate(input) && input.isNotEmpty()) {
                 isInputValid = true
                 signal()
             } else {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -14,7 +14,6 @@ import com.varabyte.kotter.foundation.runUntilSignal
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.serialization.FileExtension
-import java.nio.file.Paths
 
 const val DEFAULT_INVALID_INPUT_MESSAGE = "Input is invalid!"
 
@@ -260,25 +259,22 @@ private fun getSelectedChoices(choices: List<String>, selection: List<Boolean>):
     return result
 }
 
-fun Session.promptDefaultFileFolderInput(
+fun Session.promptDefaultDirectoryAssistedInput(
     inputType: InputType,
     fileExtensionList: List<FileExtension>,
     multiple: Boolean = false,
+    prefixMessage: String = "",
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     val messageFileExtension = "[${fileExtensionList.joinToString(", ") { fileExtension -> fileExtension.extension }}]"
 
     val pluralSuffix: String
-    val hintText: String
     val messageExtension: String
     if (multiple) {
         pluralSuffix = "(s)"
-        val sampleFileExtension = if (fileExtensionList.isEmpty()) "" else fileExtensionList.first().extension
-        hintText = "input1$sampleFileExtension, input2$sampleFileExtension, ..."
         messageExtension = " Enter multiple files comma separated."
     } else {
         pluralSuffix = ""
-        hintText = Paths.get("").toAbsolutePath().toString()
         messageExtension = ""
     }
 
@@ -309,16 +305,16 @@ fun Session.promptDefaultFileFolderInput(
             }
         }
 
-    return promptInput(
-        message = "What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
-        hint = hintText,
-        allowEmptyInput = false,
+    val directoryNavigator = DirectoryNavigator(
+        inputType = inputType,
+        fileExtensions = fileExtensionList,
+        multiple = multiple
+    )
+
+    return promptInputDirectoryAssisted(
+        message = "${prefixMessage}What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
-        inputValidator = InputValidator.isFileOrFolderValid(
-            inputType,
-            fileExtensionList,
-            multiple = multiple
-        ),
+        directoryNavigator = directoryNavigator,
         onInputReady = onInputReady
     )
 }

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -68,8 +68,8 @@ fun Session.promptInputDirectoryAssisted(
 ): String {
     var lastUserInput = ""
     var isInputValid by liveVarOf(true)
-    var subInputText = directoryNavigator.getMatches()
-    var hints = directoryNavigator.getHints()
+    var subInputText by liveVarOf(directoryNavigator.getMatches())
+    var hints by liveVarOf(directoryNavigator.getHints())
     section {
         drawInputWithSubInputText(
             message = message,
@@ -96,6 +96,8 @@ fun Session.promptInputDirectoryAssisted(
         onInputEntered {
             if (directoryNavigator.validate(input) && input.isNotEmpty()) {
                 isInputValid = true
+                subInputText = ""
+                hints = arrayOf("")
                 signal()
             } else {
                 isInputValid = false

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -42,7 +42,7 @@ fun Session.promptInput(
     var hintText = hint
     var isInputValid by liveVarOf(true)
     section {
-        drawInput(message, hintText, isInputValid, allowEmptyInput, invalidInputMessage, lastUserInput.isEmpty())
+        drawInput(message, isInputValid, allowEmptyInput, invalidInputMessage, lastUserInput.isEmpty(), hintText)
     }.runUntilSignal {
         onInputChanged { isInputValid = true }
         onInputEntered {
@@ -71,14 +71,15 @@ fun Session.promptInputDirectoryAssisted(
     var subInputText by liveVarOf(directoryNavigator.getMatches())
     var hints by liveVarOf(directoryNavigator.getHints())
     section {
-        drawInputWithSubInputText(
+        drawInput(
             message = message,
             isInputValid = isInputValid,
             allowEmptyInput = false,
             lastInputEmpty = lastUserInput.isEmpty(),
             invalidInputMessage = invalidInputMessage,
-            subInputText,
-            *hints
+            hint = hints,
+            displaySubInputText = true,
+            subInputText = subInputText
         )
     }.runUntilSignal {
         onKeyPressed {
@@ -123,11 +124,11 @@ fun Session.promptInputNumber(
     section {
         drawInput(
             message,
-            hintText,
             isInputValid,
             allowEmptyInput,
             invalidInputMessage,
-            lastUserInput.isEmpty()
+            lastUserInput.isEmpty(),
+            hintText
         )
     }.runUntilSignal {
         onInputChanged {
@@ -270,6 +271,7 @@ fun Session.promptDefaultDirectoryAssistedInput(
     inputType: InputType,
     fileExtensionList: List<FileExtension>,
     multiple: Boolean = false,
+    postMessageText: String = "",
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     val messageFileExtension = "[${fileExtensionList.joinToString(", ") { fileExtension -> fileExtension.extension }}]"
@@ -318,7 +320,7 @@ fun Session.promptDefaultDirectoryAssistedInput(
     )
 
     return promptInputDirectoryAssisted(
-        message = "What ${if (multiple) "are" else "is"} the input $inputMessage?$messageExtension",
+        message = "What ${if (multiple) "are" else "is"} the input $inputMessage?$postMessageText$messageExtension",
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
         directoryNavigator = directoryNavigator,
         onInputReady = onInputReady

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -2,8 +2,6 @@ package de.maibornwolff.codecharta.dialogProvider
 
 import com.varabyte.kotter.foundation.collections.LiveList
 import com.varabyte.kotter.foundation.collections.liveListOf
-import com.varabyte.kotter.foundation.input.Completions
-import com.varabyte.kotter.foundation.input.InputCompleter
 import com.varabyte.kotter.foundation.input.Keys
 import com.varabyte.kotter.foundation.input.onInputChanged
 import com.varabyte.kotter.foundation.input.onInputEntered
@@ -38,14 +36,13 @@ fun Session.promptInput(
     allowEmptyInput: Boolean = false,
     invalidInputMessage: String = DEFAULT_INVALID_INPUT_MESSAGE,
     inputValidator: (String) -> Boolean = { true },
-    inputCompleter: InputCompleter = Completions(hint),
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     var lastUserInput = ""
     var hintText = hint
     var isInputValid by liveVarOf(true)
     section {
-        drawInput(message, hintText, isInputValid, allowEmptyInput, invalidInputMessage, lastUserInput.isEmpty(), inputCompleter)
+        drawInput(message, hintText, isInputValid, allowEmptyInput, invalidInputMessage, lastUserInput.isEmpty())
     }.runUntilSignal {
         onInputChanged { isInputValid = true }
         onInputEntered {
@@ -128,8 +125,7 @@ fun Session.promptInputNumber(
             isInputValid,
             allowEmptyInput,
             invalidInputMessage,
-            lastUserInput.isEmpty(),
-            inputCompleter = Completions(hint)
+            lastUserInput.isEmpty()
         )
     }.runUntilSignal {
         onInputChanged {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -11,6 +11,8 @@ import com.varabyte.kotter.foundation.input.onKeyPressed
 import com.varabyte.kotter.foundation.input.sendKeys
 import com.varabyte.kotter.foundation.liveVarOf
 import com.varabyte.kotter.foundation.runUntilSignal
+import com.varabyte.kotter.foundation.text.text
+import com.varabyte.kotter.foundation.text.yellow
 import com.varabyte.kotter.runtime.RunScope
 import com.varabyte.kotter.runtime.Session
 import de.maibornwolff.codecharta.serialization.FileExtension
@@ -21,6 +23,13 @@ enum class InputType(val inputType: String) {
     FOLDER("folder"),
     FILE("file"),
     FOLDER_AND_FILE("folder or file")
+}
+
+fun Session.displayInfo(message: String) {
+    section {
+        yellow { text("! ") }
+        text(message)
+    }.run()
 }
 
 fun Session.promptInput(
@@ -263,7 +272,6 @@ fun Session.promptDefaultDirectoryAssistedInput(
     inputType: InputType,
     fileExtensionList: List<FileExtension>,
     multiple: Boolean = false,
-    prefixMessage: String = "",
     onInputReady: suspend RunScope.() -> Unit
 ): String {
     val messageFileExtension = "[${fileExtensionList.joinToString(", ") { fileExtension -> fileExtension.extension }}]"
@@ -312,7 +320,7 @@ fun Session.promptDefaultDirectoryAssistedInput(
     )
 
     return promptInputDirectoryAssisted(
-        message = "${prefixMessage}What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
+        message = "What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
         directoryNavigator = directoryNavigator,
         onInputReady = onInputReady

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProvider.kt
@@ -318,7 +318,7 @@ fun Session.promptDefaultDirectoryAssistedInput(
     )
 
     return promptInputDirectoryAssisted(
-        message = "What ${if (multiple) "are" else "is"} the input $inputMessage.$messageExtension",
+        message = "What ${if (multiple) "are" else "is"} the input $inputMessage?$messageExtension",
         invalidInputMessage = "Please input a valid ${inputType.inputType}",
         directoryNavigator = directoryNavigator,
         onInputReady = onInputReady

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -8,11 +8,12 @@ import kotlin.io.path.isDirectory
 import kotlin.io.path.listDirectoryEntries
 import kotlin.math.max
 
-class DialogDirectoryProvider(
+class DirectoryNavigator(
     val inputType: InputType,
     private val fileExtensions: List<FileExtension>,
     val multiple: Boolean
 ) {
+    var validate: (String) -> Boolean
     private val systemSeparator = File.separatorChar
     private var filesAllowed = true
     private var currentDirectory: Path = Paths.get("")
@@ -25,6 +26,7 @@ class DialogDirectoryProvider(
     init {
         this.prepareMatches("")
         this.filesAllowed = inputType == InputType.FILE || inputType == InputType.FOLDER_AND_FILE
+        this.validate = InputValidator.isFileOrFolderValid(inputType, fileExtensions, multiple)
     }
 
     private fun updateCompletedInput(currentInput: String) {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -15,12 +15,12 @@ class DirectoryNavigator(
 ) {
     var validate: (String) -> Boolean
     private val systemSeparator = File.separatorChar
-    private var filesAllowed = true
+    internal var filesAllowed = true
     private var currentDirectory: Path = Paths.get("")
-    private var currentDirectoryContent = listOf<Path>()
+    internal var currentDirectoryContent = listOf<Path>()
     private var completedInput = ""
-    private var possibleDirectories = listOf<Path>()
-    private var possibleFiles = listOf<Path>()
+    internal var possibleDirectories = listOf<Path>()
+    internal var possibleFiles = listOf<Path>()
     private val targetLineLength = 120
 
     init {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -32,7 +32,7 @@ class DirectoryNavigator(
     private fun updateCompletedInput(currentInput: String) {
         if (multiple) {
             val commaIndex = currentInput.lastIndexOf(',')
-            completedInput = if (commaIndex >= 0) currentInput.substring(0,commaIndex+1) else ""
+            completedInput = if (commaIndex >= 0) currentInput.substring(0, commaIndex + 1) else ""
         }
     }
 
@@ -56,13 +56,13 @@ class DirectoryNavigator(
         }
     }
 
-
-
     fun getHints(): Array<String> {
         val possibleMatches = currentDirectoryContent.filter { path ->
-            (path.isDirectory() ||
-                ( filesAllowed && InputValidator.verifyFile(path.toFile(), fileExtensions)) )
-        }.map { if (it.isDirectory())  completedInput + it.toString() + systemSeparator else completedInput + it.toString() }
+            (
+                path.isDirectory() ||
+                    (filesAllowed && InputValidator.verifyFile(path.toFile(), fileExtensions))
+            )
+        }.map { if (it.isDirectory()) completedInput + it.toString() + systemSeparator else completedInput + it.toString() }
 
         return possibleMatches.toTypedArray()
     }

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -48,7 +48,7 @@ class DirectoryNavigator(
 
         updateCurrentFolder(splitInput)
         currentDirectoryContent = currentDirectory.listDirectoryEntries().sorted()
-        possibleDirectories = currentDirectoryContent.filter { it.isDirectory() }.filter { it.toString().startsWith(splitInput) }
+        possibleDirectories = currentDirectoryContent.filter { it.isDirectory() && it.toString().startsWith(splitInput) }
         if (filesAllowed) {
             possibleFiles = currentDirectoryContent.filter {
                 InputValidator.verifyFile(it.toFile(), fileExtensions)
@@ -76,7 +76,7 @@ class DirectoryNavigator(
         possibleDirectories.forEach {
             val dirName = it.toFile().name
             val nameLength = dirName.length + 1
-            if (!checkPossibleEntry(currentMatches.size, paddedSize, nameLength)) {
+            if (!isEntryPossible(currentMatches.size, paddedSize, nameLength)) {
                 currentMatches.add("(${currentMatches.size}/$totalMatches)")
                 return finalizeOutputString(currentMatches, paddedSize)
             }
@@ -87,7 +87,7 @@ class DirectoryNavigator(
         possibleFiles.forEach {
             val fileName = it.toFile().name
             val nameLength = fileName.length
-            if (!checkPossibleEntry(currentMatches.size, paddedSize, nameLength)) {
+            if (!isEntryPossible(currentMatches.size, paddedSize, nameLength)) {
                 currentMatches.add("(${currentMatches.size}/$totalMatches)")
                 return finalizeOutputString(currentMatches, paddedSize)
             }
@@ -98,7 +98,7 @@ class DirectoryNavigator(
         return finalizeOutputString(currentMatches, paddedSize)
     }
 
-    private fun checkPossibleEntry(entryCount: Int, entrySize: Int, newEntrySize: Int): Boolean {
+    private fun isEntryPossible(entryCount: Int, entrySize: Int, newEntrySize: Int): Boolean {
         return (entryCount + 1) * max(entrySize, newEntrySize) < targetLineLength * 2
     }
 

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -24,9 +24,9 @@ class DirectoryNavigator(
     private val targetLineLength = 120
 
     init {
-        this.prepareMatches("")
         this.filesAllowed = inputType == InputType.FILE || inputType == InputType.FOLDER_AND_FILE
         this.validate = InputValidator.isFileOrFolderValid(inputType, fileExtensions, multiple)
+        this.prepareMatches("")
     }
 
     private fun updateCompletedInput(currentInput: String) {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigator.kt
@@ -47,7 +47,7 @@ class DirectoryNavigator(
         val splitInput = if (multiple) currentInput.substringAfterLast(',') else currentInput
 
         updateCurrentFolder(splitInput)
-        currentDirectoryContent = currentDirectory.listDirectoryEntries()
+        currentDirectoryContent = currentDirectory.listDirectoryEntries().sorted()
         possibleDirectories = currentDirectoryContent.filter { it.isDirectory() }.filter { it.toString().startsWith(splitInput) }
         if (filesAllowed) {
             possibleFiles = currentDirectoryContent.filter {

--- a/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidator.kt
+++ b/analysis/dialogProvider/src/main/kotlin/de/maibornwolff/codecharta/dialogProvider/InputValidator.kt
@@ -44,7 +44,7 @@ class InputValidator {
             input.toInt() > minValue
         }
 
-        private fun verifyFile(objectToVerify: File, fileExtensionList: List<FileExtension>): Boolean {
+        fun verifyFile(objectToVerify: File, fileExtensionList: List<FileExtension>): Boolean {
             return objectToVerify.isFile &&
                 (fileExtensionList.isEmpty() || fileExtensionList.any { objectToVerify.name.endsWith(it.extension) })
         }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProviderTest.kt
@@ -1,0 +1,14 @@
+package de.maibornwolff.codecharta.dialogProvider
+
+import de.maibornwolff.codecharta.serialization.FileExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DialogDirectoryProviderTest {
+    @Test
+    fun `this should provide a good change directory experience`() {
+        val uut = DialogDirectoryProvider(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON))
+        uut.prepareMatches("")
+        assertThat(uut.getHint("someInput")).isEqualTo("")
+    }
+}

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogDirectoryProviderTest.kt
@@ -9,6 +9,6 @@ class DialogDirectoryProviderTest {
     fun `this should provide a good change directory experience`() {
         val uut = DialogDirectoryProvider(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON))
         uut.prepareMatches("")
-        assertThat(uut.getHint("someInput")).isEqualTo("")
+        assertThat(uut.getHints()).isEqualTo("")
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -8,6 +8,7 @@ import com.varabyte.kotter.foundation.text.green
 import com.varabyte.kotter.foundation.text.invert
 import com.varabyte.kotter.foundation.text.text
 import com.varabyte.kotter.foundation.text.textLine
+import com.varabyte.kotter.foundation.text.yellow
 import com.varabyte.kotter.runtime.terminal.inmemory.press
 import com.varabyte.kotter.runtime.terminal.inmemory.resolveRerenders
 import com.varabyte.kotter.runtime.terminal.inmemory.type
@@ -765,6 +766,14 @@ class DialogProviderTest {
 
     @Test
     fun `displayInfo should print message as expected`() {
+        val testString = "testString"
+        testSession { terminal ->
+            displayInfo(testString)
+            terminal.assertMatches {
+                yellow { text("! ") }
+                text(testString)
+            }
+        }
     }
 
     @Nested

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -20,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class DialogProviderTest {
     private val testInput = "this is text to simulate user input."
@@ -753,10 +754,14 @@ class DialogProviderTest {
         }
     }
 
+    @Test
+    fun `displayInfo should print message as expected`() {
+    }
+
     @Nested
-    @DisplayName("defaultFileOrFolderInput > ")
-    inner class DefaultFileOrFolderInputTests {
-        // defaultFileOrFolderInput
+    @DisplayName("defaultDirectoryAssistedInput > ")
+    inner class DefaultDirectoryAssistedInput {
+        // defaultDirectoryAssistedInput
 
         @Test
         fun `should prompt file type correctly`() {
@@ -767,7 +772,7 @@ class DialogProviderTest {
 
             testSession { terminal ->
                 result =
-                    promptDefaultFileFolderInput(InputType.FILE, listOf(), onInputReady = {
+                    promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(), onInputReady = {
                         terminal.type(inputFileName)
                         terminal.press(Keys.ENTER)
                     })
@@ -790,7 +795,7 @@ class DialogProviderTest {
 
             testSession { terminal ->
                 result =
-                    promptDefaultFileFolderInput(InputType.FILE, listOf(FileExtension.CCJSON), onInputReady = {
+                    promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(FileExtension.CCJSON), onInputReady = {
                         terminal.type(inputFileName)
                         terminal.press(Keys.ENTER)
                     })
@@ -810,11 +815,12 @@ class DialogProviderTest {
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/valid.log"
             val testMessage = "What are the input file(s). Enter multiple files comma separated."
-            val multiTestHint = "input1, input2, ..."
+            val initialHint = "build" + File.separatorChar
+            val directoryContent = "build${File.separatorChar}           src${File.separatorChar}             build.gradle.kts"
 
             testSession { terminal ->
                 result =
-                    promptDefaultFileFolderInput(InputType.FILE, listOf(), multiple = true, onInputReady = {
+                    promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(), multiple = true, onInputReady = {
                         terminal.assertMatches {
                             bold {
                                 green { text("? ") }
@@ -822,8 +828,12 @@ class DialogProviderTest {
                             }
                             text("> ")
                             black(isBright = true) {
-                                invert { text(multiTestHint[0]) }
-                                text("${multiTestHint.drop(1)} ")
+                                invert { text(initialHint[0]) }
+                                text("${initialHint.drop(1)} ")
+                            }
+                            text("\n")
+                            black(isBright = true) {
+                                text(directoryContent)
                             }
                         }
                         terminal.type(inputFileName)
@@ -845,11 +855,12 @@ class DialogProviderTest {
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/validExtension.cc.json"
             val testMessage = "What are the input [.cc.json] file(s). Enter multiple files comma separated."
-            val multiTestHint = "input1.cc.json, input2.cc.json, ..."
+            val initialHint = "build" + File.separatorChar
+            val directoryContent = "build" + File.separatorChar + " src" + File.separatorChar
 
             testSession { terminal ->
                 result =
-                    promptDefaultFileFolderInput(InputType.FILE, listOf(FileExtension.CCJSON), multiple = true, onInputReady = {
+                    promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(FileExtension.CCJSON), multiple = true, onInputReady = {
                         terminal.assertMatches {
                             bold {
                                 green { text("? ") }
@@ -857,8 +868,12 @@ class DialogProviderTest {
                             }
                             text("> ")
                             black(isBright = true) {
-                                invert { text(multiTestHint[0]) }
-                                text("${multiTestHint.drop(1)} ")
+                                invert { text(initialHint[0]) }
+                                text("${initialHint.drop(1)} ")
+                            }
+                            text("\n")
+                            black(isBright = true) {
+                                text(directoryContent)
                             }
                         }
                         terminal.type(inputFileName)
@@ -872,6 +887,11 @@ class DialogProviderTest {
 
                 assertThat(result).isEqualTo(inputFileName)
             }
+        }
+
+        @Test
+        fun `directoryNavigator should provide repeated auto-completion`() {
+
         }
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -891,6 +891,84 @@ class DialogProviderTest {
 
         @Test
         fun `directoryNavigator should provide repeated auto-completion`() {
+            var result: String
+            val testFilePath = "src/test/resources"
+            val inputFileName = "$testFilePath/validExtension.cc.json"
+            val testMessage = "What are the input folder(s) or [.cc.json] file(s). Enter multiple files comma separated."
+            val slash = File.separatorChar
+            val initialHint = "build$slash"
+            val directoryContent = "build$slash src$slash"
+
+            testSession { terminal ->
+                result =
+                    promptDefaultDirectoryAssistedInput(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), multiple = true, onInputReady = {
+                        terminal.assertMatches {
+                            bold {
+                                green { text("? ") }
+                                textLine(testMessage)
+                            }
+                            text("> ")
+                            black(isBright = true) {
+                                invert { text(initialHint[0]) }
+                                text("${initialHint.drop(1)} ")
+                            }
+                            text("\n")
+                            black(isBright = true) {
+                                text(directoryContent)
+                            }
+                        }
+                        terminal.type("sr")
+//                        assertThat( terminal.resolveRerenders().stripFormatting()).containsExactly(
+//                            "? $testMessage",
+//                            "> $inputFileName ",
+//                            ""
+//                        )
+//                        terminal.assertMatches {
+//                            bold {
+//                                green { text("? ") }
+//                                textLine(testMessage)
+//                            }
+//                            text("> ")
+//                            black(isBright = true) {
+//                                text("sr")
+//                                invert { text("c") }
+//                            }
+//                            text("\n")
+//                            black(isBright = true) {
+//                                text("src$slash")
+//                            }
+//                        }
+                        terminal.press(Keys.TAB)
+                        terminal.type("test${slash}resour")
+                        terminal.resolveRerenders()
+//                        terminal.assertMatches {
+//                            bold {
+//                                green { text("? ") }
+//                                textLine(testMessage)
+//                            }
+//                            text("> ")
+//                            black(isBright = true) {
+//                                text("src${slash}test${slash}resour")
+//                                invert { text("c") }
+//                            }
+//                            text("\n")
+//                            black(isBright = true) {
+//                                text("es$slash")
+//                            }
+//                        }
+                        terminal.press(Keys.RIGHT)
+                        terminal.type("valid")
+                        terminal.press(Keys.TAB)
+                        terminal.press(Keys.ENTER)
+                    })
+                assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
+                    "? $testMessage",
+                    "> $inputFileName ",
+                    ""
+                )
+
+                assertThat(result).isEqualTo(inputFileName)
+            }
         }
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -771,21 +771,22 @@ class DialogProviderTest {
             var result: String
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/valid.log"
+            val inputFile = File(inputFileName)
             val testMessage = "What is the input file."
 
             testSession { terminal ->
                 result =
                     promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(), onInputReady = {
-                        terminal.type(inputFileName)
+                        terminal.type(inputFile.toString())
                         terminal.press(Keys.ENTER)
                     })
                 assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
                     "? $testMessage",
-                    "> $inputFileName ",
+                    "> $inputFile ",
+                    inputFile.name,
                     ""
                 )
-
-                assertThat(result).isEqualTo(inputFileName)
+                assertThat(result).isEqualTo(inputFile.toString())
             }
         }
 
@@ -794,21 +795,23 @@ class DialogProviderTest {
             var result: String
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/validExtension.cc.json"
+            val inputFile = File(inputFileName)
             val testMessage = "What is the input [.cc.json] file."
 
             testSession { terminal ->
                 result =
                     promptDefaultDirectoryAssistedInput(InputType.FILE, listOf(FileExtension.CCJSON), onInputReady = {
-                        terminal.type(inputFileName)
+                        terminal.type(inputFile.toString())
                         terminal.press(Keys.ENTER)
                     })
                 assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
                     "? $testMessage",
-                    "> $inputFileName ",
+                    "> $inputFile ",
+                    inputFile.name,
                     ""
                 )
 
-                assertThat(result).isEqualTo(inputFileName)
+                assertThat(result).isEqualTo(inputFile.toString())
             }
         }
 
@@ -817,6 +820,7 @@ class DialogProviderTest {
             var result: String
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/valid.log"
+            val inputFile = File(inputFileName)
             val testMessage = "What are the input file(s). Enter multiple files comma separated."
             val initialHint = "build" + File.separatorChar
             val directoryContent = "build${File.separatorChar}           src${File.separatorChar}             build.gradle.kts"
@@ -839,16 +843,17 @@ class DialogProviderTest {
                                 text(directoryContent)
                             }
                         }
-                        terminal.type(inputFileName)
+                        terminal.type(inputFile.toString())
                         terminal.press(Keys.ENTER)
                     })
                 assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
                     "? $testMessage",
-                    "> $inputFileName ",
+                    "> $inputFile ",
+                    inputFile.name,
                     ""
                 )
 
-                assertThat(result).isEqualTo(inputFileName)
+                assertThat(result).isEqualTo(inputFile.toString())
             }
         }
 
@@ -857,6 +862,7 @@ class DialogProviderTest {
             var result: String
             val testFilePath = "src/test/resources"
             val inputFileName = "$testFilePath/validExtension.cc.json"
+            val inputFile = File(inputFileName)
             val testMessage = "What are the input [.cc.json] file(s). Enter multiple files comma separated."
             val initialHint = "build" + File.separatorChar
             val directoryContent = "build" + File.separatorChar + " src" + File.separatorChar
@@ -879,16 +885,17 @@ class DialogProviderTest {
                                 text(directoryContent)
                             }
                         }
-                        terminal.type(inputFileName)
+                        terminal.type(inputFile.toString())
                         terminal.press(Keys.ENTER)
                     })
                 assertThat(terminal.resolveRerenders().stripFormatting()).containsExactly(
                     "? $testMessage",
-                    "> $inputFileName ",
+                    "> $inputFile ",
+                    inputFile.name,
                     ""
                 )
 
-                assertThat(result).isEqualTo(inputFileName)
+                assertThat(result).isEqualTo(inputFile.toString())
             }
         }
 

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -987,7 +987,7 @@ class DialogProviderTest {
                             }
                             terminal.type("sr")
                             terminal.press(Keys.RIGHT)
-                            terminal.type("test${slash}")
+                            terminal.type("test$slash")
                             terminal.press(Keys.ENTER)
                         }
                     )
@@ -996,7 +996,7 @@ class DialogProviderTest {
                     "> ${File(testFilePath)}$slash ",
                     ""
                 )
-                assertThat(result).isEqualTo(File(testFilePath).toString()+slash)
+                assertThat(result).isEqualTo(File(testFilePath).toString() + slash)
             }
         }
     }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -891,7 +891,6 @@ class DialogProviderTest {
 
         @Test
         fun `directoryNavigator should provide repeated auto-completion`() {
-
         }
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DialogProviderTest.kt
@@ -18,6 +18,7 @@ import com.varabyte.kotterx.test.terminal.assertMatches
 import de.maibornwolff.codecharta.serialization.FileExtension
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -943,6 +944,7 @@ class DialogProviderTest {
                 )
                 assertThat(result).isEqualTo(File(inputFileName).toString())
             }
+            unmockkAll()
         }
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -4,10 +4,10 @@ import de.maibornwolff.codecharta.serialization.FileExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class DialogDirectoryProviderTest {
+class DirectoryNavigatorTest {
     @Test
     fun `this should provide a good change directory experience`() {
-        val uut = DialogDirectoryProvider(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON))
+        val uut = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
         uut.prepareMatches("")
         assertThat(uut.getHints()).isEqualTo("")
     }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class DirectoryNavigatorTest {
+    private val slash = File.separatorChar
+
     @Test
     fun `this should provide a good change directory experience`() {
         val uut = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
@@ -13,4 +15,47 @@ class DirectoryNavigatorTest {
         uut.prepareMatches("")
         assertThat(uut.getHints()).isEqualTo(arrayOf("build$systemSlash", "src$systemSlash"))
     }
+
+    @Test
+    fun `should set input types correctly`() {
+        val navigatorFiles = DirectoryNavigator(InputType.FILE, listOf(), false)
+        val navigatorFolderAndFiles = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(), false)
+        val navigatorFolders = DirectoryNavigator(InputType.FOLDER, listOf(), false)
+
+        assertThat(navigatorFiles.filesAllowed).isTrue()
+        assertThat(navigatorFolderAndFiles.filesAllowed).isTrue()
+        assertThat(navigatorFolders.filesAllowed).isFalse()
+    }
+
+    @Test
+    fun `should filter possible file options correctly`() {
+        val navigator = DirectoryNavigator(InputType.FILE, listOf(), false)
+        assertThat(navigator.currentDirectoryContent.size).isEqualTo(3)
+        assertThat(navigator.possibleDirectories.size).isEqualTo(2)
+        assertThat(navigator.possibleFiles.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `should filter unaccepted file options`() {
+        val navigator = DirectoryNavigator(InputType.FOLDER, listOf(), false)
+        assertThat(navigator.currentDirectoryContent.size).isEqualTo(3)
+        assertThat(navigator.possibleDirectories.size).isEqualTo(2)
+        assertThat(navigator.possibleFiles.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `should perform an update cycle as expected `() {
+        val resourcePath = "src/test/resources/"
+        val matchingFile = "${resourcePath}validExtension.cc.json"
+        val navigator = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
+
+        navigator.prepareMatches(File(resourcePath).toString()+slash)
+        val hints = navigator.getHints()
+        val matchesString = navigator.getMatches()
+
+        assertThat(hints.size).isEqualTo(1)
+        assertThat(hints).containsExactly(File(matchingFile).toString())
+        assertThat(matchesString).isEqualTo("validExtension.cc.json")
+    }
+
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -3,12 +3,14 @@ package de.maibornwolff.codecharta.dialogProvider
 import de.maibornwolff.codecharta.serialization.FileExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class DirectoryNavigatorTest {
     @Test
     fun `this should provide a good change directory experience`() {
         val uut = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
+        val systemSlash = File.separatorChar
         uut.prepareMatches("")
-        assertThat(uut.getHints()).isEqualTo("")
+        assertThat(uut.getHints()).isEqualTo(arrayOf("build$systemSlash", "src$systemSlash"))
     }
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -49,7 +49,7 @@ class DirectoryNavigatorTest {
         val matchingFile = "${resourcePath}validExtension.cc.json"
         val navigator = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
 
-        navigator.prepareMatches(File(resourcePath).toString()+slash)
+        navigator.prepareMatches(File(resourcePath).toString() + slash)
         val hints = navigator.getHints()
         val matchesString = navigator.getMatches()
 
@@ -57,5 +57,4 @@ class DirectoryNavigatorTest {
         assertThat(hints).containsExactly(File(matchingFile).toString())
         assertThat(matchesString).isEqualTo("validExtension.cc.json")
     }
-
 }

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -45,9 +45,18 @@ class DirectoryNavigatorTest {
 
     @Test
     fun `should perform an update cycle as expected `() {
+        val partialResourcePath = "src/test/"
         val resourcePath = "src/test/resources/"
         val matchingFile = "${resourcePath}validExtension.cc.json"
         val navigator = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
+
+        navigator.prepareMatches(File(partialResourcePath).toString() + slash)
+        assertThat(navigator.getHints().size).isEqualTo(2)
+        assertThat(navigator.getHints()).containsExactly(
+            File("src/test/kotlin/").toString() + slash,
+            File("src/test/resources/").toString() + slash
+        )
+        assertThat(navigator.getMatches()).isEqualTo("kotlin$slash    resources$slash")
 
         navigator.prepareMatches(File(resourcePath).toString() + slash)
         val hints = navigator.getHints()

--- a/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
+++ b/analysis/dialogProvider/src/test/kotlin/de/maibornwolff/codecharta/dialogProvider/DirectoryNavigatorTest.kt
@@ -9,14 +9,6 @@ class DirectoryNavigatorTest {
     private val slash = File.separatorChar
 
     @Test
-    fun `this should provide a good change directory experience`() {
-        val uut = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
-        val systemSlash = File.separatorChar
-        uut.prepareMatches("")
-        assertThat(uut.getHints()).isEqualTo(arrayOf("build$systemSlash", "src$systemSlash"))
-    }
-
-    @Test
     fun `should set input types correctly`() {
         val navigatorFiles = DirectoryNavigator(InputType.FILE, listOf(), false)
         val navigatorFolderAndFiles = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(), false)
@@ -30,6 +22,7 @@ class DirectoryNavigatorTest {
     @Test
     fun `should filter possible file options correctly`() {
         val navigator = DirectoryNavigator(InputType.FILE, listOf(), false)
+
         assertThat(navigator.currentDirectoryContent.size).isEqualTo(3)
         assertThat(navigator.possibleDirectories.size).isEqualTo(2)
         assertThat(navigator.possibleFiles.size).isEqualTo(1)
@@ -38,6 +31,7 @@ class DirectoryNavigatorTest {
     @Test
     fun `should filter unaccepted file options`() {
         val navigator = DirectoryNavigator(InputType.FOLDER, listOf(), false)
+
         assertThat(navigator.currentDirectoryContent.size).isEqualTo(3)
         assertThat(navigator.possibleDirectories.size).isEqualTo(2)
         assertThat(navigator.possibleFiles.size).isEqualTo(0)
@@ -51,6 +45,7 @@ class DirectoryNavigatorTest {
         val navigator = DirectoryNavigator(InputType.FOLDER_AND_FILE, listOf(FileExtension.CCJSON), false)
 
         navigator.prepareMatches(File(partialResourcePath).toString() + slash)
+
         assertThat(navigator.getHints().size).isEqualTo(2)
         assertThat(navigator.getHints()).containsExactly(
             File("src/test/kotlin/").toString() + slash,


### PR DESCRIPTION
### Analysis: Kotter Dialog Expansion No.2

Issue #3923

## Description

- Add auto complete functionality to all modules that require an input file
  - List all current working directory contents filtered by the current input
  - Refresh current working directory when completing a partial path
  - Provide suggetions to complete the input via Arrow key right or tab (experimental)
  - Provide the same "default" behavior to generate the text above the input, e.g. "What is the input file?"
- Fix bug where print statements inside dialog segments are omitted by the running dialog
  - Those statements will be transformed into an additional line of dialog

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
