### PR TITLE
Feat/4078/unified parser applicable check

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
   - It currently supports:
     - Typescript
     - Kotlin
+  - It is also available when calling the ccsh without parameters [#4102](https://github.com/MaibornWolff/codecharta/pull/4102)
 - Add auto-completing file input to all interactive dialogs [#4081](https://github.com/MaibornWolff/codecharta/pull/4081)
 
 ## [1.133.0] - 2025-05-19

--- a/analysis/analysers/parsers/UnifiedParser/README.md
+++ b/analysis/analysers/parsers/UnifiedParser/README.md
@@ -71,11 +71,11 @@ This Parser is built with extensibility in mind and can be extended in two ways:
 
 Adding a new language to the parser is done by creating a new language specific 'collector', which inherits from the abstract class 'MetricCollector'. Such a collector requires two parameters. First a reference to the treesitter implementation for the language. For many language, this can be found [here](https://github.com/bonede/tree-sitter-ng) and can be added as a dependency via the 'libs.versions.toml'. Second, the collector requires language specific queries in form of a query provider.
 
-As the treesitter grammars differ by language, these queries need to be adjusted for each language. Creating a new query provider is done by inheriting from the 'MetricQueries' interface and creating one query for each member. This interface has one member for each of the metrics currently supported by this parser. It is also possible to only provide queries for only some of the metrics. Fot this, the 'getAvailableMetrics' function can be overwritten to only include the metric this language supports
+As the treesitter grammars differ by language, these queries need to be adjusted for each language. Creating a new query provider is done by inheriting from the 'MetricQueries' interface and creating one query for each member. This interface has one member for each of the metrics currently supported by this parser. It is also possible to provide queries for only some of the metrics. Fot this, the 'getAvailableMetrics' function can be overwritten to only include the metric this language supports
 
 By default, it is not necessary to implement any functionality in the language specific collectors. If however the calculation for one metric is different from the base implementation, the function to calculate that metric can be overwritten
 
-Finally, to make the newly created collector accessible, set for which file types it should be applied in the 'applyLanguageSpecificCollector' function of the 'ProjectScanner'.
+Finally, to make the newly created collector accessible, add it to the 'AvailableCollectors' enum.
 
 ### Adding a new metric
 

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
@@ -7,6 +7,7 @@ import de.maibornwolff.codecharta.analysers.analyserinterface.util.CodeChartaCon
 import de.maibornwolff.codecharta.analysers.analyserinterface.util.CommaSeparatedParameterPreprocessor
 import de.maibornwolff.codecharta.analysers.analyserinterface.util.CommaSeparatedStringToListConverter
 import de.maibornwolff.codecharta.analysers.filters.mergefilter.MergeFilter
+import de.maibornwolff.codecharta.analysers.parsers.unified.metriccollectors.AvailableCollectors
 import de.maibornwolff.codecharta.analysers.parsers.unified.metricqueries.mapNamesToMetrics
 import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
@@ -15,6 +16,7 @@ import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
 import de.maibornwolff.codecharta.util.InputHelper
 import de.maibornwolff.codecharta.util.Logger
+import de.maibornwolff.codecharta.util.ResourceSearchHelper
 import picocli.CommandLine
 import java.io.InputStream
 import java.io.PrintStream
@@ -99,8 +101,11 @@ class UnifiedParser(
     override fun getDialog(): AnalyserDialogInterface = Dialog
 
     override fun isApplicable(resourceToBeParsed: String): Boolean {
-        // TODO: maybe we want to use this function?
-        return false
+        println("Checking if SourceCodeParser is applicable...")
+        return ResourceSearchHelper.isFileWithOneOrMoreOfEndingsPresent(
+            resourceToBeParsed,
+            AvailableCollectors.entries.map { it.fileExtension }
+        )
     }
 
     override fun getAttributeDescriptorMaps(): Map<String, AttributeDescriptor> {

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
@@ -101,7 +101,7 @@ class UnifiedParser(
     override fun getDialog(): AnalyserDialogInterface = Dialog
 
     override fun isApplicable(resourceToBeParsed: String): Boolean {
-        println("Checking if SourceCodeParser is applicable...")
+        println("Checking if UnifiedParser is applicable...")
         return ResourceSearchHelper.isFileWithOneOrMoreOfEndingsPresent(
             resourceToBeParsed,
             AvailableCollectors.entries.map { it.fileExtension }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
@@ -1,0 +1,14 @@
+package de.maibornwolff.codecharta.analysers.parsers.unified.metriccollectors
+
+import de.maibornwolff.codecharta.serialization.FileExtension
+
+enum class AvailableCollectors(
+    val fileExtension: FileExtension,
+    val collectorFactory: () -> MetricCollector
+) {
+    TYPESCRIPT(FileExtension.TYPESCRIPT, ::TypescriptCollector),
+    JAVASCRIPT(FileExtension.JAVASCRIPT, ::JavascriptCollector),
+    KOTLIN(FileExtension.KOTLIN, ::KotlinCollector),
+    JAVA(FileExtension.JAVA, ::JavaCollector),
+    CSHARP(FileExtension.CSHARP, ::CSharpCollector)
+}


### PR DESCRIPTION
# Implement 'isApplicable' for UnifiedParser

Closes: #4078

## Description

Implements the 'isApplicable' function for the unifiedParser, meaning executing 'ccsh' without any parameters now suggests the unifiedParser if any applicable file was within the input

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
