### PR TITLE
Docs/4103/coverage importer improvements

### DIFF
--- a/analysis/analysers/importers/CoverageImporter/README.md
+++ b/analysis/analysers/importers/CoverageImporter/README.md
@@ -119,3 +119,8 @@ Example Output file: `typescript_coverage.cc.json`
 }
 ```
 
+## Extending the Coverage Importer
+
+The coverage importer has different implementations (or strategies) based on the format of the coverage report.
+
+To add support for a new report format, it is necessary to create a new class which implements the 'ImporterStrategy' interface. This new strategy handles extracting the relevant information from the coverage report and inserting them into the projectBuilder, which will generate the final output (this does not need to be implemented). If the report is in xml format, the ImporterStrategy interface provides some functionality to find the relevant elements in the report based on their xml-tag. After this implementation is done, add the new strategy to the 'SupportedFormats' enum, so that it will be available for execution. It is recommended to also add some dummy reports of the new format as testing resource together with tests, to ensure the format is correctly handled.

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/CoberturaStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/CoberturaStrategy.kt
@@ -19,6 +19,7 @@ class CoberturaStrategy : ImporterStrategy {
     override fun addNodesToProjectBuilder(coverageFile: File, projectBuilder: ProjectBuilder, error: PrintStream, keepFullPaths: Boolean) {
         processXMLReport(coverageFile, projectBuilder, error, "package") { element, builder -> processPackageElement(element, builder) }
         if (!keepFullPaths) removeExtraNodesAroundProject(projectBuilder)
+        printPackageWarning()
     }
 
     private fun processPackageElement(packageElement: Element, projectBuilder: ProjectBuilder) {

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/ImporterStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/ImporterStrategy.kt
@@ -98,4 +98,11 @@ interface ImporterStrategy {
         }
         projectBuilder.rootNode.children = newRoot.children
     }
+
+    fun printPackageWarning() {
+        println("\n")
+        Logger.warn { "NOTE: The selected coverage report format contains only package information! " }
+        Logger.warn { "NOTE: The resulting cc.json might contain file paths not starting from the project root." }
+        Logger.warn { "NOTE: Consider running another analyser on the project (e.g. unifiedParser) and merging the results." }
+    }
 }

--- a/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JacocoStrategy.kt
+++ b/analysis/analysers/importers/CoverageImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/coverage/strategies/JacocoStrategy.kt
@@ -19,6 +19,7 @@ class JacocoStrategy : ImporterStrategy {
     override fun addNodesToProjectBuilder(coverageFile: File, projectBuilder: ProjectBuilder, error: PrintStream, keepFullPaths: Boolean) {
         processXMLReport(coverageFile, projectBuilder, error, "package") { element, builder -> processPackageElement(element, builder) }
         if (!keepFullPaths) removeExtraNodesAroundProject(projectBuilder)
+        printPackageWarning()
     }
 
     private fun processPackageElement(packageElement: Element, projectBuilder: ProjectBuilder) {


### PR DESCRIPTION
# Improve docs for coverage importer

Closes: #4103

## Description

Adds section in readme on how to extend the importer
Adds warnings for strategies that work on package level that the resulting cc.json does not contain the full filepaths

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
