### PR TITLE
fix/4110/progresstracker-reset

### DIFF
--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/progresstracker/ProgressTracker.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/progresstracker/ProgressTracker.kt
@@ -6,6 +6,7 @@ import kotlin.math.log10
 
 class ProgressTracker() {
     private var startTime = System.currentTimeMillis()
+    private var lastLineLength = 0
 
     // function based on java implementation by Alexander Shuev: https://stackoverflow.com/questions/1001290/console-based-progress-in-java
     fun updateProgress(total: Long, parsed: Long, unit: String, filename: String = "") {
@@ -55,8 +56,19 @@ class ProgressTracker() {
 
             if (filename != "") {
                 string.append(" parsed file: $filename")
+                val currentLength = string.length - 1 // -1 because we don't count the \r at the start of the line
+                string.append(getClearingSpaces(currentLength))
             }
             System.err.print(string)
         }
+    }
+
+    private fun getClearingSpaces(currentLength: Int): String {
+        var result = ""
+        if (currentLength < lastLineLength) {
+            result = " ".repeat(lastLineLength - currentLength)
+        }
+        lastLineLength = currentLength
+        return result
     }
 }


### PR DESCRIPTION
# fix progressbar trailing characters

Closes: #4110

## Description

Fixes the progressbar showing trailing characters if a previous filename was longer

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
