### PR TITLE
feat/4121/adjust-exclude-param

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Changed
+
+- Rename `--without-default-excludes` flag of UnifiedParser to `--include-build-folders` [#4144](https://github.com/MaibornWolff/codecharta/pull/4144)
+
 ## [1.135.0] - 2025-07-28
 
 ### Added 🚀

--- a/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/CommonAnalyserParameters.kt
+++ b/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/CommonAnalyserParameters.kt
@@ -34,10 +34,13 @@ abstract class CommonAnalyserParameters {
     protected var patternsToExclude: List<String> = listOf()
 
     @CommandLine.Option(
-        names = ["--without-default-excludes"],
-        description = ["include build, target, dist, resources and out folders as well as files/folders starting with '.' "]
+        names = ["-ibf", "--include-build-folders"],
+        description = [
+            "include build folders (out, build, dist and target) and " +
+                "common resource folders (e.g. resources, node_modules or files/folders starting with '.')"
+        ]
     )
-    protected var withoutDefaultExcludes = false
+    protected var includeBuildFolders = false
 
     @CommandLine.Option(
         names = ["-fe", "--file-extensions"],

--- a/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/util/CodeChartaConstants.kt
+++ b/analysis/analysers/AnalyserInterface/src/main/kotlin/de/maibornwolff/codecharta/analysers/analyserinterface/util/CodeChartaConstants.kt
@@ -12,6 +12,6 @@ class CodeChartaConstants {
          */
         const val EXECUTION_STARTED_SYNC_FLAG = "\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E\u000E"
 
-        val DEFAULT_EXCLUDES = arrayOf("/out/", "/build/", "/target/", "/dist/", "/resources/", "/node_modules/", "(/|^)\\..*")
+        val BUILD_FOLDERS = arrayOf("/out/", "/build/", "/target/", "/dist/", "/resources/", "/node_modules/", "(/|^)\\..*")
     }
 }

--- a/analysis/analysers/parsers/RawTextParser/README.md
+++ b/analysis/analysers/parsers/RawTextParser/README.md
@@ -15,20 +15,20 @@ This parser analyzes code, regardless of the programming language, to generate t
 
 ## Usage and Parameters
 
-| Parameter                                 | Description                                                                                          |
-|-------------------------------------------|------------------------------------------------------------------------------------------------------|
-| `FILE or FOLDER`                          | file/project to parseProject                                                                         |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                      |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                      |
-| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                     |
-| `-h, --help`                              | displays this help and exits                                                                         |
-| `-m, --metrics=metrics`                   | comma-separated list of metrics to be computed (all available metrics are computed if not specified) |
-| `--max-indentation-level=<maxIndentLvl>`  | maximum Indentation Level (default 10)                                                               |
-| `-nc, --not-compressed`                   | save uncompressed output File                                                                        |
-| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                    |
-| `--tab-width=<tabWidth>`                  | tab width used (estimated if not provided)                                                           |
-| `--verbose`                               | verbose mode                                                                                         |
-| `--without-default-excludes`              | include build, target, dist, resources and out folders as well as files/folders starting with '.'    |
+| Parameter                                 | Description                                                                                                                                                                                        |
+|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FILE or FOLDER`                          | file/project to parseProject                                                                                                                                                                       |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                                                                    |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                                                                    |
+| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                                                                                                                   |
+| `-h, --help`                              | displays this help and exits                                                                                                                                                                       |
+| `-m, --metrics=metrics`                   | comma-separated list of metrics to be computed (all available metrics are computed if not specified)                                                                                               |
+| `--max-indentation-level=<maxIndentLvl>`  | maximum Indentation Level (default 10)                                                                                                                                                             |
+| `-nc, --not-compressed`                   | save uncompressed output File                                                                                                                                                                      |
+| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                                                                                                                  |
+| `--tab-width=<tabWidth>`                  | tab width used (estimated if not provided)                                                                                                                                                         |
+| `--verbose`                               | verbose mode                                                                                                                                                                                       |
+| `--without-default-excludes`              | (DEPRECATION WARNING: this flag will soon be disabled and replaced by '--include-build-folders') include build, target, dist, resources and out folders as well as files/folders starting with '.' |
 
 ```
 Usage: ccsh rawtextparser [-h] [-nc] [--verbose] [--without-default-excludes]

--- a/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/RawTextParser.kt
+++ b/analysis/analysers/parsers/RawTextParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/rawtext/RawTextParser.kt
@@ -79,7 +79,10 @@ class RawTextParser(
 
     @CommandLine.Option(
         names = ["--without-default-excludes"],
-        description = ["include build, target, dist, resources and out folders as well as files/folders starting with '.' "]
+        description = [
+            "DEPRECATION WARNING: this flag will soon be disabled and replaced by '--include-build-folders'" +
+                "include build, target, dist, resources and out folders as well as files/folders starting with '.' "
+        ]
     )
     private var withoutDefaultExcludes = false
 

--- a/analysis/analysers/parsers/UnifiedParser/README.md
+++ b/analysis/analysers/parsers/UnifiedParser/README.md
@@ -31,20 +31,20 @@ The Unified Parser is parser to generate code metrics from a source code file or
 
 ## Usage and Parameters
 
-| Parameter                                 | Description                                                                                   |
-|-------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `FOLDER or FILE`                          | The project folder or code file to parse                                                      |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                               |
-| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)              |
-| `-h, --help`                              | displays this help and exits                                                                  |
-| `-nc, --not-compressed`                   | save uncompressed output File                                                                 |
-| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                             |
-| `--verbose`                               | displays messages about parsed and ignored files                                              |
-| `--without-default-excludes`              | do not exclude build, target, dist and out folders as well as files/folders starting with '.' |
+| Parameter                                 | Description                                                                                                                                       |
+|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FOLDER or FILE`                          | The project folder or code file to parse                                                                                                          |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                   |
+| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                                                                  |
+| `-h, --help`                              | displays this help and exits                                                                                                                      |
+| `-ibf, --include-build-folders`           | include build folders (out, build, dist and target) and common resource folders (e.g. resources, node_modules or files/folders starting with '.') |
+| `-nc, --not-compressed`                   | save uncompressed output File                                                                                                                     |
+| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                                                                 |
+| `--verbose`                               | displays messages about parsed and ignored files                                                                                                  |
 
 ```
-Usage: ccsh unifiedparser [-h] [-nc] [--verbose] [--without-default-excludes]
-                          [-o=<outputFile>] [-e=<patternsToExclude>]...
+Usage: ccsh unifiedparser [-h] [-ibf] [-nc] [--verbose] [-o=<outputFile>]
+                          [-e=<patternsToExclude>]...
                           [-fe=<fileExtensionsToAnalyse>]... FILE or FOLDER
 ```
 
@@ -65,7 +65,7 @@ ccsh unifiedparser src/test/resources -o foo.cc.json -nc --verbose
 ```
 
 ```
-ccsh unifiedparser src/test/resources -o foo.cc.json --without-default-excludes -e=something -e=/.*\.foo
+ccsh unifiedparser src/test/resources -o foo.cc.json --include-build-folders -e=something -e=/.*\.foo
 ```
 
 If a project is piped into the UnifiedParser, the results and the piped project are merged.

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/Dialog.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/Dialog.kt
@@ -25,7 +25,7 @@ class Dialog {
             val fileExtensions =
                 if (askExcludeInclude == "Only include" || askExcludeInclude == "Both") includeFileExtensionsQuestion(session) else ""
 
-            val withoutDefaultExcludes = defaultExcludesQuestion(session)
+            val includeBuildFolders = includeBuildFolderQuestion(session)
 
             val verbose = verboseQuestion(session)
 
@@ -36,7 +36,7 @@ class Dialog {
                 "--verbose=${!verbose}",
                 "--exclude=$exclude",
                 "--file-extensions=$fileExtensions",
-                if (withoutDefaultExcludes) "--without-default-excludes" else null
+                if (includeBuildFolders) "--include-build-folders" else null
             )
         }
 
@@ -94,10 +94,10 @@ class Dialog {
             )
         }
 
-        private fun defaultExcludesQuestion(session: Session): Boolean {
+        private fun includeBuildFolderQuestion(session: Session): Boolean {
             return session.promptConfirm(
-                message = "Do you want to include build, target, dist, resources" +
-                    " and out folders as well as files/folders starting with '.'?",
+                message = "Do you want to include build folders (build, target, dist, out) and common resource folders " +
+                    "e.g. resources, node_modules or files/folders starting with '.'?",
                 onInputReady = testCallback()
             )
         }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParser.kt
@@ -46,7 +46,7 @@ class UnifiedParser(
             "Input invalid file for UnifiedParser, stopping execution..."
         }
 
-        if (!withoutDefaultExcludes) patternsToExclude += CodeChartaConstants.DEFAULT_EXCLUDES
+        if (!includeBuildFolders) patternsToExclude += CodeChartaConstants.BUILD_FOLDERS
         val projectBuilder = ProjectBuilder()
         val projectScanner = ProjectScanner(inputFile!!, projectBuilder, patternsToExclude, fileExtensionsToAnalyse)
         projectScanner.traverseInputProject(verbose)

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/DialogTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/DialogTest.kt
@@ -88,7 +88,7 @@ class DialogTest {
         assertThat(parseResult.matchedOption("verbose").getValue<Boolean>()).isEqualTo(isVerbose)
         assertThat(parseResult.matchedOption("exclude").getValue<List<String>>()).isEqualTo(listOf(exclude))
         assertThat(parseResult.matchedOption("file-extensions").getValue<List<String>>()).isEqualTo(listOf(include))
-        assertThat(parseResult.hasMatchedOption("without-default-excludes")).isFalse()
+        assertThat(parseResult.hasMatchedOption("include-build-folders")).isFalse()
     }
 
     @Test
@@ -119,7 +119,7 @@ class DialogTest {
                 terminal.press(Keys.DOWN)
                 terminal.press(Keys.ENTER)
             }
-            val defaultExcludesCallback: suspend RunScope.() -> Unit = {
+            val includeBuildCallback: suspend RunScope.() -> Unit = {
                 terminal.press(Keys.ENTER)
             }
             val verboseCallback: suspend RunScope.() -> Unit = {
@@ -131,7 +131,7 @@ class DialogTest {
                 outFileCallback,
                 compressCallback,
                 excludeOrIncludeCallback,
-                defaultExcludesCallback,
+                includeBuildCallback,
                 verboseCallback
             )
 
@@ -146,7 +146,7 @@ class DialogTest {
         assertThat(parseResult.matchedOption("verbose").getValue<Boolean>()).isEqualTo(isVerbose)
         assertThat(parseResult.matchedOption("exclude").getValue<List<String>>()).isEqualTo(listOf<String>())
         assertThat(parseResult.matchedOption("file-extensions").getValue<List<String>>()).isEqualTo(listOf<String>())
-        assertThat(parseResult.hasMatchedOption("without-default-excludes")).isTrue()
+        assertThat(parseResult.hasMatchedOption("include-build-folders")).isTrue()
     }
 
     @Test
@@ -214,6 +214,6 @@ class DialogTest {
         assertThat(parseResult.matchedOption("verbose").getValue<Boolean>()).isEqualTo(isVerbose)
         assertThat(parseResult.matchedOption("exclude").getValue<List<String>>()).isEqualTo(listOf(exclude))
         assertThat(parseResult.matchedOption("file-extensions").getValue<List<String>>()).isEqualTo(listOf(include))
-        assertThat(parseResult.hasMatchedOption("without-default-excludes")).isFalse()
+        assertThat(parseResult.hasMatchedOption("include-build-folders")).isFalse()
     }
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
@@ -226,7 +226,7 @@ class UnifiedParserTest {
         val expectedResultFile = File("${testResourceBaseFolder}includeAll.cc.json").absoluteFile
 
         // when
-        val result = executeForOutput(pipedProject, arrayOf(inputFilePath, "--without-default-excludes"))
+        val result = executeForOutput(pipedProject, arrayOf(inputFilePath, "--include-build-folders"))
 
         // then
         JSONAssert.assertEquals(result, expectedResultFile.readText(), JSONCompareMode.NON_EXTENSIBLE)

--- a/gh-pages/_docs/05-parser/02-raw-text.md
+++ b/gh-pages/_docs/05-parser/02-raw-text.md
@@ -22,20 +22,20 @@ This parser analyzes code, regardless of the programming language, to generate t
 
 ## Usage and Parameters
 
-| Parameter                                 | Description                                                                                          |
-|-------------------------------------------|------------------------------------------------------------------------------------------------------|
-| `FILE or FOLDER`                          | file/project to parseProject                                                                         |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                      |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                      |
-| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                     |
-| `-h, --help`                              | displays this help and exits                                                                         |
-| `-m, --metrics=metrics`                   | comma-separated list of metrics to be computed (all available metrics are computed if not specified) |
-| `--max-indentation-level=<maxIndentLvl>`  | maximum Indentation Level (default 10)                                                               |
-| `-nc, --not-compressed`                   | save uncompressed output File                                                                        |
-| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                    |
-| `--tab-width=<tabWidth>`                  | tab width used (estimated if not provided)                                                           |
-| `--verbose`                               | verbose mode                                                                                         |
-| `--without-default-excludes`              | include build, target, dist, resources and out folders as well as files/folders starting with '.'    |
+| Parameter                                 | Description                                                                                                                                                                                          |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FILE or FOLDER`                          | file/project to parseProject                                                                                                                                                                         |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                                                                      |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                                                                      |
+| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                                                                                                                     |
+| `-h, --help`                              | displays this help and exits                                                                                                                                                                         |
+| `-m, --metrics=metrics`                   | comma-separated list of metrics to be computed (all available metrics are computed if not specified)                                                                                                 |
+| `--max-indentation-level=<maxIndentLvl>`  | maximum Indentation Level (default 10)                                                                                                                                                               |
+| `-nc, --not-compressed`                   | save uncompressed output File                                                                                                                                                                        |
+| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                                                                                                                    |
+| `--tab-width=<tabWidth>`                  | tab width used (estimated if not provided)                                                                                                                                                           |
+| `--verbose`                               | verbose mode                                                                                                                                                                                         |
+| `--without-default-excludes`              | ("DEPRECATION WARNING: this flag will soon be disabled and replaced by '--include-build-folders'") include build, target, dist, resources and out folders as well as files/folders starting with '.' |
 
 ```
 Usage: ccsh rawtextparser [-h] [-nc] [--verbose] [--without-default-excludes]

--- a/gh-pages/_docs/05-parser/05-unified.md
+++ b/gh-pages/_docs/05-parser/05-unified.md
@@ -37,20 +37,20 @@ The Unified Parser is parser to generate code metrics from a source code file or
 
 ## Usage and Parameters
 
-| Parameter                                 | Description                                                                                   |
-|-------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `FOLDER or FILE`                          | The project folder or code file to parse                                                      |
-| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                               |
-| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)              |
-| `-h, --help`                              | displays this help and exits                                                                  |
-| `-nc, --not-compressed`                   | save uncompressed output File                                                                 |
-| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                             |
-| `--verbose`                               | displays messages about parsed and ignored files                                              |
-| `--without-default-excludes`              | do not exclude build, target, dist and out folders as well as files/folders starting with '.' |
+| Parameter                                 | Description                                                                                                                                       |
+|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FOLDER or FILE`                          | The project folder or code file to parse                                                                                                          |
+| `-e, --exclude=<exclude>`                 | comma-separated list of regex patterns to exclude files/folders                                                                                   |
+| `-fe, --file-extensions=<fileExtensions>` | comma-separated list of file-extensions to parse only those files (default: any)                                                                  |
+| `-h, --help`                              | displays this help and exits                                                                                                                      |
+| `-ibf, --include-build-folders`           | include build folders (out, build, dist and target) and common resource folders (e.g. resources, node_modules or files/folders starting with '.') |
+| `-nc, --not-compressed`                   | save uncompressed output File                                                                                                                     |
+| `-o, --output-file=<outputFile>`          | output File (or empty for stdout)                                                                                                                 |
+| `--verbose`                               | displays messages about parsed and ignored files                                                                                                  |
 
 ```
-Usage: ccsh unifiedparser [-h] [-nc] [--verbose] [--without-default-excludes]
-                          [-o=<outputFile>] [-e=<patternsToExclude>]...
+Usage: ccsh unifiedparser [-h] [-ibf] [-nc] [--verbose] [-o=<outputFile>]
+                          [-e=<patternsToExclude>]...
                           [-fe=<fileExtensionsToAnalyse>]... FILE or FOLDER
 ```
 
@@ -71,7 +71,7 @@ ccsh unifiedparser src/test/resources -o foo.cc.json -nc --verbose
 ```
 
 ```
-ccsh unifiedparser src/test/resources -o foo.cc.json --without-default-excludes -e=something -e=/.*\.foo
+ccsh unifiedparser src/test/resources -o foo.cc.json --include-build-folders -e=something -e=/.*\.foo
 ```
 
 If a project is piped into the UnifiedParser, the results and the piped project are merged.


### PR DESCRIPTION
# Replace without-default-excludes flag with include-build-folders

Closes: #421

## Description

Removes the "--without-default-excludes" flag for the unifiedparser and replaces it with a new flag:

      -ibf, --include-build-folders
                       include build folders (out, build, dist and target) and
                         common resource folders (e.g. resources, node_modules
                         or files/folders starting with '.')


NOTE: This only applies to the unifiedParser right now and will be extended to the other parsers once they are refactored to use the common interface for parsers. A deprecation note will be added.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
