### PR TITLE
fix/4142/node-modules-not-excluded

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Rename `--without-default-excludes` flag of UnifiedParser to `--include-build-folders` [#4144](https://github.com/MaibornWolff/codecharta/pull/4144)
 
+### Fixed 🐞
+
+- Fix exclude patterns starting with a `/` not working for direct children of project root [#4149](https://github.com/MaibornWolff/codecharta/pull/4149)
+
 ## [1.135.0] - 2025-07-28
 
 ### Added 🚀

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/ProjectScanner.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/ProjectScanner.kt
@@ -102,7 +102,7 @@ class ProjectScanner(
     }
 
     private fun isPathExcluded(file: File): Boolean {
-        return this.excludePatterns.isNotEmpty() && excludePatternRegex.containsMatchIn(getRelativeFileName(file.toString()))
+        return this.excludePatterns.isNotEmpty() && excludePatternRegex.containsMatchIn("/" + getRelativeFileName(file.toString()))
     }
 
     private fun isFileExtensionIncluded(fileExtension: String): Boolean {

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
@@ -219,6 +219,21 @@ class UnifiedParserTest {
     }
 
     @Test
+    fun `should correctly exclude files and folders if exclude pattern was specified`() {
+        // given
+        val pipedProject = ""
+        val inputFilePath = "${testResourceBaseFolder}sampleproject"
+        val expectedResultFile = File("${testResourceBaseFolder}excludePattern.cc.json").absoluteFile
+        val excludePattern = "/bar/, foo.kt, .*.py"
+
+        // when
+        val result = executeForOutput(pipedProject, arrayOf(inputFilePath, "-e=$excludePattern"))
+
+        // then
+        JSONAssert.assertEquals(result, expectedResultFile.readText(), JSONCompareMode.NON_EXTENSIBLE)
+    }
+
+    @Test
     fun `should include normally excluded folders when without-default-excludes flag is set`() {
         // given
         val pipedProject = ""

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/excludePattern.cc.json
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/excludePattern.cc.json
@@ -1,0 +1,78 @@
+{
+  "checksum": "c80c43bf12d26252f2932d8e136c23d5",
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "link": "",
+        "children": [
+          {
+            "name": "helloWorld.ts",
+            "type": "File",
+            "attributes": {
+              "complexity": 1,
+              "comment_lines": 2,
+              "rloc": 5,
+              "loc": 8
+            },
+            "link": "",
+            "children": []
+          },
+          {
+            "name": "whenCase.kt",
+            "type": "File",
+            "attributes": {
+              "complexity": 5,
+              "comment_lines": 0,
+              "rloc": 11,
+              "loc": 13
+            },
+            "link": "",
+            "children": []
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.3",
+    "edges": [],
+    "attributeTypes": {},
+    "attributeDescriptors": {
+      "complexity": {
+        "title": "Complexity",
+        "description": "Complexity of the file based on the number of paths through the code (McCabe Complexity)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+        "direction": -1
+      },
+      "comment_lines": {
+        "title": "Comment lines",
+        "description": "Number of lines containing either a comment or commented-out code",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1
+      },
+      "loc": {
+        "title": "Lines of Code",
+        "description": "Lines of code including empty lines and comments",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1
+      },
+      "rloc": {
+        "title": "Real Lines of Code",
+        "description": "Number of lines that contain at least one character which is neither a whitespace nor a tabulation nor part of a comment",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1
+      }
+    },
+    "blacklist": []
+  }
+}


### PR DESCRIPTION
# Fix exclude pattern not correctly working for direct children of project root

Closes: #4142

## Description

Due to a bug all exclude patterns that started with a '/' did not apply to direct subfolders of the folder that CodeCharta was called on. This PR fixes this and adds a test for exclude patterns

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [x] Changes have been manually tested
- [x] All TODOs related to this PR have been closed
- [x] There are automated tests for newly written code and bug fixes
- [x] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [x] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [x] CHANGELOG.md has been updated

## Screenshots or gifs
