### PR TITLE
feat/4147/wrong-token-warning

### DIFF
--- a/analysis/analysers/importers/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sonar/SonarImporter.kt
+++ b/analysis/analysers/importers/SonarImporter/src/main/kotlin/de/maibornwolff/codecharta/analysers/importers/sonar/SonarImporter.kt
@@ -13,6 +13,7 @@ import de.maibornwolff.codecharta.model.AttributeDescriptor
 import de.maibornwolff.codecharta.model.AttributeGenerator
 import de.maibornwolff.codecharta.serialization.ProjectDeserializer
 import de.maibornwolff.codecharta.serialization.ProjectSerializer
+import de.maibornwolff.codecharta.util.Logger
 import de.maibornwolff.codecharta.util.ResourceSearchHelper
 import picocli.CommandLine
 import java.io.File
@@ -106,6 +107,13 @@ class SonarImporter(
 
     override fun call(): Unit? {
         require(!(url == "" || projectId == "")) { "Input invalid Url or ProjectID for SonarImporter, stopping execution..." }
+
+        if (!userToken.startsWith("squ_")) {
+            Logger.error {
+                "Could not verify that given token is of type 'User Token'. Please ensure the used token is of this type, " +
+                    "tokens of type 'Project Analysis token' or 'Global Analysis token' might result in 'Insufficient privileges' error."
+            }
+        }
 
         val importer = createMeasuresAPIImporter()
         var project = importer.getProjectFromMeasureAPI(projectId, metrics)


### PR DESCRIPTION
# Add warning if sonar token is of wrong type

Closes: #4147

## Description

All sonar user tokens start with 'squ_' since SonarQube Version 9.5. If the used token does not start with that we show a warning so that users can more easily debug issues.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
