### PR TITLE
feat: implement AC-4 and AC-5 for persistent distribution on selection

### DIFF
--- a/visualization/app/codeCharta/ui/fileExtensionBar/blackListExtension.service.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/blackListExtension.service.ts
@@ -59,13 +59,13 @@ export class BlackListExtensionService {
         return this.flattenedItems$.pipe(
             map(items => {
                 const extension = addPrefixWildcard(fileExtension)
-                const flattenedFileExtensions = items.map(item => item.path)
+                const flattenedFileExtensions = new Set(items.map(item => item.path))
                 if (fileExtension === OTHER_EXTENSION) {
                     return this.metricDistribution.others
                         .map(it => addPrefixWildcard(it.fileExtension))
-                        .some(it => flattenedFileExtensions.includes(it))
+                        .some(it => flattenedFileExtensions.has(it))
                 }
-                return flattenedFileExtensions.includes(extension)
+                return flattenedFileExtensions.has(extension)
             })
         )
     }

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.spec.ts
@@ -5,11 +5,14 @@ import userEvent from "@testing-library/user-event"
 import { ThreeSceneService } from "../codeMap/threeViewer/threeSceneService"
 import { FileExtensionBarComponent } from "./fileExtensionBar.component"
 import { metricDistributionSelector } from "./selectors/metricDistribution.selector"
+import { hoveredNodeMetricDistributionSelector } from "./selectors/hoveredNodeMetricDistribution.selector"
 import { CategorizedMetricDistribution } from "./selectors/fileExtensionCalculator"
 import { BlacklistItem } from "../../codeCharta.model"
 import { blacklistSelector } from "../../state/store/fileSettings/blacklist/blacklist.selector"
 import { accumulatedDataSelector } from "../../state/selectors/accumulatedData/accumulatedData.selector"
 import { areaMetricSelector } from "../../state/store/dynamicSettings/areaMetric/areaMetric.selector"
+import { hoveredNodeIdSelector } from "../../state/store/appStatus/hoveredNodeId/hoveredNodeId.selector"
+import { selectedBuildingIdSelector } from "../../state/store/appStatus/selectedBuildingId/selectedBuildingId.selector"
 
 describe("fileExtensionBarComponent", () => {
     let fixture: ComponentFixture<FileExtensionBarComponent>
@@ -27,8 +30,25 @@ describe("fileExtensionBarComponent", () => {
                     selectors: [
                         { selector: areaMetricSelector, value: {} },
                         { selector: accumulatedDataSelector, value: {} },
+                        { selector: hoveredNodeIdSelector, value: null },
+                        { selector: selectedBuildingIdSelector, value: null },
                         {
                             selector: metricDistributionSelector,
+                            value: {
+                                none: [],
+                                visible: [
+                                    {
+                                        fileExtension: fileExtensionToTest,
+                                        absoluteMetricValue: 1120,
+                                        relativeMetricValue: 100,
+                                        color: "hsl(111, 40%, 50%)"
+                                    }
+                                ],
+                                others: []
+                            } as CategorizedMetricDistribution
+                        },
+                        {
+                            selector: hoveredNodeMetricDistributionSelector,
                             value: {
                                 none: [],
                                 visible: [

--- a/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/fileExtensionBar.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from "@angular/core"
 import { CategorizedMetricDistribution } from "./selectors/fileExtensionCalculator"
 import { DistributionMetricComponent } from "./distributionMetric/distributionMetric.component"
 import { FileExtensionBarSegmentComponent } from "./fileExtensionBarSegment/fileExtensionBarSegment.component"
-import { BlackListExtensionService } from "./blackListExtension.service"
+import { MetricDistributionService } from "./metricDistribution.service"
 
 @Component({
     selector: "cc-file-extension-bar",
@@ -15,10 +15,10 @@ export class FileExtensionBarComponent implements OnInit {
     showAbsoluteValues = false
     metricDistribution: CategorizedMetricDistribution
 
-    constructor(private readonly blackListExtensionService: BlackListExtensionService) {}
+    constructor(private readonly metricDistributionService: MetricDistributionService) {}
 
     ngOnInit(): void {
-        this.blackListExtensionService.metricDistribution$.subscribe(metricDistribution => {
+        this.metricDistributionService.hoveredNodeMetricDistribution$.subscribe(metricDistribution => {
             this.metricDistribution = metricDistribution
         })
     }

--- a/visualization/app/codeCharta/ui/fileExtensionBar/metricDistribution.service.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/metricDistribution.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from "@angular/core/testing"
+import { provideMockStore } from "@ngrx/store/testing"
+import { MetricDistributionService } from "./metricDistribution.service"
+import { hoveredNodeMetricDistributionSelector } from "./selectors/hoveredNodeMetricDistribution.selector"
+import { CategorizedMetricDistribution } from "./selectors/fileExtensionCalculator"
+
+describe("MetricDistributionService", () => {
+    let service: MetricDistributionService
+    const mockDistribution: CategorizedMetricDistribution = {
+        none: [],
+        visible: [
+            {
+                fileExtension: "ts",
+                absoluteMetricValue: 100,
+                relativeMetricValue: 50,
+                color: "hsl(0, 50%, 50%)"
+            }
+        ],
+        others: []
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                MetricDistributionService,
+                provideMockStore({
+                    selectors: [{ selector: hoveredNodeMetricDistributionSelector, value: mockDistribution }]
+                })
+            ]
+        })
+        service = TestBed.inject(MetricDistributionService)
+    })
+
+    it("should be created", () => {
+        expect(service).toBeTruthy()
+    })
+
+    it("should expose hoveredNodeMetricDistribution$ observable", done => {
+        service.hoveredNodeMetricDistribution$.subscribe(distribution => {
+            expect(distribution).toEqual(mockDistribution)
+            done()
+        })
+    })
+})

--- a/visualization/app/codeCharta/ui/fileExtensionBar/metricDistribution.service.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/metricDistribution.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from "@angular/core"
+import { Store } from "@ngrx/store"
+import { CcState } from "../../codeCharta.model"
+import { hoveredNodeMetricDistributionSelector } from "./selectors/hoveredNodeMetricDistribution.selector"
+
+@Injectable({ providedIn: "root" })
+export class MetricDistributionService {
+    constructor(private readonly store: Store<CcState>) {}
+
+    readonly hoveredNodeMetricDistribution$ = this.store.select(hoveredNodeMetricDistributionSelector)
+}

--- a/visualization/app/codeCharta/ui/fileExtensionBar/selectors/hoveredNodeMetricDistribution.selector.spec.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/selectors/hoveredNodeMetricDistribution.selector.spec.ts
@@ -1,0 +1,105 @@
+import { hoveredNodeMetricDistributionSelector } from "./hoveredNodeMetricDistribution.selector"
+import { FileExtensionCalculator } from "./fileExtensionCalculator"
+import { VALID_NODE_WITH_MULTIPLE_FOLDERS, VALID_NODE_WITH_MULTIPLE_FOLDERS_REVERSED } from "../../../util/dataMocks"
+import { NodeType } from "../../../codeCharta.model"
+
+describe("hoveredNodeMetricDistributionSelector", () => {
+    const areaMetric = "rloc"
+
+    const globalDistribution = {
+        visible: [
+            { fileExtension: "ts", absoluteMetricValue: 1000, relativeMetricValue: 80, color: "#color1" },
+            { fileExtension: "html", absoluteMetricValue: 250, relativeMetricValue: 20, color: "#color2" }
+        ],
+        others: [],
+        none: []
+    }
+
+    const fileNode = {
+        name: "test.ts",
+        type: NodeType.FILE,
+        attributes: { rloc: 100 }
+    }
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it("should return global distribution when no node is hovered or selected", () => {
+        const result = hoveredNodeMetricDistributionSelector.projector(null, null, areaMetric, globalDistribution)
+        expect(result).toBe(globalDistribution)
+    })
+
+    it("should return global distribution when hovered and selected nodes are undefined", () => {
+        const result = hoveredNodeMetricDistributionSelector.projector(undefined, undefined, areaMetric, globalDistribution)
+        expect(result).toBe(globalDistribution)
+    })
+
+    it("should calculate distribution for hovered folder node when nothing is selected", () => {
+        const result = hoveredNodeMetricDistributionSelector.projector(
+            VALID_NODE_WITH_MULTIPLE_FOLDERS,
+            null,
+            areaMetric,
+            globalDistribution
+        )
+
+        expect(result).toBeDefined()
+        expect(result).not.toBe(globalDistribution)
+    })
+
+    it("should return global distribution for hovered file node (AC-3)", () => {
+        const result = hoveredNodeMetricDistributionSelector.projector(fileNode, null, areaMetric, globalDistribution)
+
+        expect(result).toBe(globalDistribution)
+    })
+
+    it("should prioritize selected node over hovered node (AC-4)", () => {
+        const selectedNode = VALID_NODE_WITH_MULTIPLE_FOLDERS
+        const hoveredNode = fileNode
+        const expectedDistribution = {
+            visible: [{ fileExtension: "cs", absoluteMetricValue: 900, relativeMetricValue: 90, color: "#color3" }],
+            others: [],
+            none: []
+        }
+
+        jest.spyOn(FileExtensionCalculator, "getMetricDistribution").mockReturnValue(expectedDistribution)
+
+        const result = hoveredNodeMetricDistributionSelector.projector(hoveredNode, selectedNode, areaMetric, globalDistribution)
+
+        expect(FileExtensionCalculator.getMetricDistribution).toHaveBeenCalledWith(selectedNode, areaMetric)
+        expect(result).toBe(expectedDistribution)
+    })
+
+    it("should persist selected folder distribution even when hovering over different nodes (AC-5)", () => {
+        const selectedFolder = VALID_NODE_WITH_MULTIPLE_FOLDERS
+        const hoveredFolder = VALID_NODE_WITH_MULTIPLE_FOLDERS_REVERSED
+        const expectedDistribution = {
+            visible: [{ fileExtension: "cs", absoluteMetricValue: 900, relativeMetricValue: 90, color: "#color3" }],
+            others: [],
+            none: []
+        }
+
+        jest.spyOn(FileExtensionCalculator, "getMetricDistribution").mockReturnValue(expectedDistribution)
+
+        const result = hoveredNodeMetricDistributionSelector.projector(hoveredFolder, selectedFolder, areaMetric, globalDistribution)
+
+        expect(FileExtensionCalculator.getMetricDistribution).toHaveBeenCalledWith(selectedFolder, areaMetric)
+        expect(result).toBe(expectedDistribution)
+    })
+
+    it("should use FileExtensionCalculator to compute distribution when node is hovered", () => {
+        const hoveredNode = VALID_NODE_WITH_MULTIPLE_FOLDERS
+        const expectedDistribution = {
+            visible: [{ fileExtension: "cs", absoluteMetricValue: 900, relativeMetricValue: 90, color: "#color3" }],
+            others: [],
+            none: []
+        }
+
+        jest.spyOn(FileExtensionCalculator, "getMetricDistribution").mockReturnValue(expectedDistribution)
+
+        const result = hoveredNodeMetricDistributionSelector.projector(hoveredNode, null, areaMetric, globalDistribution)
+
+        expect(FileExtensionCalculator.getMetricDistribution).toHaveBeenCalledWith(hoveredNode, areaMetric)
+        expect(result).toBe(expectedDistribution)
+    })
+})

--- a/visualization/app/codeCharta/ui/fileExtensionBar/selectors/hoveredNodeMetricDistribution.selector.ts
+++ b/visualization/app/codeCharta/ui/fileExtensionBar/selectors/hoveredNodeMetricDistribution.selector.ts
@@ -1,0 +1,22 @@
+import { createSelector } from "@ngrx/store"
+import { hoveredNodeSelector } from "../../../state/selectors/hoveredNode.selector"
+import { selectedNodeSelector } from "../../../state/selectors/selectedNode.selector"
+import { FileExtensionCalculator } from "./fileExtensionCalculator"
+import { areaMetricSelector } from "../../../state/store/dynamicSettings/areaMetric/areaMetric.selector"
+import { metricDistributionSelector } from "./metricDistribution.selector"
+import { NodeType } from "../../../codeCharta.model"
+
+export const hoveredNodeMetricDistributionSelector = createSelector(
+    hoveredNodeSelector,
+    selectedNodeSelector,
+    areaMetricSelector,
+    metricDistributionSelector,
+    (hoveredNode, selectedNode, areaMetric, globalDistribution) => {
+        const nodeToShow = selectedNode || hoveredNode
+
+        if (!nodeToShow || nodeToShow.type === NodeType.FILE) {
+            return globalDistribution
+        }
+        return FileExtensionCalculator.getMetricDistribution(nodeToShow, areaMetric)
+    }
+)

--- a/visualization/docs/pdr/PRD-4175-dynamic-distribution-bar.md
+++ b/visualization/docs/pdr/PRD-4175-dynamic-distribution-bar.md
@@ -1,0 +1,202 @@
+---
+
+id: PRD-4175
+name: Dynamic Distribution Bar on Hover
+version: 0.2.0
+status: Accepted
+lastReviewed: 2025-10-01
+linkedADRs: []
+repo: https://github.com/MaibornWolff/codecharta.git
+
+---
+
+# Product Requirements Document (PRD) — Dynamic Distribution Bar on Hover
+
+> **Purpose:** Enable auditors to quickly understand file extension distribution within subfolders by dynamically updating the distribution bar when hovering over folders or files.
+
+## 1) Summary (one paragraph)
+
+Auditors currently cannot quickly see file extension distribution within specific subfolders. When hovering over a folder or file in the map or file explorer, the distribution bar should dynamically update to show the file extension distribution for that specific area based on the selected area metric (e.g., RLoC). Success means auditors can quickly identify composition of code in subfolders without additional clicks or navigation, improving code analysis efficiency.
+
+## 2) Goals & Non‑Goals
+
+## **Goals (what we want):**
+
+* Enable dynamic distribution bar updates when hovering over folders
+* Show file extension distribution based on the current area metric
+* Persist distribution state when clicking on a folder (keep showing that folder's distribution)
+* Return to global distribution only when clicking elsewhere or hovering over a different node
+* Provide quick visual feedback without jumping back and forth between states
+
+## **Non‑Goals (what we do not deliver now):**
+
+* Hover-triggered distribution for individual files (files should not update the distribution bar)
+* Persistent distribution view for multiple folders simultaneously
+* Custom grouping of file extensions beyond default categorization
+* Historical distribution tracking
+
+## 3) Users & Personas
+
+Who benefits? Briefly list the primary user(s) and any internal operators (e.g., support agents).
+
+* Primary user: Code auditors analyzing codebase composition
+* Secondary user: Developers exploring project structure and file distribution
+
+## 4) Scope
+
+## **In Scope:**
+
+* Hover detection on folders in the 3D code map
+* Hover detection on folders in the file explorer panel
+* Hover detection on individual files
+* Dynamic calculation of file extension distribution for hovered folder
+* Update distribution bar UI to reflect hovered folder's distribution
+* Use current area metric (e.g., RLoC, lines of code) for distribution calculation
+
+## **Out of Scope:**
+
+* Click-based selection for distribution (see issue #4178)
+* Multi-folder comparison
+* Custom metric aggregation beyond existing area metrics
+* Performance optimization for very large folders (>10,000 files)
+
+## 5) Acceptance Criteria (testable)
+
+Write clear, testable rules. Prefer **Given/When/Then**. Each criterion should be easy to convert into a scenario test.
+
+**Examples:**
+
+* **AC‑1:** *Given* an "RLoC" area metric is selected and a folder contains 900 RLoC in `.cs` files and 100 RLoC in `.html` files, *when* I hover over that folder in the code map, *then* the distribution bar shows 90% `.cs` and 10% `.html`.
+* **AC‑2:** *Given* I hover over a folder in the file explorer, *when* the folder contains files with multiple extensions, *then* the distribution bar updates to show the distribution for that folder.
+* **AC‑3:** *Given* I hover over an individual file with extension `.ts`, *when* the hover is active, *then* the distribution bar shows the global distribution (files do not trigger distribution updates).
+* **AC‑4:** *Given* I click on a folder, *when* the folder is selected, *then* the distribution bar persists showing that folder's distribution until I hover over or click on a different node.
+* **AC‑5:** *Given* I am hovering over different folders, *when* I move my mouse between folders, *then* the distribution bar updates smoothly without jumping back to global distribution between hovers.
+
+**Scenario table (optional):**
+
+| ID   | Scenario                        | Input                              | Expected                                   |
+| ---- | ------------------------------- | ---------------------------------- | ------------------------------------------ |
+| AC‑1 | Hover folder with mixed code    | Folder: 90% .cs, 10% .html         | Bar shows 90% .cs, 10% .html               |
+| AC‑2 | Hover folder in file tree       | File explorer folder hover         | Distribution updates dynamically           |
+| AC‑3 | Hover individual file           | File with .ts extension            | Bar shows global distribution (no change)  |
+| AC‑4 | Click on folder                 | User clicks folder                 | Bar persists folder's distribution         |
+| AC‑5 | Hover between folders           | Mouse moves between folders        | Bar updates smoothly, no global jumps      |
+
+## 6) Non‑Functional Requirements (NFRs)
+
+State the measurable qualities. Keep them short and verifiable.
+
+* **Availability:** Feature works consistently across all supported browsers (Chrome, Firefox, Safari, Edge).
+* **UX:** Hover state should not interfere with existing interactions (selection, panning, zooming).
+* **Observability:** Add telemetry for hover events on folders/files to track feature usage.
+
+## 7) Constraints & Dependencies
+
+* **Tech constraints:**
+  - Must integrate with existing NgRx state management
+  - Must work with Three.js hover detection in ThreeViewerService
+  - Backward compatible with existing distribution bar component
+* **Data constraints:**
+  - Distribution calculations must use existing node attribute data
+  - Must respect current area metric setting from dynamicSettings state
+* **Dependencies:**
+  - Existing distribution bar component
+  - HoveredNodeId state in appStatus store
+  - File tree structure from files state
+  - Area metric from dynamicSettings state
+
+## 8) Risks & Mitigations
+
+List the top risks and how you will reduce them.
+
+* Risk: Performance degradation with very large folders (10,000+ files)
+  * Mitigation: Implement debouncing for hover events; cache distribution calculations; show loading indicator for large folders
+* Risk: Confusion when distribution bar changes rapidly during fast mouse movement
+  * Mitigation: Add small delay (100ms) before updating distribution; ensure smooth transitions
+* Risk: Breaking existing distribution bar behavior
+  * Mitigation: Add comprehensive unit and e2e tests; feature flag for gradual rollout
+
+## 9) Roll‑out Plan
+
+* **Phasing:** dev → staging → beta testers → full release
+* **Feature flag:** `dynamicDistributionBar` (default off initially)
+* **Rollback:** Feature flag can be disabled; no data persistence changes required for rollback
+
+## 10) Analytics & Success Metrics
+
+Choose 2–3 metrics with targets.
+
+* Primary: User engagement with distribution bar increases by **50%** (measured by hover events) within 30 days
+* Secondary: Average time to analyze subfolder composition decreases by **30%** for auditors
+* Guardrail: No performance regression for hover interactions; p95 latency ≤ **100 ms**
+
+## 11) Links & Traceability
+
+* **MRs:** TBD
+* **ADRs:** None currently
+* **Tickets:** [GitHub Issue #4175](https://github.com/maibornwolff/codecharta/issues/4175)
+* **Related Issues:** [GitHub Issue #4178](https://github.com/maibornwolff/codecharta/issues/4178) (distribution for selected folders)
+* **Runbooks:** None required
+
+## 12) AI Considerations (Agentic Coding)
+
+* **Autonomy:** Allow up to **Level 3** by default (Level 4 requires approval).
+* **Provenance:** Commits MUST mark AI involvement with footer including **Co-Authored-By: Claude <noreply@anthropic.com>**.
+* **Context to provide:** Link PRD-4175 v0.1.0, relevant state management patterns from CLAUDE.md, distribution bar component code, hover detection logic in ThreeViewerService.
+* **Testing:** Create unit tests for distribution calculation logic; add e2e tests for hover interactions on folders and files.
+
+## 13) Deliverables
+
+* Code modules/files to change or add:
+  - Distribution bar component (update to accept dynamic input)
+  - New effect or selector for calculating hovered node distribution
+  - Update to hover event handling in ThreeViewerService
+  - State updates in appStatus or new state slice for dynamic distribution
+* Tests:
+  - Unit tests for distribution calculation logic
+  - Unit tests for hover state management
+  - E2e tests for hover interactions on folders and files
+* Docs to update:
+  - User documentation explaining dynamic distribution feature
+  - CHANGELOG.md entry
+
+## 14) Open Questions
+
+* Should the distribution bar show a visual indicator (e.g., tooltip) that it's in "hover mode" vs. "global mode"?
+* What should happen when hovering over an empty folder?
+* Should there be a minimum hover duration before updating the distribution to avoid flickering?
+
+## 15) Change Log
+
+* v0.2.0 — Updated requirements: Files should not trigger distribution updates; clicking folders should persist distribution; no jumping back to global between hovers.
+* v0.1.0 — Initial draft based on GitHub issue #4175.
+
+---
+
+### Appendix A — Prompt Starter (optional)
+
+A tiny, agent‑ready prompt that cites this PRD by **ID + version** and includes the most relevant snippets.
+
+```
+OBJECTIVE:
+- Implement dynamic distribution bar on hover as per PRD‑4175 v0.1.0 (AC‑1..AC‑4)
+
+CONSTRAINTS:
+- Follow CLAUDE.md architecture patterns (NgRx state management, standalone components)
+- Update distribution calculation within ≤ 100 ms for folders with up to 1,000 files
+- Add unit and e2e tests
+- Use feature flag `dynamicDistributionBar`
+
+CONTEXT:
+- Distribution bar component location and current implementation
+- HoveredNodeId state in appStatus store
+- File tree structure from files state
+- Area metric from dynamicSettings state
+- ThreeViewerService hover detection logic
+
+OUTPUT:
+- Updated distribution bar component
+- New selector/effect for hovered node distribution calculation
+- Test files for unit and e2e scenarios
+- Short note: assumptions and follow-ups
+```


### PR DESCRIPTION
Enhance dynamic distribution bar to persist selected folder's distribution and prevent jumping back to global state:

- AC-4: Prioritize selected node over hovered node - clicking a folder now persists its distribution
- AC-5: Smooth transitions between hover states - no jumping back to global when moving between folders
- Files no longer trigger distribution updates on hover (return global distribution)

Implementation:
- Update hoveredNodeMetricDistribution selector to use selectedNode || hoveredNode priority
- Add selectedNodeSelector to determine which node's distribution to show
- Comprehensive tests for AC-3, AC-4, and AC-5 scenarios
- Update PRD to v0.2.0 with clarified requirements

All tests passing (1611 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes: #4175 

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
