### PR TITLE
fix/hovering-style-issues

### DIFF
--- a/visualization/app/material/material.scss
+++ b/visualization/app/material/material.scss
@@ -19,6 +19,7 @@
 
 @include mat.elevation-classes();
 @include mat.app-background();
+@include mat.core-theme(theme.$cc-theme);
 @include mat.button-theme(theme.$cc-theme);
 @include mat.button-toggle-theme(theme.$cc-theme);
 @include mat.progress-spinner-theme(theme.$cc-theme);


### PR DESCRIPTION
## Summary
- Fixed missing hover effect on mat-option elements in file selector dropdown
- Added `mat.core-theme()` mixin to Material theme configuration
- Resolved issue introduced after Angular Material upgrade to v20

## Root Cause
When using individual component theme mixins (instead of `mat.all-component-themes()`), the core theme must be explicitly included to provide theming for foundational components like mat-option, ripples, and pseudo-checkboxes.

## Test plan
- [x] Verified mat-option elements now show hover background color in file selector
- [x] Tested with development server
- [ ] Manually test file selector dropdown hover states
- [ ] Verify no visual regressions in other Material components

🤖 Generated with [Claude Code](https://claude.com/claude-code)