### PR TITLE
feat/automatically-delete-plans

### DIFF
--- a/.github/workflows/release-analysis.yml
+++ b/.github/workflows/release-analysis.yml
@@ -164,3 +164,37 @@ jobs:
           docker tag codecharta/codecharta-analysis:staging codecharta/codecharta-analysis:${{ needs.build.outputs.version }}
           docker push codecharta/codecharta-analysis:latest
           docker push codecharta/codecharta-analysis:${{ needs.build.outputs.version }}
+
+  # Cleanup old plans
+  cleanup_plans:
+    needs: build
+    name: Cleanup Old Plans
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Run plans cleanup for analysis
+        run: |
+          npm run plans:cleanup:analysis
+
+      - name: Commit deleted plans
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          if [[ -n $(git status -s plans/) ]]; then
+            git add plans/
+            git commit -m "chore(docs): cleanup old analysis plans after release ${{ needs.build.outputs.version }}"
+            git push
+          else
+            echo "No plans to cleanup"
+          fi

--- a/.github/workflows/release-visualization.yml
+++ b/.github/workflows/release-visualization.yml
@@ -212,3 +212,37 @@ jobs:
           branch: gh-pages
           folder: visualization/dist/bundler/browser
           target-folder: visualization/app
+
+  # Cleanup old plans
+  cleanup_plans:
+    needs: build
+    name: Cleanup Old Plans
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Run plans cleanup for visualization
+        run: |
+          npm run plans:cleanup:visualization
+
+      - name: Commit deleted plans
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          if [[ -n $(git status -s plans/) ]]; then
+            git add plans/
+            git commit -m "chore(docs): cleanup old visualization plans after release ${{ needs.build.outputs.version }}"
+            git push
+          else
+            echo "No plans to cleanup"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,14 @@ Each state slice has dedicated actions, reducers, and selectors. Effects (`state
 - Update `state` field as work progresses: `todo` → `progress` → `complete`
 - Always use the AskUserQuestion tool to clarify ambiguous requirements before finalizing the plan
 
+**Plan Frontmatter Requirements**:
+- `component`: Specify `analysis`, `visualization`, or `both` to indicate which part of the codebase is affected
+- `version`: When marking a plan as `state: complete`, update the version field with the current semantic version:
+  - For `analysis`: Use version from `analysis/gradle.properties` (currentVersion field)
+  - For `visualization`: Use version from `visualization/package.json`
+  - For `both`: Use the higher version number or list both
+- Plans that are 2+ minor versions old and marked as complete will be automatically cleaned up using `npm run plans:cleanup`
+
 ### Branching Strategy
 
 - Main branch: `main`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "format": "biome format --fix --no-errors-on-unmatched",
     "format:check": "biome check",
     "prepare": "husky install",
-    "commitlint": "commitlint --config commitlint.config.js --edit"
+    "commitlint": "commitlint --config commitlint.config.js --edit",
+    "plans:cleanup": "node scripts/cleanup-old-plans.js",
+    "plans:cleanup:dry-run": "node scripts/cleanup-old-plans.js --dry-run",
+    "plans:cleanup:analysis": "node scripts/cleanup-old-plans.js --component=analysis",
+    "plans:cleanup:visualization": "node scripts/cleanup-old-plans.js --component=visualization"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/plans/template.md
+++ b/plans/template.md
@@ -2,12 +2,18 @@
 name: <name>
 issue: <#issueid>
 state: <todo | progress | complete>
-version: <version number>
+component: <analysis | visualization | both>
+version: <semantic version when completed, e.g., 1.138.0>
 ---
 
 ## Goal
 
 <Describe the goal of this task in 1-3 sentences>
+
+**Important:** When marking this plan as `state: complete`, update the `version` field with the current version of the affected component(s):
+- For analysis changes: Use version from `analysis/gradle.properties` (currentVersion)
+- For visualization changes: Use version from `visualization/package.json`
+- For both: Use the higher version number or list both (e.g., "analysis: 1.138.0, visualization: 1.137.0")
 
 ## Tasks
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,78 @@
+# CodeCharta Scripts
+
+This directory contains utility scripts for the CodeCharta project.
+
+## cleanup-old-plans.js
+
+Automatically cleans up old plan files from the `plans/` directory based on version age.
+
+### Usage
+
+```bash
+# Run cleanup for all plans (both analysis and visualization)
+npm run plans:cleanup
+
+# Dry run (preview what would be deleted without actually deleting)
+npm run plans:cleanup:dry-run
+
+# Clean up only analysis plans
+npm run plans:cleanup:analysis
+
+# Clean up only visualization plans
+npm run plans:cleanup:visualization
+
+# Advanced usage with custom component filter
+node scripts/cleanup-old-plans.js --component=analysis --dry-run
+```
+
+### How it works
+
+1. Reads current versions from:
+   - Analysis: `analysis/gradle.properties` (currentVersion)
+   - Visualization: `visualization/package.json` (version)
+
+2. Scans all plan files in `plans/` directory (excluding `template.md`)
+
+3. Parses frontmatter to check:
+   - `state`: Must be `complete`
+   - `component`: Must be `analysis`, `visualization`, or `both`
+   - `version`: Must be a valid semantic version (e.g., `1.138.0`)
+
+4. Deletes plans that are **2 or more minor versions old**:
+   - Example: If current analysis version is `1.138.0`, plans with version `≤ 1.136.0` are deleted
+   - For `component: both`, uses the higher of the two current versions
+
+5. Component filtering:
+   - `--component=analysis`: Deletes plans with `component: analysis` or `component: both`
+   - `--component=visualization`: Deletes plans with `component: visualization` or `component: both`
+   - `--component=both` (or no filter): Deletes all old plans regardless of component
+
+6. Skips plans that:
+   - Are not marked as `complete`
+   - Don't have a `version` field
+   - Don't have a `component` field
+   - Don't match the component filter (if specified)
+   - Are less than 2 minor versions old
+
+### Automated Cleanup
+
+This script runs automatically on every release:
+- **Analysis releases**: Runs `npm run plans:cleanup:analysis` (cleans analysis and shared plans)
+- **Visualization releases**: Runs `npm run plans:cleanup:visualization` (cleans visualization and shared plans)
+- Deleted plans are automatically committed and pushed to the repository
+
+### Manual Usage
+
+Run this script manually:
+- **Monthly**: As part of regular maintenance
+- **Before releases**: To preview cleanup before version bumps (use `--dry-run`)
+- **Ad-hoc**: Whenever the plans folder feels cluttered
+
+### Output
+
+The script provides a detailed summary showing:
+- Current versions for analysis and visualization
+- Component filter (if specified)
+- Plans that will be deleted (with their version and component)
+- Plans that were skipped (with reasons)
+- Success/failure status for deletions

--- a/scripts/cleanup-old-plans.js
+++ b/scripts/cleanup-old-plans.js
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+
+/**
+ * Cleanup script for old plan files in the plans/ directory.
+ *
+ * This script:
+ * 1. Reads current versions from analysis/gradle.properties and visualization/package.json
+ * 2. Parses all plan files to extract frontmatter
+ * 3. For completed plans, compares their version to current version
+ * 4. Deletes plans that are 2+ minor versions old
+ * 5. Generates a summary report of what was deleted
+ *
+ * Usage:
+ *   npm run plans:cleanup [--dry-run] [--component=<analysis|visualization|both>]
+ *
+ * Options:
+ *   --dry-run: Preview what would be deleted without actually deleting
+ *   --component: Only clean up plans for specific component (default: both)
+ */
+
+const fs = require("fs")
+const path = require("path")
+
+// Parse command line arguments
+const isDryRun = process.argv.includes("--dry-run")
+const componentArg = process.argv.find(arg => arg.startsWith("--component="))
+const componentFilter = componentArg ? componentArg.split("=")[1] : null
+
+// Validate component filter
+if (componentFilter && !["analysis", "visualization", "both"].includes(componentFilter)) {
+    console.error(`❌ Invalid component: ${componentFilter}`)
+    console.error("   Valid values: analysis, visualization, both")
+    process.exit(1)
+}
+
+/**
+ * Parse semantic version string (e.g., "1.138.0") into components
+ */
+function parseVersion(versionString) {
+    if (!versionString) return null
+
+    // Extract version number from various formats
+    // "1.138.0", "analysis: 1.138.0", "1.138.0, visualization: 1.137.0"
+    const match = versionString.match(/(\d+)\.(\d+)\.(\d+)/)
+    if (!match) return null
+
+    return {
+        major: parseInt(match[1], 10),
+        minor: parseInt(match[2], 10),
+        patch: parseInt(match[3], 10),
+        original: versionString
+    }
+}
+
+/**
+ * Compare two versions. Returns:
+ * - negative if v1 < v2
+ * - 0 if v1 === v2
+ * - positive if v1 > v2
+ */
+function compareVersions(v1, v2) {
+    if (!v1 || !v2) return 0
+
+    if (v1.major !== v2.major) return v1.major - v2.major
+    if (v1.minor !== v2.minor) return v1.minor - v2.minor
+    return v1.patch - v2.patch
+}
+
+/**
+ * Calculate the difference in minor versions
+ */
+function minorVersionDifference(currentVersion, planVersion) {
+    if (!currentVersion || !planVersion) return 0
+
+    // If major versions differ, consider it very old
+    if (currentVersion.major !== planVersion.major) {
+        return 999
+    }
+
+    return currentVersion.minor - planVersion.minor
+}
+
+/**
+ * Read current version from analysis/gradle.properties
+ */
+function getAnalysisVersion() {
+    const gradlePropsPath = path.join(__dirname, "..", "analysis", "gradle.properties")
+    try {
+        const content = fs.readFileSync(gradlePropsPath, "utf-8")
+        const match = content.match(/currentVersion=([0-9.]+)/)
+        if (match) {
+            return parseVersion(match[1])
+        }
+    } catch (error) {
+        console.error(`Error reading analysis version: ${error.message}`)
+    }
+    return null
+}
+
+/**
+ * Read current version from visualization/package.json
+ */
+function getVisualizationVersion() {
+    const packageJsonPath = path.join(__dirname, "..", "visualization", "package.json")
+    try {
+        const content = fs.readFileSync(packageJsonPath, "utf-8")
+        const pkg = JSON.parse(content)
+        return parseVersion(pkg.version)
+    } catch (error) {
+        console.error(`Error reading visualization version: ${error.message}`)
+    }
+    return null
+}
+
+/**
+ * Parse frontmatter from a markdown file
+ */
+function parseFrontmatter(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, "utf-8")
+
+        // Extract frontmatter between --- markers
+        const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+        if (!frontmatterMatch) return null
+
+        const frontmatter = {}
+        const lines = frontmatterMatch[1].split("\n")
+
+        for (const line of lines) {
+            const colonIndex = line.indexOf(":")
+            if (colonIndex === -1) continue
+
+            const key = line.substring(0, colonIndex).trim()
+            const value = line.substring(colonIndex + 1).trim()
+            frontmatter[key] = value
+        }
+
+        return frontmatter
+    } catch (error) {
+        console.error(`Error parsing ${filePath}: ${error.message}`)
+        return null
+    }
+}
+
+/**
+ * Check if a plan should be deleted based on version age and component filter
+ */
+function shouldDeletePlan(frontmatter, analysisVersion, visualizationVersion, versionThreshold, componentFilter) {
+    // Only delete completed plans
+    if (frontmatter.state !== "complete") {
+        return false
+    }
+
+    // Must have a version
+    if (!frontmatter.version) {
+        return false
+    }
+
+    // Must have a component
+    if (!frontmatter.component) {
+        return false
+    }
+
+    // If component filter is specified, check if plan matches
+    if (componentFilter) {
+        // For filter "analysis": delete plans with component "analysis" or "both"
+        // For filter "visualization": delete plans with component "visualization" or "both"
+        // For filter "both": delete any plans (no additional filtering)
+        if (componentFilter === "analysis") {
+            if (frontmatter.component !== "analysis" && frontmatter.component !== "both") {
+                return false
+            }
+        } else if (componentFilter === "visualization") {
+            if (frontmatter.component !== "visualization" && frontmatter.component !== "both") {
+                return false
+            }
+        }
+        // If componentFilter === "both", no additional filtering needed
+    }
+
+    // Parse plan version
+    const planVersion = parseVersion(frontmatter.version)
+    if (!planVersion) {
+        return false
+    }
+
+    // Determine which current version to compare against based on component
+    let currentVersion
+    if (frontmatter.component === "analysis") {
+        currentVersion = analysisVersion
+    } else if (frontmatter.component === "visualization") {
+        currentVersion = visualizationVersion
+    } else if (frontmatter.component === "both") {
+        // For 'both', use the higher version
+        currentVersion = compareVersions(analysisVersion, visualizationVersion) >= 0 ? analysisVersion : visualizationVersion
+    } else {
+        // No component specified or unrecognized - skip
+        return false
+    }
+
+    if (!currentVersion) {
+        return false
+    }
+
+    // Check if plan is old enough to delete
+    const versionDiff = minorVersionDifference(currentVersion, planVersion)
+    return versionDiff >= versionThreshold
+}
+
+/**
+ * Main cleanup function
+ */
+function cleanupOldPlans() {
+    const plansDir = path.join(__dirname, "..", "plans")
+    const versionThreshold = 2 // Delete plans 2+ minor versions old
+
+    console.log("🧹 CodeCharta Plans Cleanup Script\n")
+
+    if (isDryRun) {
+        console.log("🔍 Running in DRY RUN mode - no files will be deleted\n")
+    }
+
+    if (componentFilter) {
+        console.log(`🎯 Component filter: ${componentFilter}\n`)
+    }
+
+    // Get current versions
+    const analysisVersion = getAnalysisVersion()
+    const visualizationVersion = getVisualizationVersion()
+
+    console.log("📊 Current Versions:")
+    console.log(`   Analysis:      ${analysisVersion ? analysisVersion.original : "N/A"}`)
+    console.log(`   Visualization: ${visualizationVersion ? visualizationVersion.original : "N/A"}`)
+    console.log(`   Threshold:     ${versionThreshold} minor versions\n`)
+
+    if (!analysisVersion && !visualizationVersion) {
+        console.error("❌ Could not read current versions. Aborting.")
+        process.exit(1)
+    }
+
+    // Read all plan files
+    let planFiles
+    try {
+        planFiles = fs
+            .readdirSync(plansDir)
+            .filter(file => file.endsWith(".md") && file !== "template.md")
+            .map(file => path.join(plansDir, file))
+    } catch (error) {
+        console.error(`❌ Error reading plans directory: ${error.message}`)
+        process.exit(1)
+    }
+
+    console.log(`📝 Found ${planFiles.length} plan files (excluding template.md)\n`)
+
+    // Process each plan
+    const toDelete = []
+    const skipped = {
+        incomplete: [],
+        noVersion: [],
+        noComponent: [],
+        tooRecent: []
+    }
+
+    for (const filePath of planFiles) {
+        const fileName = path.basename(filePath)
+        const frontmatter = parseFrontmatter(filePath)
+
+        if (!frontmatter) {
+            console.log(`⚠️  Skipped ${fileName}: Could not parse frontmatter`)
+            continue
+        }
+
+        if (frontmatter.state !== "complete") {
+            skipped.incomplete.push(fileName)
+            continue
+        }
+
+        if (!frontmatter.version) {
+            skipped.noVersion.push(fileName)
+            continue
+        }
+
+        if (!frontmatter.component) {
+            skipped.noComponent.push(fileName)
+            continue
+        }
+
+        if (shouldDeletePlan(frontmatter, analysisVersion, visualizationVersion, versionThreshold, componentFilter)) {
+            toDelete.push({
+                path: filePath,
+                name: fileName,
+                version: frontmatter.version,
+                component: frontmatter.component
+            })
+        } else {
+            skipped.tooRecent.push(fileName)
+        }
+    }
+
+    // Print summary
+    console.log("📋 Summary:\n")
+
+    if (toDelete.length > 0) {
+        console.log(`🗑️  Plans to delete (${toDelete.length}):`)
+        for (const plan of toDelete) {
+            console.log(`   - ${plan.name}`)
+            console.log(`     Component: ${plan.component}, Version: ${plan.version}`)
+        }
+        console.log()
+    } else {
+        console.log("✅ No plans to delete\n")
+    }
+
+    if (skipped.incomplete.length > 0) {
+        console.log(`⏭️  Skipped incomplete plans (${skipped.incomplete.length}):`)
+        for (const name of skipped.incomplete) {
+            console.log(`   - ${name}`)
+        }
+        console.log()
+    }
+
+    if (skipped.noVersion.length > 0) {
+        console.log(`⚠️  Skipped completed plans without version (${skipped.noVersion.length}):`)
+        for (const name of skipped.noVersion) {
+            console.log(`   - ${name} (missing version field)`)
+        }
+        console.log()
+    }
+
+    if (skipped.noComponent.length > 0) {
+        console.log(`⚠️  Skipped completed plans without component (${skipped.noComponent.length}):`)
+        for (const name of skipped.noComponent) {
+            console.log(`   - ${name} (missing component field)`)
+        }
+        console.log()
+    }
+
+    if (skipped.tooRecent.length > 0) {
+        console.log(`📌 Kept recent completed plans (${skipped.tooRecent.length}):`)
+        for (const name of skipped.tooRecent) {
+            console.log(`   - ${name}`)
+        }
+        console.log()
+    }
+
+    // Delete files
+    if (toDelete.length > 0 && !isDryRun) {
+        console.log("🗑️  Deleting old plans...\n")
+        let deletedCount = 0
+
+        for (const plan of toDelete) {
+            try {
+                fs.unlinkSync(plan.path)
+                console.log(`   ✓ Deleted ${plan.name}`)
+                deletedCount++
+            } catch (error) {
+                console.error(`   ✗ Failed to delete ${plan.name}: ${error.message}`)
+            }
+        }
+
+        console.log(`\n✅ Successfully deleted ${deletedCount} of ${toDelete.length} plans`)
+    } else if (isDryRun && toDelete.length > 0) {
+        console.log("🔍 DRY RUN: No files were deleted")
+    }
+
+    console.log("\n✨ Cleanup complete!")
+}
+
+// Run the script
+cleanupOldPlans()


### PR DESCRIPTION
## Summary

This PR introduces an automated plan cleanup system that removes old, completed plan files from the `plans/` directory to reduce clutter and keep documentation current.

### Key Features

- **Automated cleanup script** (`scripts/cleanup-old-plans.js`) that:
  - Reads current versions from `analysis/gradle.properties` and `visualization/package.json`
  - Deletes completed plans that are 2+ minor versions old
  - Supports component-based filtering (analysis/visualization/both)
  - Provides detailed summary reports

- **Integration with release workflows**:
  - Analysis releases automatically clean up analysis and shared (both) plans
  - Visualization releases automatically clean up visualization and shared (both) plans
  - Deleted plans are committed and pushed automatically

- **Enhanced plan template**:
  - Added `component` field to specify affected codebase parts
  - Added semantic versioning requirements for completed plans
  - Clear instructions for version tracking

- **Flexible npm scripts**:
  - `npm run plans:cleanup` - Clean all old plans
  - `npm run plans:cleanup:dry-run` - Preview without deleting
  - `npm run plans:cleanup:analysis` - Clean analysis plans only
  - `npm run plans:cleanup:visualization` - Clean visualization plans only

### Changes

- Updated `.github/workflows/release-analysis.yml` with cleanup job
- Updated `.github/workflows/release-visualization.yml` with cleanup job
- Enhanced `CLAUDE.md` with plan versioning documentation
- Updated `plans/template.md` with component and version fields
- Added `scripts/cleanup-old-plans.js` with comprehensive cleanup logic
- Added `scripts/README.md` documenting the cleanup script
- Added npm scripts to `package.json` for manual cleanup

### Test Plan

- [x] Script correctly identifies and deletes old plans in dry-run mode
- [x] Component filtering works for analysis/visualization/both
- [x] Version comparison logic handles semantic versioning correctly
- [x] Script skips incomplete plans and plans without versions
- [x] GitHub Actions workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)