### PR TITLE
Add jsx support and expand Tsx unit tests

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+- Add JSX support to UnifiedParser
+- Add TSX support to UnifiedParser
+
 ## [1.143.0] - 2026-04-28
 
 ### Added 🚀

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
@@ -37,6 +37,7 @@ class UnifiedParserTest {
             Arguments.of("go", ".go"),
             Arguments.of("java", ".java"),
             Arguments.of("javascript", ".js"),
+            Arguments.of("jsx", ".jsx"),
             Arguments.of("kotlin", ".kt"),
             Arguments.of("objectiveC", ".m"),
             Arguments.of("php", ".php"),

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/JsxCollectorTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/JsxCollectorTest.kt
@@ -1,0 +1,135 @@
+package de.maibornwolff.codecharta.analysers.parsers.unified.metriccollectors
+
+import de.maibornwolff.treesitter.excavationsite.api.AvailableFileMetrics
+import de.maibornwolff.treesitter.excavationsite.api.Language
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class JsxCollectorTest {
+    private val collector = TreeSitterLibraryCollector(Language.JAVASCRIPT)
+
+    private fun createTestFile(content: String): File {
+        val tempFile = File.createTempFile("testFile", ".jsx")
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+
+    @Test
+    fun `should parse a minimal JSX component and return non-zero loc`() {
+        // Arrange
+        val fileContent = """
+            function Hello() {
+                return <div>Hello World</div>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.LINES_OF_CODE.metricName] as Double).isGreaterThan(0.0)
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName] as Double).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count ternary operator inside JSX expression for complexity`() {
+        // Arrange
+        val fileContent = """const element = (<h1>{x < 10 ? "Banana" : "Apple"}</h1>);"""
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count logical AND short-circuit in JSX expression for complexity`() {
+        // Arrange
+        val fileContent = """const element = (<div>{isLoggedIn && <Dashboard />}</div>);"""
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should not count inline arrow function in JSX prop as a function`() {
+        // Arrange
+        val fileContent = """
+            function App() {
+                return (<Button onClick={() => doStuff()} />);
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count arrow function component assigned to const as a function`() {
+        // Arrange
+        val fileContent = """
+            const Fruit = () => (
+                <div>Hello</div>
+            );
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should not count map callback returning JSX as a function`() {
+        // Arrange
+        val fileContent = """
+            function List({ items }) {
+                return (<ul>{items.map((item) => <li key={item.id}>{item.name}</li>)}</ul>);
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count JSX block comment in comment lines`() {
+        // Arrange
+        val fileContent = """
+            function App() {
+                return (
+                    <div>
+                        {/* this is a JSX comment */}
+                        <p>Hello</p>
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(1.0)
+    }
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TsxCollectorTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TsxCollectorTest.kt
@@ -17,10 +17,12 @@ class TsxCollectorTest {
     }
 
     @Test
-    fun `should parse a minimal tsx component and return non-zero loc`() {
+    fun `should count functional component with JSX for number of functions`() {
         // Arrange
         val fileContent = """
-            function Hello() {
+            import React from 'react';
+
+            const MyComponent: React.FC = () => {
                 return <div>Hello World</div>;
             }
         """.trimIndent()
@@ -30,34 +32,73 @@ class TsxCollectorTest {
         val result = collector.collectMetricsForFile(input)
 
         // Assert
-        assertThat(result.attributes[AvailableFileMetrics.LINES_OF_CODE.metricName] as Double).isGreaterThan(0.0)
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName] as Double).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
     }
 
     @Test
-    fun `should count ternary operator inside JSX expression for complexity`() {
+    fun `should count function component with typed props for number of functions`() {
         // Arrange
-        val fileContent = """const element = (<h1>{x < 10 ? "Banana" : "Apple"}</h1>);"""
+        val fileContent = """
+            interface Props {
+                name: string;
+                age: number;
+            }
+
+            function UserCard({ name, age }: Props) {
+                return (
+                    <div className="user-card">
+                        <h2>{name}</h2>
+                        <p>Age: {age}</p>
+                    </div>
+                );
+            }
+        """.trimIndent()
         val input = createTestFile(fileContent)
 
         // Act
         val result = collector.collectMetricsForFile(input)
 
         // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
     }
 
     @Test
-    fun `should count logical AND short-circuit in JSX expression for complexity`() {
+    fun `should count class component with render method for number of functions`() {
         // Arrange
-        val fileContent = """const element = (<div>{isLoggedIn && <Dashboard />}</div>);"""
+        val fileContent = """
+            import React, { Component } from 'react';
+
+            interface State {
+                count: number;
+            }
+
+            class Counter extends Component<{}, State> {
+                constructor(props: {}) {
+                    super(props);
+                    this.state = { count: 0 };
+                }
+
+                increment() {
+                    this.setState({ count: this.state.count + 1 });
+                }
+
+                render() {
+                    return (
+                        <div>
+                            <p>Count: {this.state.count}</p>
+                            <button onClick={() => this.increment()}>Increment</button>
+                        </div>
+                    );
+                }
+            }
+        """.trimIndent()
         val input = createTestFile(fileContent)
 
         // Act
         val result = collector.collectMetricsForFile(input)
 
         // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(3.0)
     }
 
     @Test
@@ -78,60 +119,6 @@ class TsxCollectorTest {
     }
 
     @Test
-    fun `should count arrow function component assigned to const as a function`() {
-        // Arrange
-        val fileContent = """
-            const Fruit = () => (
-                <div>Hello</div>
-            );
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
-    }
-
-    @Test
-    fun `should count logical OR short-circuit in JSX expression for complexity`() {
-        // Arrange
-        val fileContent = """const element = (<div>{error || <Content />}</div>);"""
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
-    }
-
-    @Test
-    fun `should accumulate complexity across multiple JSX conditional expressions`() {
-        // Arrange
-        val fileContent = """
-            function Card({ isAdmin, isActive, role }) {
-                return (
-                    <div>
-                        {isAdmin && <AdminBadge />}
-                        {isActive ? <ActiveIcon /> : <InactiveIcon />}
-                        {role === "guest" || <Content />}
-                    </div>
-                );
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        // 1 (function) + 1 (&&) + 1 (ternary) + 1 (||) = 4
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(4.0)
-    }
-
-    @Test
     fun `should not count map callback returning JSX as a function`() {
         // Arrange
         val fileContent = """
@@ -149,27 +136,13 @@ class TsxCollectorTest {
     }
 
     @Test
-    fun `should count nullish coalescing operator in JSX expression for complexity`() {
-        // Arrange
-        val fileContent = """const element = (<div>{value ?? <Fallback />}</div>);"""
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(1.0)
-    }
-
-    @Test
-    fun `should count JSX block comment in comment lines`() {
+    fun `should count complexity with JSX ternary operators`() {
         // Arrange
         val fileContent = """
-            function App() {
+            const ConditionalComponent: React.FC<{ isLoading: boolean }> = ({ isLoading }) => {
                 return (
                     <div>
-                        {/* this is a JSX comment */}
-                        <p>Hello</p>
+                        {isLoading ? <Spinner /> : <Content />}
                     </div>
                 );
             }
@@ -180,6 +153,555 @@ class TsxCollectorTest {
         val result = collector.collectMetricsForFile(input)
 
         // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should count complexity with JSX logical AND operators`() {
+        // Arrange
+        val fileContent = """
+            const OptionalComponent = ({ showMessage }: { showMessage: boolean }) => {
+                return (
+                    <div>
+                        {showMessage && <p>Message is visible</p>}
+                        {!showMessage && <p>Message is hidden</p>}
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should count complexity with multiple conditional renders`() {
+        // Arrange
+        val fileContent = """
+            const StatusDisplay = ({ status }: { status: string }) => {
+                if (status === 'loading') {
+                    return <Spinner />;
+                } else if (status === 'error') {
+                    return <Error />;
+                } else if (status === 'success') {
+                    return <Success />;
+                }
+                return <Idle />;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `should count complexity with switch statement for JSX rendering`() {
+        // Arrange
+        val fileContent = """
+            const SwitchComponent = ({ type }: { type: string }) => {
+                switch (type) {
+                    case 'primary':
+                        return <PrimaryButton />;
+                    case 'secondary':
+                        return <SecondaryButton />;
+                    case 'danger':
+                        return <DangerButton />;
+                    default:
+                        return <DefaultButton />;
+                }
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(5.0)
+    }
+
+    @Test
+    fun `should count JSX with fragments and multiple children`() {
+        // Arrange
+        val fileContent = """
+            const FragmentComponent = () => {
+                return (
+                    <>
+                        <Header />
+                        <main>
+                            <Content />
+                        </main>
+                        <Footer />
+                    </>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count hook usage with complexity`() {
+        // Arrange
+        val fileContent = """
+            import { useState, useEffect } from 'react';
+
+            const HookComponent = () => {
+                const [count, setCount] = useState(0);
+                const [data, setData] = useState<string | null>(null);
+
+                useEffect(() => {
+                    if (count > 10) {
+                        fetchData();
+                    }
+                }, [count]);
+
+                const fetchData = async () => {
+                    try {
+                        const response = await fetch('/api/data');
+                        setData(await response.text());
+                    } catch (error) {
+                        console.error(error);
+                    }
+                };
+
+                return <div>{data ?? 'Loading...'}</div>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(2.0)
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(6.0)
+    }
+
+    @Test
+    fun `should count generic component with TypeScript types`() {
+        // Arrange
+        val fileContent = """
+            interface ListProps<T> {
+                items: T[];
+                renderItem: (item: T) => React.ReactNode;
+            }
+
+            function List<T>({ items, renderItem }: ListProps<T>) {
+                return (
+                    <ul>
+                        {items.map((item, index) => (
+                            <li key={index}>{renderItem(item)}</li>
+                        ))}
+                    </ul>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count JSX with event handlers for complexity`() {
+        // Arrange
+        val fileContent = """
+            const Form = () => {
+                const handleSubmit = (e: React.FormEvent) => {
+                    e.preventDefault();
+                    if (isValid()) {
+                        submit();
+                    }
+                };
+
+                const isValid = () => {
+                    return name.length > 0 && email.includes('@');
+                };
+
+                return (
+                    <form onSubmit={handleSubmit}>
+                        <input type="text" />
+                        <button type="submit">Submit</button>
+                    </form>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(3.0)
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(5.0)
+    }
+
+    @Test
+    fun `should count JSX comments and TypeScript comments for comment_lines`() {
+        // Arrange
+        val fileContent = """
+            /**
+             * This is a JSDoc comment
+             * describing the component
+             */
+            const CommentedComponent = () => {
+                // This is a line comment
+                return (
+                    <div>
+                        {/* This is a JSX comment */}
+                        <p>Hello</p>
+                        {/* Another JSX comment
+                            spanning multiple lines */}
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(8.0)
+    }
+
+    @Test
+    fun `should not include comments or empty lines for rloc with JSX`() {
+        // Arrange
+        val fileContent = """
+            const Component = () => {
+                // comment
+
+
+                return <div>Content</div>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.REAL_LINES_OF_CODE.metricName]).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should count lines of code including JSX for loc`() {
+        // Arrange
+        val fileContent = """
+            const Component = () => {
+                // comment
+
+
+                return <div>Content</div>;
+            }
+        """.trimIndent() + "\n"
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.LINES_OF_CODE.metricName]).isEqualTo(6.0)
+    }
+
+    @Test
+    fun `should handle nested JSX elements with complex structure`() {
+        // Arrange
+        val fileContent = """
+            const NestedComponent = ({ items }: { items: string[] }) => {
+                return (
+                    <div className="container">
+                        <header>
+                            <h1>Title</h1>
+                            <nav>
+                                {items.length > 0 && (
+                                    <ul>
+                                        {items.map((item, idx) => (
+                                            <li key={idx}>
+                                                <a href={`#${'$'}{item}`}>{item}</a>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </nav>
+                        </header>
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should count parameters correctly for React components`() {
+        // Arrange
+        val fileContent = """
+            function NoProps() {
+                return <div>No props</div>;
+            }
+
+            function OneParam({ title }: { title: string }) {
+                return <h1>{title}</h1>;
+            }
+
+            function TwoParams({ name, age }: { name: string; age: number }) {
+                return <div>{name} is {age}</div>;
+            }
+
+            function ThreeParams({ x, y, z }: { x: number; y: number; z: number }) {
+                return <div>{x + y + z}</div>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes["max_parameters_per_function"]).isEqualTo(1.0)
+        assertThat(result.attributes["min_parameters_per_function"]).isEqualTo(0.0)
+        assertThat(result.attributes["mean_parameters_per_function"]).isEqualTo(0.75)
+        assertThat(result.attributes["median_parameters_per_function"]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should correctly calculate complexity per function with JSX conditionals`() {
+        // Arrange
+        val fileContent = """
+            function NoComplexity() {
+                return <div>Simple</div>;
+            }
+
+            function WithConditionals({ show, isAdmin }: { show: boolean; isAdmin: boolean }) {
+                return (
+                    <div>
+                        {show && <Content />}
+                        {isAdmin ? <AdminPanel /> : <UserPanel />}
+                    </div>
+                );
+            }
+
+            function WithLoop({ items }: { items: string[] }) {
+                for (const item of items) {
+                    console.log(item);
+                }
+                return <ul>{items.map(i => <li>{i}</li>)}</ul>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes["max_complexity_per_function"]).isEqualTo(2.0)
+        assertThat(result.attributes["min_complexity_per_function"]).isEqualTo(0.0)
+        assertThat(result.attributes["mean_complexity_per_function"]).isEqualTo(1.33)
+        assertThat(result.attributes["median_complexity_per_function"]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should count JSX spread attributes and props`() {
+        // Arrange
+        val fileContent = """
+            interface ButtonProps {
+                variant: 'primary' | 'secondary';
+                onClick: () => void;
+            }
+
+            const Button = ({ variant, ...rest }: ButtonProps & React.HTMLProps<HTMLButtonElement>) => {
+                return (
+                    <button
+                        className={`btn btn-${'$'}{variant}`}
+                        {...rest}
+                    >
+                        Click me
+                    </button>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should handle JSX with template literals and expressions`() {
+        // Arrange
+        val fileContent = """
+            const StyledComponent = ({ color, size }: { color: string; size: number }) => {
+                const style = {
+                    color: color,
+                    fontSize: `${'$'}{size}px`
+                };
+
+                return (
+                    <div style={style}>
+                        {`This text is ${'$'}{color} and ${'$'}{size}px`}
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should handle JSX with self-closing tags`() {
+        // Arrange
+        val fileContent = """
+            const SelfClosingComponent = () => {
+                return (
+                    <div>
+                        <img src="image.jpg" alt="description" />
+                        <input type="text" placeholder="Enter text" />
+                        <br />
+                        <hr />
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count nullish coalescing in JSX expressions for complexity`() {
+        // Arrange
+        val fileContent = """
+            const Component = ({ value }: { value?: string }) => {
+                return <div>{value ?? 'Default Value'}</div>;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should correctly calculate rloc per function with JSX`() {
+        // Arrange
+        val fileContent = """
+            const SmallComponent = () => {
+                return <div>Small</div>;
+            }
+
+            const MediumComponent = () => {
+                // comment
+                const value = 42;
+                return <div>{value}</div>;
+            }
+
+            const LargeComponent = () => {
+                const [state, setState] = useState(0);
+
+                useEffect(() => {
+                    setState(1);
+                }, []);
+
+                return (
+                    <div>
+                        {state}
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes["max_rloc_per_function"]).isEqualTo(9.0)
+        assertThat(result.attributes["min_rloc_per_function"]).isEqualTo(1.0)
+        assertThat(result.attributes["mean_rloc_per_function"]).isEqualTo(4.0)
+        assertThat(result.attributes["median_rloc_per_function"]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should handle complex JSX with multiple conditional rendering patterns`() {
+        // Arrange
+        val fileContent = """
+            const ComplexComponent = ({
+                isLoading,
+                hasError,
+                data
+            }: {
+                isLoading: boolean;
+                hasError: boolean;
+                data: string[] | null
+            }) => {
+                if (isLoading) return <Spinner />;
+                if (hasError) return <Error />;
+                if (!data) return null;
+
+                return (
+                    <div>
+                        {data.length > 0 ? (
+                            <ul>
+                                {data.map((item, idx) => (
+                                    <li key={idx}>
+                                        {item.length > 10 ? item.substring(0, 10) + '...' : item}
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <p>No data available</p>
+                        )}
+                    </div>
+                );
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // Act
+        val result = collector.collectMetricsForFile(input)
+
+        // Assert
+        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(7.0)
     }
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TsxCollectorTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TsxCollectorTest.kt
@@ -16,29 +16,36 @@ class TsxCollectorTest {
         return tempFile
     }
 
+    private fun collectMetrics(content: String): Map<String, Any> = collector.collectMetricsForFile(createTestFile(content)).attributes
+
+    private fun assertMetric(content: String, metric: String, expected: Double) {
+        assertThat(collectMetrics(content)[metric] as Double).isEqualTo(expected)
+    }
+
+    private fun assertMetrics(content: String, vararg expectations: Pair<String, Double>) {
+        val metrics = collectMetrics(content)
+        expectations.forEach { (metric, expected) ->
+            assertThat(metrics[metric] as Double).isEqualTo(expected)
+        }
+    }
+
+    // --- Function counting tests ---
+
     @Test
     fun `should count functional component with JSX for number of functions`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             import React from 'react';
 
             const MyComponent: React.FC = () => {
                 return <div>Hello World</div>;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName, 1.0)
     }
 
     @Test
     fun `should count function component with typed props for number of functions`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             interface Props {
                 name: string;
                 age: number;
@@ -53,92 +60,43 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName, 1.0)
     }
 
     @Test
     fun `should count class component with render method for number of functions`() {
-        // Arrange
-        val fileContent = """
-            import React, { Component } from 'react';
-
-            interface State {
-                count: number;
-            }
-
-            class Counter extends Component<{}, State> {
-                constructor(props: {}) {
-                    super(props);
-                    this.state = { count: 0 };
-                }
-
-                increment() {
-                    this.setState({ count: this.state.count + 1 });
-                }
-
-                render() {
-                    return (
-                        <div>
-                            <p>Count: {this.state.count}</p>
-                            <button onClick={() => this.increment()}>Increment</button>
-                        </div>
-                    );
-                }
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(3.0)
+        assertMetric(
+            "class Counter extends Component { render() { return <div />; } }",
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName,
+            1.0
+        )
     }
 
     @Test
     fun `should not count inline arrow function in JSX prop as a function`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             function App() {
                 return (<Button onClick={() => doStuff()} />);
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName, 1.0)
     }
 
     @Test
     fun `should not count map callback returning JSX as a function`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             function List({ items }) {
                 return (<ul>{items.map((item) => <li key={item.id}>{item.name}</li>)}</ul>);
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName, 1.0)
     }
+
+    // --- Complexity tests ---
 
     @Test
     fun `should count complexity with JSX ternary operators`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const ConditionalComponent: React.FC<{ isLoading: boolean }> = ({ isLoading }) => {
                 return (
                     <div>
@@ -147,19 +105,12 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+        assertMetric(content, AvailableFileMetrics.COMPLEXITY.metricName, 2.0)
     }
 
     @Test
     fun `should count complexity with JSX logical AND operators`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const OptionalComponent = ({ showMessage }: { showMessage: boolean }) => {
                 return (
                     <div>
@@ -169,19 +120,12 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(3.0)
+        assertMetric(content, AvailableFileMetrics.COMPLEXITY.metricName, 3.0)
     }
 
     @Test
     fun `should count complexity with multiple conditional renders`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const StatusDisplay = ({ status }: { status: string }) => {
                 if (status === 'loading') {
                     return <Spinner />;
@@ -193,19 +137,12 @@ class TsxCollectorTest {
                 return <Idle />;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(4.0)
+        assertMetric(content, AvailableFileMetrics.COMPLEXITY.metricName, 4.0)
     }
 
     @Test
     fun `should count complexity with switch statement for JSX rendering`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const SwitchComponent = ({ type }: { type: string }) => {
                 switch (type) {
                     case 'primary':
@@ -219,110 +156,44 @@ class TsxCollectorTest {
                 }
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(5.0)
-    }
-
-    @Test
-    fun `should count JSX with fragments and multiple children`() {
-        // Arrange
-        val fileContent = """
-            const FragmentComponent = () => {
-                return (
-                    <>
-                        <Header />
-                        <main>
-                            <Content />
-                        </main>
-                        <Footer />
-                    </>
-                );
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.COMPLEXITY.metricName, 5.0)
     }
 
     @Test
     fun `should count hook usage with complexity`() {
-        // Arrange
-        val fileContent = """
-            import { useState, useEffect } from 'react';
-
+        val content = """
             const HookComponent = () => {
-                const [count, setCount] = useState(0);
-                const [data, setData] = useState<string | null>(null);
+                const [count] = useState(0);
 
                 useEffect(() => {
                     if (count > 10) {
-                        fetchData();
+                        doSomething();
                     }
                 }, [count]);
 
-                const fetchData = async () => {
-                    try {
-                        const response = await fetch('/api/data');
-                        setData(await response.text());
-                    } catch (error) {
-                        console.error(error);
-                    }
-                };
-
-                return <div>{data ?? 'Loading...'}</div>;
+                return <div>{count}</div>;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(2.0)
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(6.0)
+        // complexity=3: outer function (1) + useEffect arrow callback (1) + if inside callback (1)
+        assertMetrics(
+            content,
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName to 1.0,
+            AvailableFileMetrics.COMPLEXITY.metricName to 3.0
+        )
     }
 
     @Test
-    fun `should count generic component with TypeScript types`() {
-        // Arrange
-        val fileContent = """
-            interface ListProps<T> {
-                items: T[];
-                renderItem: (item: T) => React.ReactNode;
-            }
-
-            function List<T>({ items, renderItem }: ListProps<T>) {
-                return (
-                    <ul>
-                        {items.map((item, index) => (
-                            <li key={index}>{renderItem(item)}</li>
-                        ))}
-                    </ul>
-                );
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    fun `should count generic function component`() {
+        assertMetric(
+            "function List<T>(items: T[]) { return <ul />; }",
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName,
+            1.0
+        )
     }
 
     @Test
     fun `should count JSX with event handlers for complexity`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const Form = () => {
                 const handleSubmit = (e: React.FormEvent) => {
                     e.preventDefault();
@@ -343,20 +214,18 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(3.0)
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(5.0)
+        assertMetrics(
+            content,
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName to 3.0,
+            AvailableFileMetrics.COMPLEXITY.metricName to 5.0
+        )
     }
+
+    // --- Comment and LOC tests ---
 
     @Test
     fun `should count JSX comments and TypeScript comments for comment_lines`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             /**
              * This is a JSDoc comment
              * describing the component
@@ -373,19 +242,12 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(8.0)
+        assertMetric(content, AvailableFileMetrics.COMMENT_LINES.metricName, 8.0)
     }
 
     @Test
     fun `should not include comments or empty lines for rloc with JSX`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const Component = () => {
                 // comment
 
@@ -393,19 +255,12 @@ class TsxCollectorTest {
                 return <div>Content</div>;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.REAL_LINES_OF_CODE.metricName]).isEqualTo(3.0)
+        assertMetric(content, AvailableFileMetrics.REAL_LINES_OF_CODE.metricName, 3.0)
     }
 
     @Test
     fun `should count lines of code including JSX for loc`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const Component = () => {
                 // comment
 
@@ -413,19 +268,12 @@ class TsxCollectorTest {
                 return <div>Content</div>;
             }
         """.trimIndent() + "\n"
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.LINES_OF_CODE.metricName]).isEqualTo(6.0)
+        assertMetric(content, AvailableFileMetrics.LINES_OF_CODE.metricName, 6.0)
     }
 
     @Test
     fun `should handle nested JSX elements with complex structure`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const NestedComponent = ({ items }: { items: string[] }) => {
                 return (
                     <div className="container">
@@ -447,52 +295,35 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(3.0)
+        assertMetrics(
+            content,
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName to 1.0,
+            AvailableFileMetrics.COMPLEXITY.metricName to 3.0
+        )
     }
+
+    // --- Per-function distribution tests ---
 
     @Test
     fun `should count parameters correctly for React components`() {
-        // Arrange
-        val fileContent = """
-            function NoProps() {
-                return <div>No props</div>;
-            }
-
-            function OneParam({ title }: { title: string }) {
-                return <h1>{title}</h1>;
-            }
-
-            function TwoParams({ name, age }: { name: string; age: number }) {
-                return <div>{name} is {age}</div>;
-            }
-
-            function ThreeParams({ x, y, z }: { x: number; y: number; z: number }) {
-                return <div>{x + y + z}</div>;
-            }
+        val content = """
+            function NoProps() { return <div />; }
+            function OneParam(a: string) { return <div />; }
+            function TwoParams(a: string, b: number) { return <div />; }
+            function ThreeParams(a: string, b: number, c: boolean) { return <div />; }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes["max_parameters_per_function"]).isEqualTo(1.0)
-        assertThat(result.attributes["min_parameters_per_function"]).isEqualTo(0.0)
-        assertThat(result.attributes["mean_parameters_per_function"]).isEqualTo(0.75)
-        assertThat(result.attributes["median_parameters_per_function"]).isEqualTo(1.0)
+        assertMetrics(
+            content,
+            "max_parameters_per_function" to 3.0,
+            "min_parameters_per_function" to 0.0,
+            "mean_parameters_per_function" to 1.5,
+            "median_parameters_per_function" to 1.5
+        )
     }
 
     @Test
     fun `should correctly calculate complexity per function with JSX conditionals`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             function NoComplexity() {
                 return <div>Simple</div>;
             }
@@ -513,118 +344,39 @@ class TsxCollectorTest {
                 return <ul>{items.map(i => <li>{i}</li>)}</ul>;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes["max_complexity_per_function"]).isEqualTo(2.0)
-        assertThat(result.attributes["min_complexity_per_function"]).isEqualTo(0.0)
-        assertThat(result.attributes["mean_complexity_per_function"]).isEqualTo(1.33)
-        assertThat(result.attributes["median_complexity_per_function"]).isEqualTo(2.0)
+        assertMetrics(
+            content,
+            "max_complexity_per_function" to 2.0,
+            "min_complexity_per_function" to 0.0,
+            "mean_complexity_per_function" to 1.33,
+            "median_complexity_per_function" to 2.0
+        )
     }
 
     @Test
-    fun `should count JSX spread attributes and props`() {
-        // Arrange
-        val fileContent = """
+    fun `should not count function type in interface property as a function`() {
+        val content = """
             interface ButtonProps {
-                variant: 'primary' | 'secondary';
                 onClick: () => void;
             }
-
-            const Button = ({ variant, ...rest }: ButtonProps & React.HTMLProps<HTMLButtonElement>) => {
-                return (
-                    <button
-                        className={`btn btn-${'$'}{variant}`}
-                        {...rest}
-                    >
-                        Click me
-                    </button>
-                );
-            }
+            const Button = ({ onClick }: ButtonProps) => <button onClick={onClick} />;
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
-    }
-
-    @Test
-    fun `should handle JSX with template literals and expressions`() {
-        // Arrange
-        val fileContent = """
-            const StyledComponent = ({ color, size }: { color: string; size: number }) => {
-                const style = {
-                    color: color,
-                    fontSize: `${'$'}{size}px`
-                };
-
-                return (
-                    <div style={style}>
-                        {`This text is ${'$'}{color} and ${'$'}{size}px`}
-                    </div>
-                );
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
-    }
-
-    @Test
-    fun `should handle JSX with self-closing tags`() {
-        // Arrange
-        val fileContent = """
-            const SelfClosingComponent = () => {
-                return (
-                    <div>
-                        <img src="image.jpg" alt="description" />
-                        <input type="text" placeholder="Enter text" />
-                        <br />
-                        <hr />
-                    </div>
-                );
-            }
-        """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+        assertMetric(content, AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName, 1.0)
     }
 
     @Test
     fun `should count nullish coalescing in JSX expressions for complexity`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const Component = ({ value }: { value?: string }) => {
                 return <div>{value ?? 'Default Value'}</div>;
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+        assertMetric(content, AvailableFileMetrics.COMPLEXITY.metricName, 2.0)
     }
 
     @Test
     fun `should correctly calculate rloc per function with JSX`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const SmallComponent = () => {
                 return <div>Small</div>;
             }
@@ -649,22 +401,115 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
+        assertMetrics(
+            content,
+            "max_rloc_per_function" to 9.0,
+            "min_rloc_per_function" to 1.0,
+            "mean_rloc_per_function" to 4.0,
+            "median_rloc_per_function" to 2.0
+        )
+    }
 
-        // Act
-        val result = collector.collectMetricsForFile(input)
+    // --- Misc metrics tests ---
 
-        // Assert
-        assertThat(result.attributes["max_rloc_per_function"]).isEqualTo(9.0)
-        assertThat(result.attributes["min_rloc_per_function"]).isEqualTo(1.0)
-        assertThat(result.attributes["mean_rloc_per_function"]).isEqualTo(4.0)
-        assertThat(result.attributes["median_rloc_per_function"]).isEqualTo(2.0)
+    @Test
+    fun `should count logic_complexity without function definitions unlike complexity`() {
+        val content = """
+            const Component = ({ show }: { show: boolean }) => {
+                if (show) return <div />;
+                return null;
+            }
+        """.trimIndent()
+        // complexity counts the function definition (+1) and the if (+1) = 2
+        // logic_complexity counts only control flow, not function definitions = 1
+        assertMetrics(
+            content,
+            AvailableFileMetrics.COMPLEXITY.metricName to 2.0,
+            AvailableFileMetrics.LOGIC_COMPLEXITY.metricName to 1.0
+        )
+    }
+
+    @Test
+    fun `should detect message chain in JSX component`() {
+        val content = """
+            const Component = () => {
+                const result = items.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0).toString();
+                return <div>{result}</div>;
+            }
+        """.trimIndent()
+        assertMetric(content, AvailableFileMetrics.MESSAGE_CHAINS.metricName, 1.0)
+    }
+
+    @Test
+    fun `should detect long method in TSX component`() {
+        val content = """
+            const LongComponent = () => {
+                const a = 1;
+                const b = 2;
+                const c = 3;
+                const d = 4;
+                const e = 5;
+                const f = 6;
+                const g = 7;
+                const h = 8;
+                const i = 9;
+                const j = 10;
+                const k = 11;
+                return <div />;
+            }
+        """.trimIndent()
+        assertMetric(content, AvailableFileMetrics.LONG_METHOD.metricName, 1.0)
+    }
+
+    @Test
+    fun `should detect long parameter list in TSX function`() {
+        assertMetric(
+            "function ManyParams(a: string, b: number, c: boolean, d: string, e: number) { return <div />; }",
+            AvailableFileMetrics.LONG_PARAMETER_LIST.metricName,
+            1.0
+        )
+    }
+
+    @Test
+    fun `should detect excessive comments in TSX file`() {
+        val content = """
+            // Comment 1
+            // Comment 2
+            // Comment 3
+            // Comment 4
+            // Comment 5
+            // Comment 6
+            // Comment 7
+            // Comment 8
+            // Comment 9
+            // Comment 10
+            // Comment 11
+            const Component = () => <div />;
+        """.trimIndent()
+        assertMetric(content, AvailableFileMetrics.EXCESSIVE_COMMENTS.metricName, 1.0)
+    }
+
+    @Test
+    fun `should calculate comment ratio for TSX file`() {
+        val content = """
+            // Comment 1
+            // Comment 2
+            const Component = () => {
+                const a = 1;
+                const b = 2;
+                const c = 3;
+                const d = 4;
+                const e = 5;
+                return <div />;
+            }
+        """.trimIndent()
+        // comment_lines=2, rloc=8 → ratio=0.25
+        assertMetric(content, AvailableFileMetrics.COMMENT_RATIO.metricName, 0.25)
     }
 
     @Test
     fun `should handle complex JSX with multiple conditional rendering patterns`() {
-        // Arrange
-        val fileContent = """
+        val content = """
             const ComplexComponent = ({
                 isLoading,
                 hasError,
@@ -695,13 +540,10 @@ class TsxCollectorTest {
                 );
             }
         """.trimIndent()
-        val input = createTestFile(fileContent)
-
-        // Act
-        val result = collector.collectMetricsForFile(input)
-
-        // Assert
-        assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
-        assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(7.0)
+        assertMetrics(
+            content,
+            AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName to 1.0,
+            AvailableFileMetrics.COMPLEXITY.metricName to 7.0
+        )
     }
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/jsxSample.cc.json
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/jsxSample.cc.json
@@ -1,0 +1,307 @@
+{
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "link": "",
+        "children": [
+          {
+            "name": "jsxSample.jsx",
+            "type": "File",
+            "attributes": {
+              "complexity": 23.0,
+              "logic_complexity": 16.0,
+              "comment_lines": 19.0,
+              "number_of_functions": 3.0,
+              "message_chains": 0.0,
+              "rloc": 59.0,
+              "loc": 91.0,
+              "long_method": 2.0,
+              "long_parameter_list": 0.0,
+              "excessive_comments": 1.0,
+              "comment_ratio": 0.32,
+              "max_parameters_per_function": 2.0,
+              "min_parameters_per_function": 0.0,
+              "mean_parameters_per_function": 0.67,
+              "median_parameters_per_function": 0.0,
+              "max_complexity_per_function": 9.0,
+              "min_complexity_per_function": 3.0,
+              "mean_complexity_per_function": 6.67,
+              "median_complexity_per_function": 8.0,
+              "max_rloc_per_function": 18.0,
+              "min_rloc_per_function": 8.0,
+              "mean_rloc_per_function": 14.67,
+              "median_rloc_per_function": 18.0
+            },
+            "link": "",
+            "children": [],
+            "checksum": "38e2f13247163649"
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.5",
+    "edges": [],
+    "attributeTypes": {},
+    "attributeDescriptors": {
+      "complexity": {
+        "title": "Complexity",
+        "description": "Complexity of the file representing how much cognitive load is needed to overview the whole file",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "logic_complexity": {
+        "title": "Logic complexity",
+        "description": "Complexity of the file based on number of paths through the code, similar to cyclomatic complexity",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_lines": {
+        "title": "Comment lines",
+        "description": "Number of lines containing either a comment or commented-out code",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "loc": {
+        "title": "Lines of Code",
+        "description": "Lines of code including empty lines and comments",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "rloc": {
+        "title": "Real Lines of Code",
+        "description": "Number of lines that contain at least one character which is neither a whitespace nor a tabulation nor part of a comment",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "number_of_functions": {
+        "title": "Number of functions",
+        "description": "The number of functions or methods present in the file. Does not include anonymous or lambda functions.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_parameters_per_function": {
+        "title": "Maximum parameters per function",
+        "description": "The maximum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_parameters_per_function": {
+        "title": "Minimum parameters per function",
+        "description": "The minimum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_parameters_per_function": {
+        "title": "Median parameters per function",
+        "description": "The median number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_parameters_per_function": {
+        "title": "Mean parameters per function",
+        "description": "The mean number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_complexity_per_function": {
+        "title": "Maximum complexity per function",
+        "description": "The maximum complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_complexity_per_function": {
+        "title": "Minimum complexity per function",
+        "description": "The minimum number of complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_complexity_per_function": {
+        "title": "Mean complexity per function",
+        "description": "The mean complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_complexity_per_function": {
+        "title": "Median complexity per function",
+        "description": "The median complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_rloc_per_function": {
+        "title": "Maximum real lines of code in a function",
+        "description": "The maximum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_rloc_per_function": {
+        "title": "Minimum real lines of code in a function",
+        "description": "The minimum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_rloc_per_function": {
+        "title": "Mean real lines of code in a function",
+        "description": "The mean number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_rloc_per_function": {
+        "title": "Median real lines of code in a function",
+        "description": "The median number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_method": {
+        "title": "Long Method",
+        "description": "Code smell showing the number of functions with more than 10 real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_parameter_list": {
+        "title": "Long Parameter List",
+        "description": "Code smell showing the number of functions with more than 4 parameters",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "excessive_comments": {
+        "title": "Excessive Comments",
+        "description": "Code smell showing whether a file has more than 10 comment lines",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_ratio": {
+        "title": "Comment Ratio",
+        "description": "The ratio of comment lines to real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": 0,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "message_chains": {
+        "title": "Message Chains",
+        "description": "Code smell showing occurrences of method call chains with 4 or more consecutive calls suggesting tight coupling",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      }
+    },
+    "blacklist": []
+  },
+  "checksum": "0e4a3ae47f6c1ebfea5539ee3379e131"
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/jsxSample.jsx
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/jsxSample.jsx
@@ -1,0 +1,91 @@
+/**
+ * This is a generated sample file for analysis only
+ */
+
+import React, { useState } from "react";
+
+/**
+ * Displays a card with user information
+ */
+function UserCard({ name, email, role, isActive }) {
+  // Apply different styles based on role
+  const roleColor = role === "admin" ? "red" : role === "user" ? "blue" : "gray";
+
+  return (
+    <div className={`user-card ${isActive ? "active" : "inactive"}`}>
+      <h2>{name}</h2>
+      <p>{email}</p>
+      <span style={{ color: roleColor }}>{role}</span>
+    </div>
+  );
+}
+
+/**
+ * Renders a filterable list of user cards
+ */
+function UserList({ users, filterRole }) {
+  const [searchText, setSearchText] = useState("");
+
+  // Filter by role if specified
+  const filteredByRole = filterRole ? users.filter((u) => u.role === filterRole) : users;
+
+  // Filter by search text
+  const visibleUsers = filteredByRole.filter((u) => {
+    if (searchText.length === 0) {
+      return true;
+    }
+    return u.name.toLowerCase().includes(searchText.toLowerCase()) || u.email.toLowerCase().includes(searchText.toLowerCase());
+  });
+
+  return (
+    <div className="user-list">
+      <input type="text" value={searchText} onChange={(e) => setSearchText(e.target.value)} placeholder="Search users..." />
+      {visibleUsers.length === 0 ? (
+        <p>No users found.</p>
+      ) : (
+        visibleUsers.map((user) => <UserCard key={user.email} {...user} />)
+      )}
+    </div>
+  );
+}
+
+/**
+ * Utility to determine access level — intentionally complex for metric coverage
+ */
+function determineAccessLevel(user, resource) {
+  // Inactive users have no access
+  if (!user.isActive) {
+    return 0;
+  }
+
+  // Admins always have full access
+  if (user.role === "admin") {
+    return 3;
+  }
+
+  if (resource.startsWith("personal-")) {
+    /* personal resources only for the user themselves */
+    return user.role === "user" ? 2 : 0;
+  } else if (resource.startsWith("team-")) {
+    if (user.role === "user") {
+      return 2;
+    } else if (user.role === "guest") {
+      return 1;
+    }
+  } else if (resource === "public") {
+    return 1;
+  }
+
+  return user.role === "guest" ? 0 : 1;
+}
+
+// Example usage
+const sampleUsers = [
+  { name: "Alice", email: "alice@example.com", role: "admin", isActive: true },
+  { name: "Bob", email: "bob@example.com", role: "user", isActive: true },
+  { name: "Carol", email: "carol@example.com", role: "guest", isActive: false },
+];
+
+console.log(determineAccessLevel(sampleUsers[0], "team-finance"));
+console.log(determineAccessLevel(sampleUsers[1], "personal-1"));
+console.log(determineAccessLevel(sampleUsers[2], "public"));

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
@@ -23,7 +23,7 @@ enum class FileExtension(
     CPP(".cpp", setOf(".cc", ".cxx", ".c++", ".hh", ".hpp", ".hxx")),
     C(".c", setOf(".h")),
     JAVA(".java"),
-    JAVASCRIPT(".js", setOf(".cjs", ".mjs")),
+    JAVASCRIPT(".js", setOf(".cjs", ".mjs", ".jsx")),
     KOTLIN(".kt"),
     OBJECTIVE_C(".m"),
     PYTHON(".py"),

--- a/gh-pages/_docs/05-parser/05-unified.md
+++ b/gh-pages/_docs/05-parser/05-unified.md
@@ -11,14 +11,14 @@ toc_label: "Jump to Section"
 
 **Category**: Parser (takes in source code and outputs cc.json)
 
-The Unified Parser is parser to generate code metrics from a source code file or a project folder without relying on tools other than
+The Unified Parser is a parser to generate code metrics from a source code file or a project folder without relying on tools other than
 CodeCharta. It generates either a cc.json or a csv file.
 
 ## Supported Languages
 
 | Language     | Supported file extensions              |
 |--------------|----------------------------------------|
-| Javascript   | .js, .cjs, .mjs                        |
+| Javascript   | .js, .cjs, .mjs, .jsx                  |
 | Typescript   | .ts, .cts, .mts                        |
 | TSX          | .tsx                                   |
 | Java         | .java                                  |
@@ -133,7 +133,7 @@ specific AST node types for each metric.
 Complexity is calculated using McCabe Complexity, counting the number of paths through the code. Each language has specific constructs that
 contribute to complexity:
 
-#### JavaScript (.js, .cjs, .mjs)
+#### JavaScript (.js, .cjs, .mjs, .jsx)
 
 - **Control flow**: `if_statement`, `do_statement`, `for_statement`, `while_statement`, `for_in_statement`, `ternary_expression`,
   `switch_case`, `switch_default`, `catch_clause`
@@ -270,7 +270,7 @@ Comment lines are counted based on language-specific comment syntax:
 
 Function counting identifies different types of function definitions per language:
 
-#### JavaScript (.js, .cjs, .mjs)
+#### JavaScript (.js, .cjs, .mjs, .jsx)
 
 - **Simple functions**: `function_declaration`, `generator_function_declaration`, `method_definition`, `function_expression`
 - **Arrow functions**: Assigned to variables (detected via `variable_declarator` with `arrow_function` value)
@@ -386,7 +386,7 @@ Parameters per function counts the number of parameters declared for each functi
 Message Chains is a code smell that detects method call chains with 4 or more consecutive calls (e.g., `obj.a().b().c().d()`), which
 can indicate tight coupling and violations of the Law of Demeter. The metric counts only method/function calls, not property accesses.
 
-#### JavaScript (.js, .cjs, .mjs)
+#### JavaScript (.js, .cjs, .mjs, .jsx)
 
 - **Chain nodes**: `call_expression`, `member_expression`
 - **Call nodes**: `call_expression`


### PR DESCRIPTION
Add JSX support to UnifiedParser                                                                                                                                                                                                
                                                                                                                                                                                                                                  
  Closes: #4360                                                                                                                                                                                                                   
                                                                                                                                                                                                                                  
  Description     
                                                                                                                                                                                                                                  
  .jsx files were not recognized by the UnifiedParser, so projects using JSX could not be analysed without renaming files.                                                                                                        
                                                                                                                                                                                                                                  
  This PR adds .jsx as a supported file extension, parsed using the existing JavaScript TreeSitter grammar (since JSX is a syntactic superset of JavaScript). It also expands the TsxCollectorTest with additional component      
  scenarios that were missing from the original TSX PR.                                                                                                                                                                           

  What does this PR implement and how?
  - Registers .jsx as an alias extension for JAVASCRIPT in FileExtension.kt
  - Adds JsxCollectorTest covering JSX-specific metric scenarios (LOC, complexity, function counting, comments)
  - Adds jsxSample.jsx and its golden output jsxSample.cc.json
  - Adds a parametrized UnifiedParserTest case for .jsx
  - Updates the UnifiedParser documentation to list .jsx as a supported extension

  Definition of Done
  - Changes have been manually tested
  - All TODOs related to this PR have been closed
  - There are automated tests for newly written code and bug fixes
  - All bugs discovered while working on this PR have been submitted as issues
  - Documentation (gh-pages unified parser doc) has been updated
  - CHANGELOG.md has been updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified parser now recognizes JSX (.jsx) and includes JSX/TSX in language analysis.

* **Tests**
  * Added extensive JSX and TSX test coverage and sample resources to validate metrics (LOC, complexity, function/parameter counts, comments, logic metrics, distributions).

* **Documentation**
  * Updated unified parser docs to list .jsx as a recognized JavaScript extension.

* **Chores**
  * Changelog updated to record JSX and TSX support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->