### PR TITLE
feat(analysis): add Delphi language support to UnifiedParser

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+- Add Delphi support to UnifiedParser (.pas, .dpr)
+
 ## [1.142.0] - 2026-03-16
 
 ### Added 🚀

--- a/analysis/analysers/parsers/UnifiedParser/README.md
+++ b/analysis/analysers/parsers/UnifiedParser/README.md
@@ -24,6 +24,7 @@ The Unified Parser is parser to generate code metrics from a source code file or
 | Swift        | .swift                                 |
 | Bash         | .sh                                    |
 | Vue          | .vue                                   |
+| Delphi       | .pas, .dpr                             |
 
 ## Supported Metrics
 

--- a/analysis/analysers/parsers/UnifiedParser/build.gradle.kts
+++ b/analysis/analysers/parsers/UnifiedParser/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(libs.kotter.test)
 
     // TreesitterLibrary provides all TreeSitter dependencies and metric calculation
-    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.4.1")
+    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.7.0")
 
     testImplementation(libs.jsonassert)
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
@@ -25,5 +25,6 @@ enum class AvailableCollectors(
     RUBY(FileExtension.RUBY, { TreeSitterLibraryCollector(Language.RUBY) }),
     SWIFT(FileExtension.SWIFT, { TreeSitterLibraryCollector(Language.SWIFT) }),
     BASH(FileExtension.BASH, { TreeSitterLibraryCollector(Language.BASH) }),
-    VUE(FileExtension.VUE, { TreeSitterLibraryCollector(Language.VUE) })
+    VUE(FileExtension.VUE, { TreeSitterLibraryCollector(Language.VUE) }),
+    DELPHI(FileExtension.DELPHI, { TreeSitterLibraryCollector(Language.DELPHI) })
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapter.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapter.kt
@@ -64,6 +64,7 @@ object TreeSitterAdapter {
         FileExtension.C -> Language.C
         FileExtension.OBJECTIVE_C -> Language.OBJECTIVE_C
         FileExtension.VUE -> Language.VUE
+        FileExtension.DELPHI -> Language.DELPHI
         else -> null
     }
 

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
@@ -33,6 +33,7 @@ class UnifiedParserTest {
             Arguments.of("cpp", ".cpp"),
             Arguments.of("c", ".c"),
             Arguments.of("cSharp", ".cs"),
+            Arguments.of("delphi", ".pas"),
             Arguments.of("go", ".go"),
             Arguments.of("java", ".java"),
             Arguments.of("javascript", ".js"),

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/DelphiCollectorTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/DelphiCollectorTest.kt
@@ -1,0 +1,101 @@
+package de.maibornwolff.codecharta.analysers.parsers.unified.metriccollectors
+
+import de.maibornwolff.treesitter.excavationsite.api.AvailableFileMetrics
+import de.maibornwolff.treesitter.excavationsite.api.Language
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class DelphiCollectorTest {
+    private val collector = TreeSitterLibraryCollector(Language.DELPHI)
+
+    private fun createTestFile(content: String): File {
+        val tempFile = File.createTempFile("testFile", ".pas")
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+
+    @Test
+    fun `should count if statements for complexity`() {
+        // given - one procedure (defProc) plus one if-statement
+        val fileContent = """
+            unit U; interface implementation
+            procedure Foo;
+            begin
+              if 1 = 1 then Bar;
+            end;
+            end.
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then - 1 (defProc) + 1 (if) = 2
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should count line and brace and star comments for comment lines`() {
+        // given - one //, one { }, and one (* *)
+        val fileContent = """
+            unit U; // line comment
+            { brace comment }
+            (* star comment *)
+            interface
+            implementation
+            end.
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should count procedure and function declarations for number of functions`() {
+        // given - a procedure and a function implementation
+        val fileContent = """
+            unit U; interface implementation
+            procedure Foo;
+            begin
+            end;
+            function Bar: Integer;
+            begin
+              Result := 1;
+            end;
+            end.
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should detect a parenthesised method chain as one message chain`() {
+        // given - 4 chained parenthesised calls (Obj.M1().M2().M3().M4()) form one chain
+        val fileContent = """
+            unit U; interface implementation
+            procedure Foo;
+            begin
+              Obj.M1().M2().M3().M4();
+            end;
+            end.
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then - the exprDot/exprCall ignore rule in DelphiDefinition prevents double-counting
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.MESSAGE_CHAINS.metricName]).isEqualTo(1.0)
+    }
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapterTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapterTest.kt
@@ -76,7 +76,8 @@ class TreeSitterAdapterTest {
             FileExtension.CPP to Language.CPP,
             FileExtension.C to Language.C,
             FileExtension.OBJECTIVE_C to Language.OBJECTIVE_C,
-            FileExtension.VUE to Language.VUE
+            FileExtension.VUE to Language.VUE,
+            FileExtension.DELPHI to Language.DELPHI
         )
 
         // Act & Assert
@@ -106,11 +107,15 @@ class TreeSitterAdapterTest {
         val javaFile = File("Test.java")
         val kotlinFile = File("Test.kt")
         val pythonFile = File("test.py")
+        val delphiUnitFile = File("Unit.pas")
+        val delphiProjectFile = File("Project.dpr")
 
         // Act & Assert
         assertThat(TreeSitterAdapter.getLanguageForFile(javaFile)).isEqualTo(Language.JAVA)
         assertThat(TreeSitterAdapter.getLanguageForFile(kotlinFile)).isEqualTo(Language.KOTLIN)
         assertThat(TreeSitterAdapter.getLanguageForFile(pythonFile)).isEqualTo(Language.PYTHON)
+        assertThat(TreeSitterAdapter.getLanguageForFile(delphiUnitFile)).isEqualTo(Language.DELPHI)
+        assertThat(TreeSitterAdapter.getLanguageForFile(delphiProjectFile)).isEqualTo(Language.DELPHI)
     }
 
     @Test
@@ -156,7 +161,8 @@ class TreeSitterAdapterTest {
             FileExtension.CPP,
             FileExtension.C,
             FileExtension.OBJECTIVE_C,
-            FileExtension.VUE
+            FileExtension.VUE,
+            FileExtension.DELPHI
         )
 
         // Act & Assert

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.cc.json
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.cc.json
@@ -1,0 +1,307 @@
+{
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "link": "",
+        "children": [
+          {
+            "name": "delphiSample.pas",
+            "type": "File",
+            "attributes": {
+              "complexity": 4.0,
+              "logic_complexity": 2.0,
+              "comment_lines": 3.0,
+              "number_of_functions": 2.0,
+              "message_chains": 0.0,
+              "rloc": 21.0,
+              "loc": 31.0,
+              "long_method": 0.0,
+              "long_parameter_list": 0.0,
+              "excessive_comments": 0.0,
+              "comment_ratio": 0.14,
+              "max_parameters_per_function": 1.0,
+              "min_parameters_per_function": 1.0,
+              "mean_parameters_per_function": 1.0,
+              "median_parameters_per_function": 1.0,
+              "max_complexity_per_function": 1.0,
+              "min_complexity_per_function": 1.0,
+              "mean_complexity_per_function": 1.0,
+              "median_complexity_per_function": 1.0,
+              "max_rloc_per_function": 4.0,
+              "min_rloc_per_function": 3.0,
+              "mean_rloc_per_function": 3.5,
+              "median_rloc_per_function": 3.5
+            },
+            "link": "",
+            "children": [],
+            "checksum": "4aad31bbb6ca8cab"
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.5",
+    "edges": [],
+    "attributeTypes": {},
+    "attributeDescriptors": {
+      "complexity": {
+        "title": "Complexity",
+        "description": "Complexity of the file representing how much cognitive load is needed to overview the whole file",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "logic_complexity": {
+        "title": "Logic complexity",
+        "description": "Complexity of the file based on number of paths through the code, similar to cyclomatic complexity",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_lines": {
+        "title": "Comment lines",
+        "description": "Number of lines containing either a comment or commented-out code",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "loc": {
+        "title": "Lines of Code",
+        "description": "Lines of code including empty lines and comments",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "rloc": {
+        "title": "Real Lines of Code",
+        "description": "Number of lines that contain at least one character which is neither a whitespace nor a tabulation nor part of a comment",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "number_of_functions": {
+        "title": "Number of functions",
+        "description": "The number of functions or methods present in the file. Does not include anonymous or lambda functions.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_parameters_per_function": {
+        "title": "Maximum parameters per function",
+        "description": "The maximum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_parameters_per_function": {
+        "title": "Minimum parameters per function",
+        "description": "The minimum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_parameters_per_function": {
+        "title": "Median parameters per function",
+        "description": "The median number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_parameters_per_function": {
+        "title": "Mean parameters per function",
+        "description": "The mean number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_complexity_per_function": {
+        "title": "Maximum complexity per function",
+        "description": "The maximum complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_complexity_per_function": {
+        "title": "Minimum complexity per function",
+        "description": "The minimum number of complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_complexity_per_function": {
+        "title": "Mean complexity per function",
+        "description": "The mean complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_complexity_per_function": {
+        "title": "Median complexity per function",
+        "description": "The median complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_rloc_per_function": {
+        "title": "Maximum real lines of code in a function",
+        "description": "The maximum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_rloc_per_function": {
+        "title": "Minimum real lines of code in a function",
+        "description": "The minimum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_rloc_per_function": {
+        "title": "Mean real lines of code in a function",
+        "description": "The mean number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_rloc_per_function": {
+        "title": "Median real lines of code in a function",
+        "description": "The median number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_method": {
+        "title": "Long Method",
+        "description": "Code smell showing the number of functions with more than 10 real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_parameter_list": {
+        "title": "Long Parameter List",
+        "description": "Code smell showing the number of functions with more than 4 parameters",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "excessive_comments": {
+        "title": "Excessive Comments",
+        "description": "Code smell showing whether a file has more than 10 comment lines",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_ratio": {
+        "title": "Comment Ratio",
+        "description": "The ratio of comment lines to real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": 0,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "message_chains": {
+        "title": "Message Chains",
+        "description": "Code smell showing occurrences of method call chains with 4 or more consecutive calls suggesting tight coupling",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      }
+    },
+    "blacklist": []
+  },
+  "checksum": "ffe6138f23b8c3aaddda33acf0630785"
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.pas
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.pas
@@ -1,0 +1,31 @@
+unit DelphiSample;
+
+{ Delphi sample unit demonstrating common metric-bearing constructs. }
+
+interface
+
+procedure Greet(const Name: string);
+function Sum(Values: array of Integer): Integer;
+
+implementation
+
+// Greets the user by printing a friendly message.
+procedure Greet(const Name: string);
+begin
+  if Name = '' then
+    WriteLn('Hello, world!')
+  else
+    WriteLn('Hello, ' + Name + '!');
+end;
+
+(* Sums the elements of an integer array. *)
+function Sum(Values: array of Integer): Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := Low(Values) to High(Values) do
+    Result := Result + Values[I];
+end;
+
+end.

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
@@ -30,5 +30,6 @@ enum class FileExtension(
     RUBY(".rb"),
     SWIFT(".swift"),
     BASH(".sh"),
-    VUE(".vue")
+    VUE(".vue"),
+    DELPHI(".pas", setOf(".dpr"))
 }

--- a/gh-pages/_docs/05-parser/05-unified.md
+++ b/gh-pages/_docs/05-parser/05-unified.md
@@ -34,6 +34,7 @@ CodeCharta. It generates either a cc.json or a csv file.
 | Swift        | .swift                                 |
 | Bash         | .sh                                    |
 | Vue          | .vue                                   |
+| Delphi       | .pas, .dpr                             |
 
 ## Supported Metrics
 
@@ -241,6 +242,12 @@ contribute to complexity:
   `computed_getter`, `computed_setter`
 - **Logical operators**: `conjunction_expression`, `disjunction_expression`
 
+#### Delphi (.pas, .dpr)
+
+- **Control flow**: `if`, `ifElse`, `for`, `foreach`, `while`, `case`, `caseCase`, `repeat`, `try`, `exceptionHandler`
+- **Functions**: `defProc` (procedure/function implementation), `lambda`
+- **Logical operators**: `kAnd`, `kOr`, `kXor` in `exprBinary`
+
 ### Comment Lines
 
 Comment lines are counted based on language-specific comment syntax:
@@ -257,6 +264,7 @@ Comment lines are counted based on language-specific comment syntax:
 - **Ruby**: `comment`
 - **Swift**: `comment`, `multiline_comment`
 - **Bash**: `comment`
+- **Delphi**: `comment` (covers `//` line, `{ }` brace, and `(* *)` star comments)
 
 ### Number of Functions
 
@@ -334,6 +342,11 @@ Function counting identifies different types of function definitions per languag
 
 - **Functions**: `function_declaration`, `init_declaration`, `deinit_declaration`, `computed_getter`, `computed_setter`
 
+#### Delphi (.pas, .dpr)
+
+- **Functions**: `defProc` (procedure/function implementation in the `implementation` section). Forward declarations in the `interface` section
+  (`declProc`) are not counted, and `lambda` contributes only to complexity.
+
 ### Lines of Code (LOC)
 
 LOC is calculated as the total number of lines in the file, including empty lines and comments. This metric is language-independent and
@@ -366,6 +379,7 @@ Parameters per function counts the number of parameters declared for each functi
 - **Ruby**: `identifier` parameters
 - **Swift**: `parameter`
 - **Bash**: Parameters are counted from function definitions
+- **Delphi**: `declArg`
 
 ### Message Chains
 
@@ -440,6 +454,12 @@ Message chains are not applicable to Bash as it does not support method chaining
 
 - **Chain nodes**: `call_expression`, `navigation_expression`
 - **Call nodes**: `call_expression`
+
+#### Delphi (.pas, .dpr)
+
+- **Chain nodes**: `exprCall`, `exprDot`
+- **Call nodes**: `exprCall`, `exprDot` (paren-less `Obj.M1.M2.M3.M4` chains). When `exprDot` is wrapped in `exprCall` (e.g.
+  `Obj.M1().M2().M3().M4()`), only `exprCall` counts, preventing double-counting of message-chain calls.
 
 ### Code Smells
 

--- a/plans/add-delphi-support.md
+++ b/plans/add-delphi-support.md
@@ -1,0 +1,220 @@
+---
+name: add-delphi-support
+issue:
+state: progress
+version:
+---
+
+## Goal
+
+Wire up the `Language.DELPHI` support added to TreesitterLibrary so the UnifiedParser
+discovers and parses `.pas` and `.dpr` files (metrics only). Validate locally via a
+Gradle composite build; the JitPack version bump is out of scope and tracked as a
+follow-up.
+
+## Context
+
+- Delphi is fully implemented in TreesitterLibrary (`languages/delphi/DelphiDefinition.kt`)
+  but only present in the `[Unreleased]` section of TSE's CHANGELOG. Latest TSE tag is
+  `v0.6.0`; codecharta currently pins `v0.4.1`.
+- Repository directory casing: the sibling repo on disk is `TreesitterLibrary`
+  (lowercase second `s`). Case-sensitive filesystems (Linux CI) require the exact
+  spelling.
+- TSE registers Delphi as `DELPHI(primaryExtension = ".pas", otherExtensions = setOf(".dpr"))`.
+- Integration shape mirrors completed `plans/add-tsx-support.md`: extend
+  `FileExtension`, register a collector, add an adapter mapping, plus tests, golden
+  fixtures, docs, and changelog.
+- A Delphi-specific `CalculationConfig` quirk (avoid double-counting message-chain
+  calls when `exprDot` sits under `exprCall`) is already handled inside TSE's
+  `DelphiDefinition` — no codecharta-side handling needed.
+
+## Out of Scope
+
+- Bumping `UnifiedParser/build.gradle.kts` from `TreeSitterExcavationSite:v0.4.1` to a
+  Delphi-enabled tag. Composite build supersedes JitPack locally; production bump is
+  a follow-up after TSE cuts the next release.
+- Wiring TSE's extraction or dependency APIs for Delphi. Codecharta's UnifiedParser
+  consumes only the metrics API today, and this plan keeps that scope.
+- Visualization changes. The `.cc.json` output format is unchanged.
+
+## Architecture / Touch-Points
+
+```
+analysis/
+├── model/.../FileExtension.kt                                       (add DELPHI)
+├── analysers/parsers/UnifiedParser/
+│   ├── build.gradle.kts                                             (composite-build edit, REVERT)
+│   └── src/
+│       ├── main/.../metriccollectors/
+│       │   ├── AvailableCollectors.kt                               (register DELPHI)
+│       │   └── TreeSitterAdapter.kt                                 (FileExtension.DELPHI -> Language.DELPHI)
+│       └── test/
+│           ├── kotlin/.../metriccollectors/
+│           │   ├── DelphiCollectorTest.kt                           (NEW)
+│           │   └── TreeSitterAdapterTest.kt                         (extend mappings/supported assertions)
+│           └── resources/languageSamples/
+│               ├── delphiSample.pas                                 (NEW fixture)
+│               └── delphiSample.cc.json                             (NEW golden file)
+├── settings.gradle.kts                                              (composite-build edit, REVERT)
+└── CHANGELOG.md                                                     (add [unreleased] entry)
+
+analysers/parsers/UnifiedParser/README.md                            (supported-languages row)
+gh-pages/_docs/05-parser/05-unified.md                               (supported-languages row)
+```
+
+Test pattern reference: `analysers/parsers/UnifiedParser/src/test/kotlin/.../metriccollectors/JavaCollectorTest.kt`
+mirrors what `DelphiCollectorTest.kt` should look like.
+
+## Tasks
+
+### 1. Phase 1 — Local composite build (uncommitted scaffolding)
+
+Wire codecharta's Gradle build to consume TreesitterLibrary HEAD locally so Delphi is
+on the classpath while iterating. **All edits in this phase must be reverted in
+Phase 5 before staging any commit.**
+
+- File: `analysis/settings.gradle.kts` — add `includeBuild("../../TreesitterLibrary")`
+  (path relative to `analysis/`; adjust if your layout differs. Note the casing —
+  directory is `TreesitterLibrary`, not `TreeSitterLibrary`)
+- File: `analysis/analysers/parsers/UnifiedParser/build.gradle.kts` — replace
+  `implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.4.1")` with
+  `implementation("de.maibornwolff.treesitter.excavationsite:treesitter-excavationsite")`
+  (composite-build coordinate, per `TreeSitterLibrary/.claude/rules/dependency-migration.md`)
+- Verify the composite build resolves and `Language.DELPHI` is reachable:
+  ```bash
+  cd analysis && ./gradlew :analysers:parsers:UnifiedParser:compileKotlin
+  ```
+
+### 2. Phase 2 — Wire Delphi into UnifiedParser
+
+Three small, mechanical edits matching the TSX precedent.
+
+- File: `analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt`
+  - Add `DELPHI(".pas", setOf(".dpr"))` (placement next to other source-language entries)
+- File: `analysis/analysers/parsers/UnifiedParser/src/main/kotlin/.../metriccollectors/AvailableCollectors.kt`
+  - Add `DELPHI(FileExtension.DELPHI, { TreeSitterLibraryCollector(Language.DELPHI) })`
+- File: `analysis/analysers/parsers/UnifiedParser/src/main/kotlin/.../metriccollectors/TreeSitterAdapter.kt`
+  - Add `FileExtension.DELPHI -> Language.DELPHI` to `getLanguageForExtension(...)`
+
+### 3. Phase 3 — Tests & golden fixtures
+
+Mirror `JavaCollectorTest` for the unit-level collector test; mirror existing
+`languageSamples/*` for the parameterized end-to-end test.
+
+- New file: `analysis/analysers/parsers/UnifiedParser/src/test/kotlin/.../metriccollectors/DelphiCollectorTest.kt`
+  - Construct `TreeSitterLibraryCollector(Language.DELPHI)`
+  - At minimum: `should count if statements for complexity`, `should count comments for comment_lines`,
+    `should count procedure declarations for number_of_functions`, `should detect message chains`
+    (the `exprDot`/`exprCall` quirk in `DelphiDefinition` is worth one targeted assertion to
+    confirm chains aren't double-counted)
+- Update: `analysis/analysers/parsers/UnifiedParser/src/test/kotlin/.../metriccollectors/TreeSitterAdapterTest.kt`
+  - Add `FileExtension.DELPHI to Language.DELPHI` in `should map all supported FileExtensions to Languages`
+  - Add `FileExtension.DELPHI` to the `supportedExtensions` list in
+    `should return true for supported FileExtensions`
+- New fixture: `analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.pas`
+  - Small but representative unit: a `unit` header, one `procedure`, one `function`, one `if`/`for`,
+    one `//` comment, one `{ }` comment, one `'...'` string. Use `.pas` (typical case);
+    `.dpr` is covered transitively by the FileExtension entry.
+- New golden: `analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/delphiSample.cc.json`
+  - Generate by running the parameterized test once and capturing actual output, then commit.
+    Verify metric values are sensible (compare against `pythonSample.cc.json` shape).
+- Update: `analysis/analysers/parsers/UnifiedParser/src/test/kotlin/.../UnifiedParserTest.kt`
+  - Add `Arguments.of("delphi", ".pas")` to `provideSupportedLanguages()`
+
+### 4. Phase 4 — Docs & changelog
+
+- File: `analysis/analysers/parsers/UnifiedParser/README.md`
+  - Add row to "Supported Languages" table: `| Delphi       | .pas, .dpr                             |`
+- File: `gh-pages/_docs/05-parser/05-unified.md`
+  - Add the same row to its "Supported Languages" table (around line 17–36)
+  - Add a `#### Delphi (.pas, .dpr)` subsection to each of the five per-language
+    sections: **Complexity**, **Comment Lines**, **Number of Functions**, **Parameters
+    per Function**, **Message Chains**. List the AST node types lifted directly
+    from `TreesitterLibrary/.../languages/delphi/DelphiMetricMapping.kt` as the
+    source of truth (e.g. `if`, `ifElse`, `for`, `foreach`, `while`, `case`,
+    `caseCase`, `repeat`, `try`, `exceptionHandler` for control flow; binary
+    `kAnd`/`kOr`/`kXor` for logical operators; `procedure`/`function`-shaped node
+    types for functions). Match the formatting of the existing Swift/Kotlin
+    subsections.
+- File: `analysis/CHANGELOG.md`
+  - Under `## [unreleased]` → `### Added 🚀`, add:
+    `- Add Delphi support to UnifiedParser (.pas, .dpr)`
+- Verify whether the root-level `/codecharta/CHANGELOG.md` also needs touching.
+  Precedent (`plans/add-tsx-support.md`) does not mention it, and recent feature
+  entries (e.g. Swift, Objective-C) live only in `analysis/CHANGELOG.md`. Default:
+  skip the root CHANGELOG. Touch it only if a maintainer requests it during review.
+
+### 5. Phase 5 — Revert composite-build scaffolding
+
+Before staging any commit: revert the two Phase 1 edits so codecharta keeps consuming
+TSE via JitPack at `v0.4.1`. **Do not commit until reverted.**
+
+- File: `analysis/settings.gradle.kts` — remove `includeBuild("../../TreesitterLibrary")`
+- File: `analysis/analysers/parsers/UnifiedParser/build.gradle.kts` — restore
+  `implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.4.1")`
+- Confirm via `git diff -- analysis/settings.gradle.kts analysis/analysers/parsers/UnifiedParser/build.gradle.kts`
+  that no composite-build artifacts remain.
+
+**Follow-up (NOT covered by this plan)**: cut TSE `v0.7.0` (or equivalent tag
+containing Delphi), then bump
+`UnifiedParser/build.gradle.kts:12` to that tag. Without that follow-up the changes
+in this plan compile locally but will fail on CI.
+
+## Steps
+
+- [x] **Phase 1**: Add `includeBuild` to `analysis/settings.gradle.kts` (uncommitted)
+- [x] **Phase 1**: Swap UnifiedParser dependency to composite-build coordinate (uncommitted)
+- [x] **Phase 1**: Bump root `analysis/build.gradle.kts` `jvmToolchain(17)` → `jvmToolchain(21)` (uncommitted; required because TSE 0.6.0 targets JVM 21)
+- [x] **Phase 1**: `./gradlew :analysers:parsers:UnifiedParser:compileKotlin` succeeds with `Language.DELPHI` reachable
+- [x] **Phase 2**: Add `DELPHI` to `FileExtension`
+- [x] **Phase 2**: Register `DELPHI` in `AvailableCollectors`
+- [x] **Phase 2**: Add Delphi mapping in `TreeSitterAdapter`
+- [x] **Phase 3**: Write `DelphiCollectorTest` (covers complexity, comments, functions, message chains)
+- [x] **Phase 3**: Add `FileExtension.DELPHI to Language.DELPHI` to `TreeSitterAdapterTest.should map all supported FileExtensions to Languages`
+- [x] **Phase 3**: Add `FileExtension.DELPHI` to `TreeSitterAdapterTest.should return true for supported FileExtensions`
+- [x] **Phase 3**: Add `delphiSample.pas` fixture
+- [x] **Phase 3**: Add `delphiSample.cc.json` golden file (captured from first run)
+- [x] **Phase 3**: Add `("delphi", ".pas")` to `UnifiedParserTest.provideSupportedLanguages`
+- [x] **Phase 3**: `./gradlew :analysers:parsers:UnifiedParser:test` is green
+- [x] **Phase 3**: `./gradlew :analysers:parsers:UnifiedParser:ktlintCheck` is clean
+- [x] **Phase 4**: Update `analysers/parsers/UnifiedParser/README.md` languages table
+- [x] **Phase 4**: Update `gh-pages/_docs/05-parser/05-unified.md` languages table
+- [x] **Phase 4**: Add Delphi subsection under **Complexity** in `gh-pages/_docs/05-parser/05-unified.md`
+- [x] **Phase 4**: Add Delphi subsection under **Comment Lines** in `gh-pages/_docs/05-parser/05-unified.md`
+- [x] **Phase 4**: Add Delphi subsection under **Number of Functions** in `gh-pages/_docs/05-parser/05-unified.md`
+- [x] **Phase 4**: Add Delphi subsection under **Parameters per Function** in `gh-pages/_docs/05-parser/05-unified.md`
+- [x] **Phase 4**: Add Delphi subsection under **Message Chains** in `gh-pages/_docs/05-parser/05-unified.md`
+- [x] **Phase 4**: Add `[unreleased]` Added entry to `analysis/CHANGELOG.md`
+- [-] **Phase 5**: Revert `analysis/settings.gradle.kts` composite-build edit
+- [ ] **Phase 5**: Revert `UnifiedParser/build.gradle.kts` to JitPack `v0.4.1`
+- [x] **Phase 5**: Revert `analysis/build.gradle.kts` `jvmToolchain(21)` → `jvmToolchain(17)` (TSE bumped down to 17 upstream)
+- [ ] **Phase 5**: `git diff` shows no composite-build artifacts in tracked files
+
+## Manual Verification
+
+(Run after Phase 3 succeeds, before reverting in Phase 5.)
+
+- [ ] Drop a real-world `.pas` file into a temp directory and run:
+  ```bash
+  cd analysis && ./gradlew installDist
+  ./build/install/codecharta-analysis/bin/ccsh unifiedparser <temp-dir> -o /tmp/delphi.cc.json --not-compressed
+  ```
+  Open the output and confirm: `complexity`, `loc`, `rloc`, `comment_lines`,
+  `number_of_functions`, and per-function aggregations are populated and non-zero
+  for files with code.
+- [ ] Run the same against a `.dpr` project file and confirm it is also picked up.
+
+## Notes
+
+- Test pattern reference: `JavaCollectorTest.kt` is the canonical shape for new
+  collector tests. Use `Assertions.assertThat(result.attributes[AvailableFileMetrics.X.metricName])`
+  rather than raw string keys.
+- Golden-file convention: existing `*Sample.cc.json` files are pretty-printed and
+  use deterministic ordering. After capturing the first run, eyeball the metric
+  values against the source rather than blindly committing.
+- The `exprDot`/`exprCall` chain quirk lives in TSE's `DelphiDefinition`; if the
+  message-chain assertion in `DelphiCollectorTest` fails, the bug is upstream in TSE,
+  not in codecharta.
+- If TSE's primary class for `.pas` parse errors (the asm/IFDEF recovery path noted
+  in TSE's CHANGELOG) ever surfaces as a flaky metric, capture the offending file
+  and report upstream — codecharta should not work around TSE bugs locally.


### PR DESCRIPTION
Adds Delphi (.pas, .dpr) as a supported language and upgrades TreeSitterExcavationSite to v0.7.0 via JitPack.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs
