### PR TITLE
feat(visualization): add label size slider for floating labels

### DIFF
--- a/plans/floating-label-size-slider.md
+++ b/plans/floating-label-size-slider.md
@@ -1,0 +1,192 @@
+---
+name: Floating Label Size Slider
+issue: -
+state: todo
+version: 1
+date: 2026-05-04
+git_commit: 836c9ccb1f1c05083add09c98525c0b5afd4f66a
+branch: worktree-bigger-labels
+---
+
+## Goal
+
+Add a "Label Size" slider in the labels modal that scales the floating CSS2D labels (name + metric value) by a single multiplier (0.75×–2.5×, default 1.0×) so screenshots remain legible. The setting persists in scenarios. Floor labels are out of scope.
+
+## Current State
+
+- Floating labels are HTML built in `LabelElement` (`visualization/app/codeCharta/features/labelSettings/services/labelElement.ts:74-93`) with hardcoded `font-size: 12px` (name) and `10px` (metric / "+N more" badge).
+- The labels modal lives in `LabelSettingsPanelComponent` (`features/labelSettings/components/labelSettingsPanel/`) and already follows a slider pattern for "Top Labels" we can mirror.
+- Label collisions use live `getBoundingClientRect()` in `labelCollision.service.ts`, so larger fonts auto-grow the rects with no constant changes needed.
+- Floor labels (`floorLabelDrawer.ts`) compute their own font from map width — we will not touch them.
+
+## Desired End State
+
+Opening the labels modal shows a new "Label Size" slider directly under "Top Labels". Dragging it immediately rescales both the name text and metric text of all visible floating labels (and the "+N more" badge) proportionally, without re-creating labels. The selected value is saved with scenarios under the existing `labelsAndFolders` section, restored on reload, and reset by the "Reset label settings" button.
+
+## What We're NOT Doing
+
+- Not changing floor labels.
+- Not introducing per-line size controls (single multiplier only).
+- Not changing collision/connector constants (rects are live-measured).
+- Not adding a separate "label box padding" / "background opacity" control.
+
+## UI Mockup
+
+```
+┌─ Labels ───────────────────┐
+│ Top Labels                 │
+│ [▬▬▬○─────] [10]           │
+│                            │
+│ Label Size            NEW  │
+│ [▬▬▬○─────] [1.0×]         │
+│                            │
+│ [Height][ Color ]          │
+│ ☐ Show node names          │
+│ ☐ Show metric values       │
+│ ☐ Group overlapping labels │
+│ [ Reset label settings ]   │
+└────────────────────────────┘
+```
+
+Slider: range `0.75–2.5`, step `0.25`, numeric input shows `× 1.0`, debounced (matches Top Labels pattern).
+
+## Architecture and Code Reuse
+
+Add the new state slice exactly the way `amountOfTopLabels` is wired up (action / reducer / selector / service / store / panel binding). Implement the visual scaling by writing `font-size` styles into `LabelElement` based on a base size multiplied by `labelSize`. The `name` span and `metric/badge` span keep their proportional ratio (12 : 10).
+
+Affected files:
+
+- `visualization/app/codeCharta/state/store/appSettings/labelSize/` *(new)*
+  - `labelSize.actions.ts` — `setLabelSize` action mirroring `setAmountOfTopLabels`
+  - `labelSize.reducer.ts` — `defaultLabelSize = 1`, `labelSize` reducer
+  - `labelSize.selector.ts` — `labelSizeSelector`
+  - `labelSize.reducer.spec.ts` — reducer test
+- `visualization/app/codeCharta/state/store/appSettings/`
+  - `appSettings.reducer.ts` — register reducer + default
+  - `appSettings.actions.ts` — append `setLabelSize` to action union
+- `visualization/app/codeCharta/codeCharta.model.ts` — add `labelSize: number` to `AppSettings`
+- `visualization/app/codeCharta/features/labelSettings/`
+  - `selectors/labelSettings.selectors.ts` — re-export `labelSizeSelector`
+  - `stores/labelSize.store.ts` *(new)* — mirror `amountOfTopLabels.store.ts`
+  - `services/labelSize.service.ts` *(new)* — mirror `amountOfTopLabels.service.ts`
+  - `services/label.constants.ts` — add `MIN_LABEL_SIZE = 0.75`, `MAX_LABEL_SIZE = 2.5`, `LABEL_SIZE_STEP = 0.25`, `BASE_NAME_FONT_PX = 12`, `BASE_METRIC_FONT_PX = 10`, `BASE_BADGE_FONT_PX = 10`
+  - `services/labelElement.ts` — accept `labelSize` and apply scaled font sizes on `this.content` (name span inherits) and overridden metric span / badge
+  - `services/labelCreation.service.ts` — read `appSettings.labelSize` (already destructured from `stateAccessStore.getValue()`) and pass into `new LabelElement(...)`
+  - `stores/labelSize.store.ts` *(new)* + `stores/labelSize.store.spec.ts` *(new)*
+  - `components/labelSettingsPanel/labelSettingsPanel.component.html` — new slider markup under Top Labels
+  - `components/labelSettingsPanel/labelSettingsPanel.component.ts` — bind signal + debounced setter; add `appSettings.labelSize` to `resetSettingsKeys`
+  - `components/labelSettingsPanel/labelSettingsPanel.component.spec.ts` — slider tests
+  - `facade.ts` — expose `labelSize$()` / `setLabelSize()`
+- `visualization/app/codeCharta/state/effects/renderCodeMapEffect/actionsRequiringRerender.ts` — add `setLabelSize` (re-render rebuilds labels with new sizes)
+- `visualization/app/codeCharta/services/loadInitialFile/loadInitialFile.service.ts` — add `case "labelSize"` in `mapAppSettingToAction` switch
+- `visualization/app/codeCharta/features/scenarios/`
+  - `model/scenario.model.ts` — add `labelSize: number` to `LabelsAndFoldersSection`
+  - `services/scenarioApplier.service.ts` — propagate in `buildLabelsAndFoldersPatch`
+  - `services/scenarios.service.ts` — capture in `getLabelsAndFoldersSection`
+  - `stores/scenarioIndexedDB.spec.ts`, `components/applyScenarioDialog/applyScenarioDialog.component.spec.ts`, `components/scenarioListDialog/scenarioListDialog.component.spec.ts`, `services/scenarios.service.spec.ts`, `services/scenarioApplier.service.spec.ts` — extend test fixtures
+- `visualization/app/codeCharta/util/dataMocks.ts` — add `labelSize: 1` to the two `appSettings` mocks
+- `visualization/app/codeCharta/util/settingsHelper.spec.ts` — extend `appSettings` fixtures (lines 30, 38) with `labelSize: 1`
+- `visualization/app/codeCharta/ui/resetSettingsButton/getPartialDefaultState.spec.ts` — add a test that resetting `appSettings.labelSize` returns the static default `1`
+
+Files intentionally NOT touched (verified):
+- `features/labelSettings/stores/stateAccess.store.ts` — its special-case for `amountOfTopLabels` overwrites the dynamic reset value with the static default. `labelSize` has no dynamic reset path (`getPartialDefaultState` already returns the static default), so no override needed here.
+- `ui/codeMap/codeMap.render.service.ts` — uses `amountOfTopLabels` for top-N slicing; `labelSize` is read by `LabelElement` directly via `LabelCreationService`, no render-service plumbing required.
+
+## Performance Considerations
+
+- Setting is applied at label creation; changing the slider triggers `setLabelSize` which is part of `actionsRequiringRerender` → existing render pipeline rebuilds labels (same path as Top Labels). Live-rect collision detection adapts automatically. Debounced input (400 ms, matching `amountOfTopLabels`) prevents thrashing.
+
+## Migration Notes
+
+- `labelSize` defaults to `1` for any scenario / state read prior to this change. Reducer default plus the initial-load switch case handle missing values by simply not dispatching, falling back to default state. No data migration required.
+
+---
+
+## Phase 1: State plumbing
+
+Add the new state slice and wire it through model, reducer, actions, selector, store, service, facade, rerender effect, initial-load service, scenario applier/service, scenario model, and dataMocks.
+
+**Tasks**:
+- [x] Create `state/store/appSettings/labelSize/labelSize.actions.ts` with `setLabelSize`.
+- [x] Create `state/store/appSettings/labelSize/labelSize.reducer.ts` with `defaultLabelSize = 1` and `labelSize` reducer using `setState` factory.
+- [x] Create `state/store/appSettings/labelSize/labelSize.selector.ts` with `labelSizeSelector`.
+- [x] Register `labelSize` in `appSettings.reducer.ts` (combiner + `defaultAppSettings`).
+- [x] Add `setLabelSize` to `appSettings.actions.ts` `appSettingsActions[]`.
+- [x] Add `labelSize: number` to `AppSettings` interface in `codeCharta.model.ts`.
+- [x] Re-export `labelSizeSelector` from `features/labelSettings/selectors/labelSettings.selectors.ts`.
+- [x] Add `LabelSizeStore` mirroring `AmountOfTopLabelsStore`.
+- [x] Add `LabelSizeService` mirroring `AmountOfTopLabelsService`.
+- [x] Extend `LabelSettingsFacade` with `labelSize$()` / `setLabelSize()`.
+- [x] Add `setLabelSize` to `actionsRequiringRerender`.
+- [x] Add `case "labelSize"` to `loadInitialFile.service.ts:mapAppSettingToAction` (also added to `optionalAppSettingsKeys` so missing-from-saved-state does not warn).
+- [x] Extend `LabelsAndFoldersSection` in `scenario.model.ts` with `labelSize: number`.
+- [x] Update `scenarios.service.ts:getLabelsAndFoldersSection` to capture `appSettings.labelSize`.
+- [x] Update `scenarioApplier.service.ts:buildLabelsAndFoldersPatch` to propagate `labelSize`.
+- [x] Add `labelSize: 1` to both `appSettings` mocks in `util/dataMocks.ts` (also fixed pre-existing missing `groupLabelCollisions: false`).
+- [x] Add `labelSize: 1` to the two `appSettings` fixtures in `util/settingsHelper.spec.ts`.
+- [x] Add `labelSize.store.spec.ts` mirroring `amountOfTopLabels.store.spec.ts`.
+- [x] Add a test in `getPartialDefaultState.spec.ts` covering `appSettings.labelSize` reset to `1`.
+- [x] Update existing scenario test fixtures so their `labelsAndFolders` objects include `labelSize` (also added pre-existing missing `labelMode`/`groupLabelCollisions`).
+
+**Automated Verification**:
+- [x] `labelSize.reducer.spec.ts` passes (new file: asserts `setLabelSize` updates state, default is `1`).
+- [x] `npm test` passes (350 suites, 2014 tests; no regressions in scenario/applier/loadInitialFile suites).
+- [x] `npm run build` succeeds (`AppSettings` exhaustive switches still compile).
+- [x] `npm run format:check` passes.
+
+---
+
+## Phase 2: Apply size to floating labels
+
+Make `LabelElement` use the multiplier and ensure it is read from state at creation time.
+
+**Tasks**:
+- [x] Add `MIN_LABEL_SIZE = 0.75`, `MAX_LABEL_SIZE = 2.5`, `LABEL_SIZE_STEP = 0.25`, `BASE_NAME_FONT_PX = 12`, `BASE_METRIC_FONT_PX = 10`, `BASE_BADGE_FONT_PX = 10` to `label.constants.ts`.
+- [x] Change `LabelElement` constructor to accept `labelSize: number`. `buildContentStyles()` sets `font-size: ${BASE_NAME_FONT_PX * labelSize}px` on `this.content`. Metric span and badge use scaled `${BASE_METRIC_FONT_PX * labelSize}px` / `${BASE_BADGE_FONT_PX * labelSize}px`.
+- [x] Update `LabelCreationService.addLeafLabel` to destructure `labelSize` from `appSettings` and pass it into `new LabelElement(nameText, metricText, labelSize)`.
+- [x] Extend `labelCreation.service.spec.ts` to cover the multiplier (label at 2× has `font-size: 24px` on content; metric span has `font-size: 20px`) plus a default-size baseline.
+
+**Automated Verification**:
+- [x] `labelCreation.service.spec.ts` passes (new test: creates a label at 2× and asserts inline `font-size` reflects `24px` on name and `20px` on metric span).
+- [x] `labelCollision.service.spec.ts` and existing label-related suites pass (5 suites, 43 tests).
+- [x] `npm test` passes overall.
+
+---
+
+## Phase 3: Slider UI in labels modal
+
+Wire the visible slider, mirror the existing Top Labels pattern (range + numeric input, debounced).
+
+**Tasks**:
+- [x] In `labelSettingsPanel.component.html`, add a slider block under Top Labels with `min="0.75" max="2.5" step="0.25"`, a numeric input with `×` suffix label, and `title="Scale floating label font size"`.
+- [x] In `labelSettingsPanel.component.ts`, add `labelSize` signal, `applyDebouncedLabelSize` (400 ms), `handleLabelSizeInput(event)` parsing as float, clamping to `[MIN_LABEL_SIZE, MAX_LABEL_SIZE]`, and snapping to `LABEL_SIZE_STEP` (parseNumberInput uses parseInt and is unsuitable for fractional values).
+- [x] Add `"appSettings.labelSize"` to `resetSettingsKeys`.
+- [x] Extend `labelSettingsPanel.component.spec.ts` with: (a) slider rendered with default value, (b) input dispatches `setLabelSize`, (c) clamp test, (d) reset button dispatches with default value.
+
+**Automated Verification**:
+- [x] New panel tests pass (slider visible, dispatch, clamp, reset).
+- [x] `npm test` passes (350 suites, 2020 tests).
+- [x] `npm run build` passes.
+- [x] `npm run format:check` passes from repo root.
+
+**Manual Verification**:
+- [ ] Open the labels modal in a dev build (`npm run dev`), drag "Label Size" between 0.75× and 2.5×, confirm floating labels resize live (name + metric + "+N more" badge) and remain legible on a screenshot at 2×.
+- [ ] Switch between Height / Color label modes with `labelSize = 2.0` and confirm both modes pick up the new size on next render.
+- [ ] Save a scenario at `labelSize = 2.0`, reload page, re-apply scenario, confirm slider reads `2.0×` and labels render large.
+- [ ] Click "Reset label settings", confirm slider snaps back to `1.0×` and labels return to default size.
+
+---
+
+## Steps
+
+- [x] Complete Phase 1: State plumbing
+- [x] Complete Phase 2: Apply size to floating labels
+- [x] Complete Phase 3: Slider UI in labels modal (manual verification still pending)
+
+## References
+
+- Pattern mirror: `state/store/appSettings/amountOfTopLabels/` (reducer/actions/selector)
+- Pattern mirror: `features/labelSettings/services/amountOfTopLabels.service.ts`, `stores/amountOfTopLabels.store.ts`
+- UI pattern source: `features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.html` (Top Labels slider, lines 1–11)
+- Render pipeline trigger: `state/effects/renderCodeMapEffect/actionsRequiringRerender.ts`
+- Scenario integration: `features/scenarios/model/scenario.model.ts:34` (`LabelsAndFoldersSection`)

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+- **Label Size slider**: New slider in the Label Settings panel scales floating label text (name, metric value, and "+N more" badge) between 0.75× and 2.5×. The setting is preserved in scenarios.
+
+### Fixed 🐞
+
+- Fix `amountOfEdgePreviews` being silently overwritten when restoring saved state — it incorrectly dispatched the top-labels action instead.
+
 ## [1.142.0] - 2026-03-16
 
 ### Added 🚀

--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -143,6 +143,7 @@ export interface DynamicSettings extends PrimaryMetrics {
 
 export interface AppSettings {
     amountOfTopLabels: number
+    labelSize: number
     amountOfEdgePreviews: number
     edgeHeight: number
     scaling: Scaling

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.html
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.html
@@ -10,6 +10,18 @@
     </div>
 </div>
 
+<div title="Scale floating label font size">
+    <span class="text-sm">Label Size</span>
+    <div class="flex items-center gap-2">
+        <input type="range" class="range range-primary range-sm flex-1"
+            [min]="MIN_LABEL_SIZE" [max]="MAX_LABEL_SIZE" [step]="LABEL_SIZE_STEP" [value]="labelSize()"
+            (input)="handleLabelSizeInput($event)" />
+        <input type="number" class="input input-sm input-bordered w-16 text-center"
+            [min]="MIN_LABEL_SIZE" [max]="MAX_LABEL_SIZE" [step]="LABEL_SIZE_STEP" [value]="labelSize()"
+            (input)="handleLabelSizeInput($event)" />
+    </div>
+</div>
+
 <div class="join w-full" aria-label="Label mode">
     <input type="radio" name="labelMode"
         class="join-item btn btn-sm flex-1"

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.spec.ts
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.spec.ts
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/angular"
 import userEvent from "@testing-library/user-event"
 import { setColorLabels } from "../../../../state/store/appSettings/colorLabels/colorLabels.actions"
 import { setLabelMode } from "../../../../state/store/appSettings/labelMode/labelMode.actions"
+import { setLabelSize } from "../../../../state/store/appSettings/labelSize/labelSize.actions"
+import { fireEvent } from "@testing-library/angular"
 import { LabelSettingsPanelComponent } from "./labelSettingsPanel.component"
 import { Store, StoreModule } from "@ngrx/store"
 import { appReducers, setStateMiddleware } from "../../../../state/store/state.manager"
@@ -150,5 +152,67 @@ describe("LabelSettingsPanelComponent", () => {
 
         const positiveCheckbox = screen.getByRole("checkbox", { name: "positive color label" }) as HTMLInputElement
         expect(positiveCheckbox.disabled).toBe(false)
+    })
+
+    describe("Label Size slider", () => {
+        const flushDebounce = () => new Promise(resolve => setTimeout(resolve, 500))
+
+        it("should render the Label Size slider with the default value", async () => {
+            // Arrange & Act
+            await render(LabelSettingsPanelComponent)
+
+            // Assert
+            const sliderContainer = screen.getByTitle("Scale floating label font size")
+            const sliders = sliderContainer.querySelectorAll("input")
+            expect(sliders).toHaveLength(2)
+            expect((sliders[0] as HTMLInputElement).value).toBe("1")
+            expect((sliders[1] as HTMLInputElement).value).toBe("1")
+        })
+
+        it("should dispatch setLabelSize when the slider value changes", async () => {
+            // Arrange
+            await render(LabelSettingsPanelComponent)
+            const dispatchSpy = jest.spyOn(TestBed.inject(Store), "dispatch")
+            const sliderContainer = screen.getByTitle("Scale floating label font size")
+            const rangeSlider = sliderContainer.querySelectorAll("input")[0] as HTMLInputElement
+
+            // Act
+            fireEvent.input(rangeSlider, { target: { value: "1.75" } })
+            await flushDebounce()
+
+            // Assert
+            expect(dispatchSpy).toHaveBeenCalledWith(setLabelSize({ value: 1.75 }))
+        })
+
+        it("should clamp values above MAX_LABEL_SIZE", async () => {
+            // Arrange
+            await render(LabelSettingsPanelComponent)
+            const dispatchSpy = jest.spyOn(TestBed.inject(Store), "dispatch")
+            const sliderContainer = screen.getByTitle("Scale floating label font size")
+            const numberInput = sliderContainer.querySelectorAll("input")[1] as HTMLInputElement
+
+            // Act
+            fireEvent.input(numberInput, { target: { value: "10" } })
+            await flushDebounce()
+
+            // Assert
+            expect(dispatchSpy).toHaveBeenCalledWith(setLabelSize({ value: 2.5 }))
+        })
+
+        it("should reset labelSize to its default when reset button is clicked", async () => {
+            // Arrange
+            const { detectChanges } = await render(LabelSettingsPanelComponent)
+            const store = TestBed.inject(Store)
+            store.dispatch(setLabelSize({ value: 2 }))
+            detectChanges()
+            const dispatchSpy = jest.spyOn(store, "dispatch")
+
+            // Act
+            screen.getByText("Reset label settings").click()
+
+            // Assert
+            const lastCall = dispatchSpy.mock.calls.at(-1)?.[0] as { value?: { appSettings?: { labelSize?: number } } }
+            expect(lastCall?.value?.appSettings?.labelSize).toBe(1)
+        })
     })
 })

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.ts
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.ts
@@ -3,6 +3,7 @@ import { toSignal } from "@angular/core/rxjs-interop"
 import { ColorLabelOptions, LabelMode } from "../../../../codeCharta.model"
 import { LabelModeService } from "../../services/labelMode.service"
 import { AmountOfTopLabelsService } from "../../services/amountOfTopLabels.service"
+import { LabelSizeService } from "../../services/labelSize.service"
 import { ShowMetricLabelNodeNameService } from "../../services/showMetricLabelNodeName.service"
 import { ShowMetricLabelNameValueService } from "../../services/showMetricLabelNameValue.service"
 import { ColorLabelsService } from "../../services/colorLabels.service"
@@ -11,6 +12,7 @@ import { StateAccessStore } from "../../stores/stateAccess.store"
 import { CodeMapRenderService } from "../../../../ui/codeMap/codeMap.render.service"
 import { debounce } from "../../../../util/debounce"
 import { parseNumberInput } from "../../../../util/parseNumberInput"
+import { LABEL_SIZE_STEP, MAX_LABEL_SIZE, MIN_LABEL_SIZE } from "../../services/label.constants"
 
 @Component({
     selector: "cc-label-settings-panel",
@@ -23,6 +25,7 @@ export class LabelSettingsPanelComponent {
 
     private readonly labelModeService = inject(LabelModeService)
     private readonly amountOfTopLabelsService = inject(AmountOfTopLabelsService)
+    private readonly labelSizeService = inject(LabelSizeService)
     private readonly showMetricLabelNodeNameService = inject(ShowMetricLabelNodeNameService)
     private readonly showMetricLabelNameValueService = inject(ShowMetricLabelNameValueService)
     private readonly colorLabelsService = inject(ColorLabelsService)
@@ -31,9 +34,13 @@ export class LabelSettingsPanelComponent {
     private readonly codeMapRenderService = inject(CodeMapRenderService)
 
     readonly LabelMode = LabelMode
+    readonly MIN_LABEL_SIZE = MIN_LABEL_SIZE
+    readonly MAX_LABEL_SIZE = MAX_LABEL_SIZE
+    readonly LABEL_SIZE_STEP = LABEL_SIZE_STEP
 
     readonly resetSettingsKeys = [
         "appSettings.amountOfTopLabels",
+        "appSettings.labelSize",
         "appSettings.showMetricLabelNodeName",
         "appSettings.showMetricLabelNameValue",
         "appSettings.colorLabels",
@@ -42,6 +49,7 @@ export class LabelSettingsPanelComponent {
     ]
 
     readonly amountOfTopLabels = toSignal(this.amountOfTopLabelsService.amountOfTopLabels$(), { requireSync: true })
+    readonly labelSize = toSignal(this.labelSizeService.labelSize$(), { requireSync: true })
     readonly showMetricLabelNodeName = toSignal(this.showMetricLabelNodeNameService.showMetricLabelNodeName$(), { requireSync: true })
     readonly showMetricLabelNodeValue = toSignal(this.showMetricLabelNameValueService.showMetricLabelNameValue$(), { requireSync: true })
     readonly colorLabels = toSignal(this.colorLabelsService.colorLabels$(), { requireSync: true })
@@ -57,10 +65,27 @@ export class LabelSettingsPanelComponent {
         this.amountOfTopLabelsService.setAmountOfTopLabels(amountOfTopLabels)
     }, LabelSettingsPanelComponent.DEBOUNCE_TIME)
 
+    readonly applyDebouncedLabelSize = debounce((labelSize: number) => {
+        this.labelSizeService.setLabelSize(labelSize)
+    }, LabelSettingsPanelComponent.DEBOUNCE_TIME)
+
     handleTopLabelsInput(event: Event) {
         const value = parseNumberInput(event, 0, 50)
         if (!Number.isNaN(value) && value !== this.amountOfTopLabels()) {
             this.applyDebouncedTopLabels(value)
+        }
+    }
+
+    handleLabelSizeInput(event: Event) {
+        const raw = Number.parseFloat((event.target as HTMLInputElement).value)
+        if (Number.isNaN(raw)) {
+            return
+        }
+        const clamped = Math.min(MAX_LABEL_SIZE, Math.max(MIN_LABEL_SIZE, raw))
+        const snapped = Math.round(clamped / LABEL_SIZE_STEP) * LABEL_SIZE_STEP
+        const value = Math.round(snapped * 100) / 100
+        if (value !== this.labelSize()) {
+            this.applyDebouncedLabelSize(value)
         }
     }
 

--- a/visualization/app/codeCharta/features/labelSettings/facade.ts
+++ b/visualization/app/codeCharta/features/labelSettings/facade.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core"
 import { LabelModeService } from "./services/labelMode.service"
 import { AmountOfTopLabelsService } from "./services/amountOfTopLabels.service"
+import { LabelSizeService } from "./services/labelSize.service"
 import { ShowMetricLabelNodeNameService } from "./services/showMetricLabelNodeName.service"
 import { ShowMetricLabelNameValueService } from "./services/showMetricLabelNameValue.service"
 import { ColorLabelsService } from "./services/colorLabels.service"
@@ -17,6 +18,7 @@ export class LabelSettingsFacade {
     constructor(
         private readonly labelModeService: LabelModeService,
         private readonly amountOfTopLabelsService: AmountOfTopLabelsService,
+        private readonly labelSizeService: LabelSizeService,
         private readonly showMetricLabelNodeNameService: ShowMetricLabelNodeNameService,
         private readonly showMetricLabelNameValueService: ShowMetricLabelNameValueService,
         private readonly colorLabelsService: ColorLabelsService,
@@ -33,6 +35,10 @@ export class LabelSettingsFacade {
 
     amountOfTopLabels$() {
         return this.amountOfTopLabelsService.amountOfTopLabels$()
+    }
+
+    labelSize$() {
+        return this.labelSizeService.labelSize$()
     }
 
     showMetricLabelNodeName$() {
@@ -58,6 +64,10 @@ export class LabelSettingsFacade {
 
     setAmountOfTopLabels(value: number) {
         this.amountOfTopLabelsService.setAmountOfTopLabels(value)
+    }
+
+    setLabelSize(value: number) {
+        this.labelSizeService.setLabelSize(value)
     }
 
     setShowMetricLabelNodeName(value: boolean) {

--- a/visualization/app/codeCharta/features/labelSettings/selectors/labelSettings.selectors.ts
+++ b/visualization/app/codeCharta/features/labelSettings/selectors/labelSettings.selectors.ts
@@ -1,6 +1,8 @@
 import { createSelector } from "@ngrx/store"
 import { appSettingsSelector } from "../../../state/store/appSettings/appSettings.selector"
 
+export { labelSizeSelector } from "../../../state/store/appSettings/labelSize/labelSize.selector"
+
 export const labelModeSelector = createSelector(appSettingsSelector, appSettings => appSettings.labelMode)
 
 export const amountOfTopLabelsSelector = createSelector(appSettingsSelector, appSettings => appSettings.amountOfTopLabels)

--- a/visualization/app/codeCharta/features/labelSettings/services/label.constants.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/label.constants.ts
@@ -4,3 +4,10 @@ export const TOOLTIP_COLLISION_PADDING_PX = 12
 export const MIN_CONNECTOR_DISTANCE = 0.5
 export const MAX_DISPLACEMENT_PX = 100
 export const MAX_CONNECTORS = 200
+
+export const MIN_LABEL_SIZE = 0.75
+export const MAX_LABEL_SIZE = 2.5
+export const LABEL_SIZE_STEP = 0.25
+export const BASE_NAME_FONT_PX = 12
+export const BASE_METRIC_FONT_PX = 10
+export const BASE_BADGE_FONT_PX = 10

--- a/visualization/app/codeCharta/features/labelSettings/services/labelCreation.service.spec.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelCreation.service.spec.ts
@@ -5,6 +5,7 @@ import { Group, BoxGeometry, Mesh } from "three"
 import { ThreeSceneService } from "../../../ui/codeMap/threeViewer/threeSceneService"
 import { StateAccessStore } from "../stores/stateAccess.store"
 import { setAmountOfTopLabels } from "../../../state/store/appSettings/amountOfTopLabels/amountOfTopLabels.actions"
+import { setLabelSize } from "../../../state/store/appSettings/labelSize/labelSize.actions"
 import { setHeightMetric } from "../../../state/store/dynamicSettings/heightMetric/heightMetric.actions"
 import { setShowMetricLabelNameValue } from "../../../state/store/appSettings/showMetricLabelNameValue/showMetricLabelNameValue.actions"
 import { setShowMetricLabelNodeName } from "../../../state/store/appSettings/showMetricLabelNodeName/showMetricLabelNodeName.actions"
@@ -137,6 +138,37 @@ describe("LabelCreationService", () => {
             const content = labelCreationService.getLabels()[0].labelElement.getContentElement()
             expect(content).toBeTruthy()
             expect(content.textContent).toContain("sample")
+        })
+
+        it("should scale font sizes by labelSize multiplier", () => {
+            // Arrange
+            store.dispatch(setShowMetricLabelNodeName({ value: true }))
+            store.dispatch(setShowMetricLabelNameValue({ value: true }))
+            store.dispatch(setLabelSize({ value: 2 }))
+
+            // Act
+            labelCreationService.addLeafLabel(sampleLeaf, 0)
+
+            // Assert
+            const content = labelCreationService.getLabels()[0].labelElement.getContentElement()
+            expect(content.style.fontSize).toBe("24px")
+            const metricSpan = content.querySelectorAll("span")[1] as HTMLSpanElement
+            expect(metricSpan.style.fontSize).toBe("20px")
+        })
+
+        it("should keep base font sizes at default labelSize of 1", () => {
+            // Arrange
+            store.dispatch(setShowMetricLabelNodeName({ value: true }))
+            store.dispatch(setShowMetricLabelNameValue({ value: true }))
+
+            // Act
+            labelCreationService.addLeafLabel(sampleLeaf, 0)
+
+            // Assert
+            const content = labelCreationService.getLabels()[0].labelElement.getContentElement()
+            expect(content.style.fontSize).toBe("12px")
+            const metricSpan = content.querySelectorAll("span")[1] as HTMLSpanElement
+            expect(metricSpan.style.fontSize).toBe("10px")
         })
     })
 

--- a/visualization/app/codeCharta/features/labelSettings/services/labelCreation.service.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelCreation.service.ts
@@ -33,7 +33,7 @@ export class LabelCreationService {
 
     addLeafLabel(node: Node, highestNodeInSet: number, enforceLabel = false) {
         const { appSettings, dynamicSettings } = this.stateAccessStore.getValue()
-        const { scaling, showMetricLabelNodeName, showMetricLabelNameValue, labelMode } = appSettings
+        const { scaling, showMetricLabelNodeName, showMetricLabelNameValue, labelMode, labelSize } = appSettings
         const { heightMetric, colorMetric } = dynamicSettings
         const multiplier = new Vector3(scaling.x, scaling.y, scaling.z)
 
@@ -50,7 +50,7 @@ export class LabelCreationService {
             metricText = `${node.attributes[metric]} ${metric}`
         }
 
-        const labelElement = new LabelElement(nameText, metricText)
+        const labelElement = new LabelElement(nameText, metricText, labelSize)
         const cssObject = labelElement.cssObject
         cssObject.userData = { node }
 

--- a/visualization/app/codeCharta/features/labelSettings/services/labelElement.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelElement.ts
@@ -1,15 +1,17 @@
 import { CSS2DObject } from "three/addons/renderers/CSS2DRenderer.js"
-import { BASE_OFFSET_PX } from "./label.constants"
+import { BASE_BADGE_FONT_PX, BASE_METRIC_FONT_PX, BASE_NAME_FONT_PX, BASE_OFFSET_PX } from "./label.constants"
 
 export class LabelElement {
     readonly cssObject: CSS2DObject
     private readonly content: HTMLDivElement
+    private readonly labelSize: number
     private badge: HTMLDivElement | null = null
 
-    constructor(nameText: string, metricText: string) {
+    constructor(nameText: string, metricText: string, labelSize: number) {
+        this.labelSize = labelSize
         const wrapper = document.createElement("div")
         this.content = document.createElement("div")
-        this.content.style.cssText = LabelElement.buildContentStyles()
+        this.content.style.cssText = LabelElement.buildContentStyles(labelSize)
 
         if (nameText) {
             const nameSpan = document.createElement("span")
@@ -20,7 +22,7 @@ export class LabelElement {
 
         if (metricText) {
             const metricSpan = document.createElement("span")
-            metricSpan.style.cssText = "display: block; font-size: 10px; color: #666; margin-top: 1px;"
+            metricSpan.style.cssText = `display: block; font-size: ${BASE_METRIC_FONT_PX * labelSize}px; color: #666; margin-top: 1px;`
             metricSpan.textContent = metricText
             this.content.appendChild(metricSpan)
         }
@@ -55,7 +57,7 @@ export class LabelElement {
         this.badge = document.createElement("div")
         this.badge.textContent = `+${hiddenCount} more`
         this.badge.style.cssText = `
-            font-size: 10px;
+            font-size: ${BASE_BADGE_FONT_PX * this.labelSize}px;
             color: #888;
             margin-top: 2px;
             text-align: center;
@@ -71,7 +73,7 @@ export class LabelElement {
         }
     }
 
-    private static buildContentStyles(): string {
+    private static buildContentStyles(labelSize: number): string {
         return `
             background: rgba(255, 255, 255, 0.85);
             backdrop-filter: blur(6px);
@@ -79,7 +81,7 @@ export class LabelElement {
             border-radius: 6px;
             padding: 4px 8px;
             font-family: Roboto, 'Helvetica Neue', sans-serif;
-            font-size: 12px;
+            font-size: ${BASE_NAME_FONT_PX * labelSize}px;
             line-height: 1.3;
             color: #1a1a1a;
             white-space: nowrap;

--- a/visualization/app/codeCharta/features/labelSettings/services/labelSize.service.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelSize.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core"
+import { LabelSizeStore } from "../stores/labelSize.store"
+
+@Injectable({
+    providedIn: "root"
+})
+export class LabelSizeService {
+    constructor(private readonly labelSizeStore: LabelSizeStore) {}
+
+    labelSize$() {
+        return this.labelSizeStore.labelSize$
+    }
+
+    setLabelSize(value: number) {
+        this.labelSizeStore.setLabelSize(value)
+    }
+}

--- a/visualization/app/codeCharta/features/labelSettings/stores/labelSize.store.spec.ts
+++ b/visualization/app/codeCharta/features/labelSettings/stores/labelSize.store.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from "@angular/core/testing"
+import { MockStore, provideMockStore } from "@ngrx/store/testing"
+import { LabelSizeStore } from "./labelSize.store"
+import { labelSizeSelector } from "../selectors/labelSettings.selectors"
+import { setLabelSize } from "../../../state/store/appSettings/labelSize/labelSize.actions"
+import { getLastAction } from "../../../util/testUtils/store.utils"
+
+describe("LabelSizeStore", () => {
+    let store: LabelSizeStore
+    let mockStore: MockStore
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [LabelSizeStore, provideMockStore({ selectors: [{ selector: labelSizeSelector, value: 1 }] })]
+        })
+
+        store = TestBed.inject(LabelSizeStore)
+        mockStore = TestBed.inject(MockStore)
+    })
+
+    describe("labelSize$", () => {
+        it("should emit value from selector", done => {
+            // Arrange
+            mockStore.overrideSelector(labelSizeSelector, 1.5)
+            mockStore.refreshState()
+
+            // Act & Assert
+            store.labelSize$.subscribe(value => {
+                expect(value).toBe(1.5)
+                done()
+            })
+        })
+    })
+
+    describe("setLabelSize", () => {
+        it("should dispatch setLabelSize action with value", async () => {
+            // Arrange & Act
+            store.setLabelSize(2)
+
+            // Assert
+            expect(await getLastAction(mockStore)).toEqual(setLabelSize({ value: 2 }))
+        })
+    })
+})

--- a/visualization/app/codeCharta/features/labelSettings/stores/labelSize.store.ts
+++ b/visualization/app/codeCharta/features/labelSettings/stores/labelSize.store.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@angular/core"
+import { Store } from "@ngrx/store"
+import { CcState } from "../../../codeCharta.model"
+import { labelSizeSelector } from "../selectors/labelSettings.selectors"
+import { setLabelSize } from "../../../state/store/appSettings/labelSize/labelSize.actions"
+
+@Injectable({
+    providedIn: "root"
+})
+export class LabelSizeStore {
+    constructor(private readonly store: Store<CcState>) {}
+
+    labelSize$ = this.store.select(labelSizeSelector)
+
+    setLabelSize(value: number) {
+        this.store.dispatch(setLabelSize({ value }))
+    }
+}

--- a/visualization/app/codeCharta/features/scenarios/components/applyScenarioDialog/applyScenarioDialog.component.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/components/applyScenarioDialog/applyScenarioDialog.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing"
 import { ApplyScenarioDialogComponent } from "./applyScenarioDialog.component"
 import { ScenarioApplierService } from "../../services/scenarioApplier.service"
 import { Scenario, ScenarioSectionKey } from "../../model/scenario.model"
-import { ColorMode, MetricData } from "../../../../codeCharta.model"
+import { ColorMode, LabelMode, MetricData } from "../../../../codeCharta.model"
 import { defaultState } from "../../../../state/store/state.manager"
 
 const createTestScenario = (): Scenario => ({
@@ -27,10 +27,13 @@ const createTestScenario = (): Scenario => ({
         filters: { blacklist: [], focusedNodePath: [] },
         labelsAndFolders: {
             amountOfTopLabels: 1,
+            labelSize: 1,
             showMetricLabelNameValue: true,
             showMetricLabelNodeName: true,
             enableFloorLabels: false,
             colorLabels: { positive: false, negative: false, neutral: false },
+            labelMode: LabelMode.Height,
+            groupLabelCollisions: false,
             markedPackages: []
         }
     }

--- a/visualization/app/codeCharta/features/scenarios/components/scenarioListDialog/scenarioListDialog.component.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/components/scenarioListDialog/scenarioListDialog.component.spec.ts
@@ -8,7 +8,7 @@ import { ScenarioApplierService } from "../../services/scenarioApplier.service"
 import { ScenariosService } from "../../services/scenarios.service"
 import { ScenarioImportExportService } from "../../services/scenarioImportExport.service"
 import { Scenario } from "../../model/scenario.model"
-import { ColorMode, MetricData, NodeType } from "../../../../codeCharta.model"
+import { ColorMode, LabelMode, MetricData, NodeType } from "../../../../codeCharta.model"
 import { FileSelectionState, FileState } from "../../../../model/files/files"
 
 const createTestScenario = (name: string, id = "test-id", mapFileNames?: string[]): Scenario => ({
@@ -34,10 +34,13 @@ const createTestScenario = (name: string, id = "test-id", mapFileNames?: string[
         filters: { blacklist: [], focusedNodePath: [] },
         labelsAndFolders: {
             amountOfTopLabels: 1,
+            labelSize: 1,
             showMetricLabelNameValue: true,
             showMetricLabelNodeName: true,
             enableFloorLabels: false,
             colorLabels: { positive: false, negative: false, neutral: false },
+            labelMode: LabelMode.Height,
+            groupLabelCollisions: false,
             markedPackages: []
         }
     }

--- a/visualization/app/codeCharta/features/scenarios/model/scenario.model.ts
+++ b/visualization/app/codeCharta/features/scenarios/model/scenario.model.ts
@@ -33,6 +33,7 @@ export interface FiltersSection {
 
 export interface LabelsAndFoldersSection {
     readonly amountOfTopLabels: number
+    readonly labelSize: number
     readonly showMetricLabelNameValue: boolean
     readonly showMetricLabelNodeName: boolean
     readonly enableFloorLabels: boolean

--- a/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.spec.ts
@@ -49,6 +49,7 @@ const testSections: ScenarioSections = {
     },
     labelsAndFolders: {
         amountOfTopLabels: 5,
+        labelSize: 1.5,
         showMetricLabelNameValue: true,
         showMetricLabelNodeName: false,
         enableFloorLabels: true,

--- a/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.ts
+++ b/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.ts
@@ -195,6 +195,7 @@ export class ScenarioApplierService {
         return {
             appSettings: {
                 amountOfTopLabels: labelsAndFolders.amountOfTopLabels,
+                labelSize: labelsAndFolders.labelSize,
                 showMetricLabelNameValue: labelsAndFolders.showMetricLabelNameValue,
                 showMetricLabelNodeName: labelsAndFolders.showMetricLabelNodeName,
                 enableFloorLabels: labelsAndFolders.enableFloorLabels,

--- a/visualization/app/codeCharta/features/scenarios/services/scenarios.service.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/services/scenarios.service.spec.ts
@@ -167,6 +167,7 @@ describe("ScenariosService", () => {
 
             // Assert
             expect(sections.labelsAndFolders.amountOfTopLabels).toBe(defaultState.appSettings.amountOfTopLabels)
+            expect(sections.labelsAndFolders.labelSize).toBe(defaultState.appSettings.labelSize)
             expect(sections.labelsAndFolders.labelMode).toBe(defaultState.appSettings.labelMode)
             expect(sections.labelsAndFolders.groupLabelCollisions).toBe(defaultState.appSettings.groupLabelCollisions)
             expect(sections.labelsAndFolders.markedPackages).toEqual(defaultState.fileSettings.markedPackages)

--- a/visualization/app/codeCharta/features/scenarios/services/scenarios.service.ts
+++ b/visualization/app/codeCharta/features/scenarios/services/scenarios.service.ts
@@ -185,6 +185,7 @@ export class ScenariosService {
             },
             labelsAndFolders: {
                 amountOfTopLabels: state.appSettings.amountOfTopLabels,
+                labelSize: state.appSettings.labelSize,
                 showMetricLabelNameValue: state.appSettings.showMetricLabelNameValue,
                 showMetricLabelNodeName: state.appSettings.showMetricLabelNodeName,
                 enableFloorLabels: state.appSettings.enableFloorLabels,

--- a/visualization/app/codeCharta/features/scenarios/stores/scenarioIndexedDB.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/stores/scenarioIndexedDB.spec.ts
@@ -4,7 +4,7 @@ if (typeof globalThis.structuredClone === "undefined") {
     globalThis.structuredClone = <T>(value: T): T => JSON.parse(JSON.stringify(value))
 }
 
-import { ColorMode } from "../../../codeCharta.model"
+import { ColorMode, LabelMode } from "../../../codeCharta.model"
 import { Scenario } from "../model/scenario.model"
 import { ScenarioIndexedDBService } from "./scenarioIndexedDB"
 
@@ -50,10 +50,13 @@ const createTestScenario = (overrides: Partial<Scenario> = {}): Scenario => ({
         },
         labelsAndFolders: {
             amountOfTopLabels: 1,
+            labelSize: 1,
             showMetricLabelNameValue: true,
             showMetricLabelNodeName: true,
             enableFloorLabels: false,
             colorLabels: { positive: false, negative: false, neutral: false },
+            labelMode: LabelMode.Height,
+            groupLabelCollisions: false,
             markedPackages: []
         }
     },

--- a/visualization/app/codeCharta/services/loadInitialFile/loadInitialFile.service.ts
+++ b/visualization/app/codeCharta/services/loadInitialFile/loadInitialFile.service.ts
@@ -40,6 +40,8 @@ import { setAllFocusedNodes } from "../../state/store/dynamicSettings/focusedNod
 import { setSearchPattern } from "../../state/store/dynamicSettings/searchPattern/searchPattern.actions"
 import { setMargin } from "../../state/store/dynamicSettings/margin/margin.actions"
 import { setAmountOfTopLabels } from "../../state/store/appSettings/amountOfTopLabels/amountOfTopLabels.actions"
+import { setAmountOfEdgePreviews } from "../../state/store/appSettings/amountOfEdgePreviews/amountOfEdgePreviews.actions"
+import { setLabelSize } from "../../state/store/appSettings/labelSize/labelSize.actions"
 import { setEdgeHeight } from "../../state/store/appSettings/edgeHeight/edgeHeight.actions"
 import { setScaling } from "../../state/store/appSettings/scaling/scaling.actions"
 import { setHideFlatBuildings } from "../../state/store/appSettings/hideFlatBuildings/hideFlatBuildings.actions"
@@ -238,7 +240,7 @@ export class LoadInitialFileService {
         return missingDynamicSettings
     }
 
-    private static readonly optionalAppSettingsKeys = new Set(["labelMode", "groupLabelCollisions"])
+    private static readonly optionalAppSettingsKeys = new Set(["labelMode", "groupLabelCollisions", "labelSize"])
 
     private applyAppSettings(savedAppSettings: AppSettings) {
         const currentAppSettings = (this.state.getValue() as CcState).appSettings
@@ -328,8 +330,11 @@ export class LoadInitialFileService {
             case "amountOfTopLabels":
                 this.store.dispatch(setAmountOfTopLabels({ value }))
                 break
+            case "labelSize":
+                this.store.dispatch(setLabelSize({ value }))
+                break
             case "amountOfEdgePreviews":
-                this.store.dispatch(setAmountOfTopLabels({ value }))
+                this.store.dispatch(setAmountOfEdgePreviews({ value }))
                 break
             case "edgeHeight":
                 this.store.dispatch(setEdgeHeight({ value }))

--- a/visualization/app/codeCharta/state/effects/renderCodeMapEffect/actionsRequiringRerender.ts
+++ b/visualization/app/codeCharta/state/effects/renderCodeMapEffect/actionsRequiringRerender.ts
@@ -1,5 +1,6 @@
 import { setAmountOfEdgePreviews } from "../../store/appSettings/amountOfEdgePreviews/amountOfEdgePreviews.actions"
 import { setAmountOfTopLabels } from "../../store/appSettings/amountOfTopLabels/amountOfTopLabels.actions"
+import { setLabelSize } from "../../store/appSettings/labelSize/labelSize.actions"
 import { setColorLabels } from "../../store/appSettings/colorLabels/colorLabels.actions"
 import { setEdgeHeight } from "../../store/appSettings/edgeHeight/edgeHeight.actions"
 import { setHideFlatBuildings } from "../../store/appSettings/hideFlatBuildings/hideFlatBuildings.actions"
@@ -53,6 +54,7 @@ export const actionsRequiringRerender = [
     setShowIncomingEdges,
     setShowOutgoingEdges,
     setAmountOfTopLabels,
+    setLabelSize,
     setLayoutAlgorithm,
     setMaxTreeMapFiles,
     setSharpnessMode,

--- a/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
@@ -1,5 +1,6 @@
 import { setAmountOfEdgePreviews } from "./amountOfEdgePreviews/amountOfEdgePreviews.actions"
 import { setAmountOfTopLabels } from "./amountOfTopLabels/amountOfTopLabels.actions"
+import { setLabelSize } from "./labelSize/labelSize.actions"
 import { setColorLabels } from "./colorLabels/colorLabels.actions"
 import { setEdgeHeight } from "./edgeHeight/edgeHeight.actions"
 import { setScreenshotToClipboardEnabled } from "./enableClipboard/screenshotToClipboardEnabled.actions"
@@ -52,6 +53,7 @@ export const appSettingsActions = [
     setEdgeHeight,
     setAmountOfEdgePreviews,
     setAmountOfTopLabels,
+    setLabelSize,
     setPresentationMode,
     setExperimentalFeaturesEnabled,
     setScreenshotToClipboardEnabled,

--- a/visualization/app/codeCharta/state/store/appSettings/appSettings.reducer.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/appSettings.reducer.ts
@@ -20,6 +20,7 @@ import { defaultScaling, scaling } from "./scaling/scaling.reducer"
 import { defaultEdgeHeight, edgeHeight } from "./edgeHeight/edgeHeight.reducer"
 import { amountOfEdgePreviews, defaultAmountOfEdgesPreviews } from "./amountOfEdgePreviews/amountOfEdgePreviews.reducer"
 import { amountOfTopLabels, defaultAmountOfTopLabels } from "./amountOfTopLabels/amountOfTopLabels.reducer"
+import { defaultLabelSize, labelSize } from "./labelSize/labelSize.reducer"
 import { defaultIsPresentationMode, isPresentationMode } from "./isPresentationMode/isPresentationMode.reducer"
 import {
     defaultExperimentalFeaturesEnabled,
@@ -65,6 +66,7 @@ export const appSettings = combineReducers({
     edgeHeight,
     amountOfEdgePreviews,
     amountOfTopLabels,
+    labelSize,
     isPresentationMode,
     experimentalFeaturesEnabled,
     screenshotToClipboardEnabled,
@@ -99,6 +101,7 @@ export const defaultAppSettings = {
     edgeHeight: defaultEdgeHeight,
     amountOfEdgePreviews: defaultAmountOfEdgesPreviews,
     amountOfTopLabels: defaultAmountOfTopLabels,
+    labelSize: defaultLabelSize,
     isPresentationMode: defaultIsPresentationMode,
     experimentalFeaturesEnabled: defaultExperimentalFeaturesEnabled,
     screenshotToClipboardEnabled: defaultScreenshotToClipboardEnabled,

--- a/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.actions.ts
@@ -1,0 +1,3 @@
+import { createAction, props } from "@ngrx/store"
+
+export const setLabelSize = createAction("SET_LABEL_SIZE", props<{ value: number }>())

--- a/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.reducer.spec.ts
@@ -1,0 +1,14 @@
+import { defaultLabelSize, labelSize } from "./labelSize.reducer"
+import { setLabelSize } from "./labelSize.actions"
+
+describe("labelSize", () => {
+    it("should default to 1", () => {
+        expect(defaultLabelSize).toEqual(1)
+    })
+
+    it("should set new labelSize", () => {
+        const result = labelSize(1, setLabelSize({ value: 2 }))
+
+        expect(result).toEqual(2)
+    })
+})

--- a/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.reducer.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.reducer.ts
@@ -1,0 +1,6 @@
+import { createReducer, on } from "@ngrx/store"
+import { setLabelSize } from "./labelSize.actions"
+import { setState } from "../../util/setState.reducer.factory"
+
+export const defaultLabelSize = 1
+export const labelSize = createReducer(defaultLabelSize, on(setLabelSize, setState(defaultLabelSize)))

--- a/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.selector.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelSize/labelSize.selector.ts
@@ -1,0 +1,4 @@
+import { createSelector } from "@ngrx/store"
+import { appSettingsSelector } from "../appSettings.selector"
+
+export const labelSizeSelector = createSelector(appSettingsSelector, appSettings => appSettings.labelSize)

--- a/visualization/app/codeCharta/ui/resetSettingsButton/getPartialDefaultState.spec.ts
+++ b/visualization/app/codeCharta/ui/resetSettingsButton/getPartialDefaultState.spec.ts
@@ -14,4 +14,13 @@ describe("getPartialDefaultState", () => {
 
         expect(actualSettings).toEqual(expectedSettings)
     })
+
+    it("should reset 'labelSize' to its static default of 1", () => {
+        const keySettings = ["appSettings.labelSize"]
+        const expectedSettings = { appSettings: { labelSize: 1 } }
+
+        const actualSettings = getPartialDefaultState(keySettings, DEFAULT_STATE)
+
+        expect(actualSettings).toEqual(expectedSettings)
+    })
 })

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -2170,6 +2170,7 @@ export const STATE: CcState = {
     },
     appSettings: {
         amountOfTopLabels: 31,
+        labelSize: 1,
         amountOfEdgePreviews: 5,
         colorLabels: {
             positive: false,
@@ -2215,7 +2216,8 @@ export const STATE: CcState = {
         layoutAlgorithm: LayoutAlgorithm.SquarifiedTreeMap,
         sharpnessMode: SharpnessMode.Standard,
         maxTreeMapFiles: 200,
-        labelMode: LabelMode.Height
+        labelMode: LabelMode.Height,
+        groupLabelCollisions: false
     },
     files: [],
     appStatus: {
@@ -2229,6 +2231,7 @@ export const STATE: CcState = {
 export const DEFAULT_STATE: CcState = {
     appSettings: {
         amountOfTopLabels: 1,
+        labelSize: 1,
         amountOfEdgePreviews: 1,
         colorLabels: {
             positive: false,
@@ -2274,7 +2277,8 @@ export const DEFAULT_STATE: CcState = {
         layoutAlgorithm: LayoutAlgorithm.SquarifiedTreeMap,
         sharpnessMode: SharpnessMode.Standard,
         maxTreeMapFiles: 100,
-        labelMode: LabelMode.Height
+        labelMode: LabelMode.Height,
+        groupLabelCollisions: false
     },
     dynamicSettings: {
         areaMetric: null,

--- a/visualization/app/codeCharta/util/settingsHelper.spec.ts
+++ b/visualization/app/codeCharta/util/settingsHelper.spec.ts
@@ -27,7 +27,8 @@ describe("SettingsHelper", () => {
                 appSettings: {
                     scaling: { y: 27 },
                     invertHeight: false,
-                    amountOfTopLabels: 23
+                    amountOfTopLabels: 23,
+                    labelSize: 1
                 }
             }
 
@@ -35,7 +36,8 @@ describe("SettingsHelper", () => {
                 appSettings: {
                     scaling: new Vector3(1, 27, 1),
                     invertHeight: false,
-                    amountOfTopLabels: 23
+                    amountOfTopLabels: 23,
+                    labelSize: 1
                 }
             }
 


### PR DESCRIPTION
Adds a "Label Size" slider in the Label Settings panel that scales floating CSS2D labels (name, metric value, and "+N more" badge) by a single multiplier between 0.75x and 2.5x (default 1x). The setting is persisted with scenarios and resets via the existing reset button.

Also fixes a pre-existing bug in loadInitialFile.service.ts where the "amountOfEdgePreviews" key dispatched setAmountOfTopLabels instead of setAmountOfEdgePreviews when restoring saved state.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Label Size slider in the Label Settings panel to adjust the size of floating label text, including names, metric values, and the "+N more" badge. The slider ranges from 0.75× to 2.5× of the default size.
  * Label size settings are automatically saved and preserved when loading saved scenarios.

* **Bug Fixes**
  * Fixed an issue where the edge previews setting was incorrectly overwritten during saved-state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->