### PR TITLE
chore: remove 'formerly mcc' aliases from metric display names

### DIFF
--- a/visualization/app/codeCharta/ui/metricChooser/filterMetricDataBySearchTerm.pipe.spec.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/filterMetricDataBySearchTerm.pipe.spec.ts
@@ -146,8 +146,8 @@ describe("FilterMetricDataBySearchTermPipe", () => {
         })
     })
 
-    describe("special case handling (formerly mcc)", () => {
-        it("should match 'complexity' when searching for 'mcc'", () => {
+    describe("special case handling (formerly mcc aliases removed)", () => {
+        it("should not match 'mcc' after the formerly-mcc aliases were removed", () => {
             // Arrange
             const searchTerm = "mcc"
 
@@ -155,12 +155,10 @@ describe("FilterMetricDataBySearchTermPipe", () => {
             const results = pipe.transform(metricData, searchTerm)
 
             // Assert
-            expect(results.length).toBe(2)
-            expect(results.map(r => r.name)).toContain("complexity")
-            expect(results.map(r => r.name)).toContain("sonar_complexity")
+            expect(results.length).toBe(0)
         })
 
-        it("should match 'complexity' when searching for 'formerly'", () => {
+        it("should not match 'formerly' after the formerly-mcc aliases were removed", () => {
             // Arrange
             const searchTerm = "formerly"
 
@@ -168,9 +166,7 @@ describe("FilterMetricDataBySearchTermPipe", () => {
             const results = pipe.transform(metricData, searchTerm)
 
             // Assert
-            expect(results.length).toBe(2)
-            expect(results.map(r => r.name)).toContain("complexity")
-            expect(results.map(r => r.name)).toContain("sonar_complexity")
+            expect(results.length).toBe(0)
         })
 
         it("should still match 'complexity' with normal search", () => {

--- a/visualization/app/codeCharta/ui/metricChooser/filterMetricDataBySearchTerm.pipe.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/filterMetricDataBySearchTerm.pipe.ts
@@ -2,10 +2,7 @@ import { Pipe, PipeTransform } from "@angular/core"
 import { EdgeMetricData, NodeMetricData } from "../../codeCharta.model"
 
 // Configuration for metric aliases and display name modifications
-const METRIC_ALIASES: Record<string, string[]> = {
-    complexity: ["formerly mcc"],
-    sonar_complexity: ["formerly mcc"]
-}
+const METRIC_ALIASES: Record<string, string[]> = {}
 
 @Pipe({
     name: "filterMetricDataBySearchTerm",

--- a/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
+++ b/visualization/app/codeCharta/ui/metricChooser/metricChooser.component.spec.ts
@@ -57,7 +57,7 @@ describe("metricChooserComponent", () => {
                 "FullTestTitle (fullMetric):\nFullTestDescription\nHigh Values: FullTestHigh\nLow Values: FullLowValue"
             )
         )
-        await waitFor(() => expect(screen.queryAllByRole("option")[4].textContent).toMatch("sonar_complexity  (formerly mcc) (55)"))
+        await waitFor(() => expect(screen.queryAllByRole("option")[4].textContent).toMatch("sonar_complexity (55)"))
         await waitFor(() => expect(screen.queryAllByRole("option")[4].getAttribute("title")).toMatch("Cyclomatic Complexity"))
 
         await userEvent.click(screen.queryAllByRole("option")[1])


### PR DESCRIPTION
## Summary
Fixes #3605 — removes the temporary "formerly mcc" search aliases that were added when `complexity` and `sonar_complexity` metrics were renamed from `mcc`. These aliases have served their purpose after the adaptation period.

## Changes
- `filterMetricDataBySearchTerm.pipe.ts`: emptied `METRIC_ALIASES` record
- `filterMetricDataBySearchTerm.pipe.spec.ts`: updated tests to expect 0 results for "mcc" / "formerly" searches
- `metricChooser.component.spec.ts`: updated expected display text to remove "(formerly mcc)"

## Type of Change
- [x] Chore / cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed metric search aliases that previously allowed queries using deprecated alternative metric names.
  * Updated metric display labels to remove legacy name variant references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaibornWolff/codecharta/pull/4479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->