### PR TITLE
build(config): block npm package versions newer than 3 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,3 +6,10 @@ engine-strict=true
 # so run `npm run prepare` once after a fresh clone to set up the git hooks (the mise
 # install task does this automatically).
 ignore-scripts=true
+
+# Refuse to resolve package versions published less than 3 days ago (value in days,
+# enforced by npm >= 11.10, silently ignored by older npm). Fast-burn supply-chain
+# compromises are typically detected and unpublished within this window. Only affects
+# resolving new versions — `npm ci` and already-locked versions are unaffected. For a
+# deliberate fresh install, override with `npm install <pkg> --min-release-age=0`.
+min-release-age=3

--- a/visualization/.npmrc
+++ b/visualization/.npmrc
@@ -6,3 +6,10 @@ engine-strict=true
 # install scripts. The one exception is electron, whose binary download is performed on
 # demand by script/ensureElectron.js (wired into `npm run start` and `npm run package`).
 ignore-scripts=true
+
+# Refuse to resolve package versions published less than 3 days ago (value in days,
+# enforced by npm >= 11.10, silently ignored by older npm). Fast-burn supply-chain
+# compromises are typically detected and unpublished within this window. Only affects
+# resolving new versions — `npm ci` and already-locked versions are unaffected. For a
+# deliberate fresh install, override with `npm install <pkg> --min-release-age=0`.
+min-release-age=3


### PR DESCRIPTION
Add min-release-age=3 to root and visualization .npmrc to mitigate fast-burn supply-chain attacks. Enforced by npm >= 11.10, silently ignored by older versions; npm ci and locked versions are unaffected.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package dependency stability by enforcing a minimum maturation period for newly published versions, reducing exposure to potential issues in recently released packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->