### PR TITLE
feat(visualization): add per-map option for top labels

### DIFF
--- a/plans/2026-06-11-per-map-top-labels.md
+++ b/plans/2026-06-11-per-map-top-labels.md
@@ -1,0 +1,76 @@
+---
+name: per-map-top-labels
+issue: -
+state: complete
+version: 1
+---
+
+## Goal
+
+When more than one map is selected (standard mode), a new "per map" radio option in the label
+settings splits all node-selecting label computations per map: Top-N labels are picked per map
+(N labels each), color-mode label selection runs per map, and overlapping-label grouping only
+groups labels belonging to the same map. Default stays "across all maps" (current behavior).
+
+## Tasks
+
+### 1. New appSettings slice `labelsPerMap` (boolean, default false)
+- actions/reducer/selector in `state/store/appSettings/labelsPerMap/`, mirroring `amountOfTopLabels`
+- register in appSettings reducer, `AppSettings` model type, default state
+
+### 2. Feature wiring in `features/labelSettings`
+- `labelsPerMap.store.ts` + `labelsPerMap.service.ts` following existing store/service pattern
+- export selector from `labelSettings.selectors.ts`
+- add `appSettings.labelsPerMap` to `resetSettingsKeys` in the panel
+
+### 3. UI radio in labelSettingsPanel
+- radio group under the Top Labels slider: `(•) across all maps  ( ) per map`, styled like the
+  existing Height/Color join radio
+- only visible when 2+ maps are visible in standard mode (hidden for single map and delta mode):
+  expose a `isMultipleMapsView$` via StateAccessStore based on visibleFileStates count + isDeltaState
+
+### 4. Per-map top-N selection in `codeMap.render.service.ts` `setLabels`
+- helper to derive a map key from `node.path` (top-level segment under root; AggregationGenerator
+  prefixes paths with `/root/<fileName>/` when maps are merged)
+- height mode: partition leaf nodes by map key, `selectTopNByValue` per partition (N each)
+- color mode: same partitioning applied to the selected color nodes
+- ignore the setting (keep global behavior) when only one map is visible or in delta mode
+
+### 5. Per-map collision grouping in `labelCollision.service.ts`
+- when per-map mode is active, `buildCollisionGroups` only unions overlapping labels that share
+  the same map key
+
+### 6. Tests
+- reducer default/toggle
+- render service: per-map vs global selection (height + color mode), single-map/delta fallback
+- panel: radio visibility and dispatch
+- collision service: overlapping labels from different maps are not grouped in per-map mode
+
+### 7. Housekeeping
+- CHANGELOG.md entry
+
+## Steps
+
+- [x] Complete Task 1: state slice `labelsPerMap`
+- [x] Complete Task 2: feature store/service/selector wiring
+- [x] Complete Task 3: UI radio with multi-map visibility
+- [x] Complete Task 4: per-map top-N selection in render service
+- [x] Complete Task 5: per-map collision grouping
+- [x] Complete Task 6: tests
+- [x] Complete Task 7: changelog
+
+## Notes
+
+- Clarified with user: one shared set of setting values; only node-selecting computations split
+  per map ("N per map", so top 10 with 3 maps = up to 30 labels). No independent per-map settings.
+- Option hidden (not just disabled) for single map and delta mode.
+- Branch from `main`: `feature/per-map-top-labels`.
+- New `labelsPerMapActiveSelector` (state/selectors) gates the behavior; the labelSettings feature
+  reaches it via `StateAccessStore.isLabelsPerMapActive()` because `ui/` may not import feature
+  internals (dependency-cruiser rules).
+- `loadInitialFile.service.ts` needed the new key in `optionalAppSettingsKeys` plus a
+  `mapAppSettingToAction` case — its switch throws on unknown saved-config keys.
+- Scenarios intentionally left untouched: persisting the flag would break previously saved
+  scenarios (undefined patch values) and was not requested.
+- Verification: `tsc --noEmit` clean, full unit suite green (381 suites / 2222 tests),
+  `npm run lint:architecture` 0 errors, Biome clean.

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
+- **Per-map top labels**: When more than one map is selected, the Label Settings panel offers a new `All maps | Per map` toggle below the Top Labels slider. In `Per map` mode the top-N labels are picked separately for each map (Height and Color label mode alike), and overlapping labels are only grouped within the same map. The toggle is hidden for a single map and in delta mode.
 - **Label Size slider**: New slider in the Label Settings panel scales floating label text (name, metric value, and "+N more" badge) between 0.75× and 2.5×. The setting is preserved in scenarios.
 - **File Explorer sidebar**: The file tree was redesigned as a dedicated left-side sidebar drawer that overlays the codemap. The drawer adds a Shown/Flattened/Hidden chip row at the top, a sort control, and click-to-edit popovers for the active flatten and exclude rules.
 - **Collapsible File Explorer**: The sidebar can now be collapsed via the `«` button in the header. Collapsed mode shows a small floating search box (with the kebab Flatten/Exclude menu) pinned at the top-left, freeing the full viewport for the codemap. Re-expand with the folder-tree button.

--- a/visualization/app/codeCharta/codeCharta.model.ts
+++ b/visualization/app/codeCharta/codeCharta.model.ts
@@ -171,6 +171,7 @@ export interface AppSettings {
     colorLabels: ColorLabelOptions
     labelMode: LabelMode
     groupLabelCollisions: boolean
+    labelsPerMap: boolean
     isColorMetricLinkedToHeightMetric: boolean
     enableFloorLabels: boolean
 }

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.html
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.html
@@ -1,4 +1,4 @@
-<div [title]="'Display the labels of the ' + amountOfTopLabels() + ' highest buildings'">
+<div [title]="topLabelsTitle()">
     <span class="text-sm">Top Labels</span>
     <div class="flex items-center gap-2">
         <input type="range" class="range range-primary range-sm flex-1"
@@ -9,6 +9,22 @@
             (input)="handleTopLabelsInput($event)" />
     </div>
 </div>
+
+@if (areMultipleMapsVisible()) {
+    <div class="join w-full" aria-label="Top labels scope"
+        title="Pick the top labels across all maps combined or separately for each map">
+        <input type="radio" name="labelsPerMap"
+            class="join-item btn btn-sm flex-1"
+            aria-label="All maps"
+            [checked]="!labelsPerMap()"
+            (change)="setLabelsPerMap(false)" />
+        <input type="radio" name="labelsPerMap"
+            class="join-item btn btn-sm flex-1"
+            aria-label="Per map"
+            [checked]="labelsPerMap()"
+            (change)="setLabelsPerMap(true)" />
+    </div>
+}
 
 <div title="Scale floating label font size">
     <span class="text-sm">Label Size</span>

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.spec.ts
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.spec.ts
@@ -4,6 +4,9 @@ import userEvent from "@testing-library/user-event"
 import { setColorLabels } from "../../../../state/store/appSettings/colorLabels/colorLabels.actions"
 import { setLabelMode } from "../../../../state/store/appSettings/labelMode/labelMode.actions"
 import { setLabelSize } from "../../../../state/store/appSettings/labelSize/labelSize.actions"
+import { setLabelsPerMap } from "../../../../state/store/appSettings/labelsPerMap/labelsPerMap.actions"
+import { setDelta, setFiles } from "../../../../state/store/files/files.actions"
+import { FILE_STATES_TWO_FILES, TEST_FILE_DATA, TEST_FILE_DATA_JAVA } from "../../../../util/dataMocks"
 import { fireEvent } from "@testing-library/angular"
 import { LabelSettingsPanelComponent } from "./labelSettingsPanel.component"
 import { Store, StoreModule } from "@ngrx/store"
@@ -152,6 +155,58 @@ describe("LabelSettingsPanelComponent", () => {
 
         const positiveCheckbox = screen.getByRole("checkbox", { name: "positive color label" }) as HTMLInputElement
         expect(positiveCheckbox.disabled).toBe(false)
+    })
+
+    describe("per-map top labels toggle", () => {
+        it("should hide the toggle when only one map is visible", async () => {
+            // Arrange & Act
+            await render(LabelSettingsPanelComponent)
+
+            // Assert
+            expect(screen.queryByRole("radio", { name: "Per map" })).toBe(null)
+        })
+
+        it("should display the toggle when multiple maps are visible in standard mode", async () => {
+            // Arrange
+            const { detectChanges } = await render(LabelSettingsPanelComponent)
+            const store = TestBed.inject(Store)
+
+            // Act
+            store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+            detectChanges()
+
+            // Assert
+            expect(screen.getByRole("radio", { name: "All maps" })).not.toBe(null)
+            expect(screen.getByRole("radio", { name: "Per map" })).not.toBe(null)
+        })
+
+        it("should hide the toggle in delta mode", async () => {
+            // Arrange
+            const { detectChanges } = await render(LabelSettingsPanelComponent)
+            const store = TestBed.inject(Store)
+
+            // Act
+            store.dispatch(setDelta({ referenceFile: TEST_FILE_DATA, comparisonFile: TEST_FILE_DATA_JAVA }))
+            detectChanges()
+
+            // Assert
+            expect(screen.queryByRole("radio", { name: "Per map" })).toBe(null)
+        })
+
+        it("should dispatch setLabelsPerMap when clicking Per map", async () => {
+            // Arrange
+            const { detectChanges } = await render(LabelSettingsPanelComponent)
+            const store = TestBed.inject(Store)
+            store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+            detectChanges()
+            const dispatchSpy = jest.spyOn(store, "dispatch")
+
+            // Act
+            await userEvent.click(screen.getByRole("radio", { name: "Per map" }))
+
+            // Assert
+            expect(dispatchSpy).toHaveBeenCalledWith(setLabelsPerMap({ value: true }))
+        })
     })
 
     describe("Label Size slider", () => {

--- a/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.ts
+++ b/visualization/app/codeCharta/features/labelSettings/components/labelSettingsPanel/labelSettingsPanel.component.ts
@@ -8,6 +8,7 @@ import { ShowMetricLabelNodeNameService } from "../../services/showMetricLabelNo
 import { ShowMetricLabelNameValueService } from "../../services/showMetricLabelNameValue.service"
 import { ColorLabelsService } from "../../services/colorLabels.service"
 import { GroupLabelCollisionsService } from "../../services/groupLabelCollisions.service"
+import { LabelsPerMapService } from "../../services/labelsPerMap.service"
 import { StateAccessStore } from "../../stores/stateAccess.store"
 import { CodeMapRenderService } from "../../../../ui/codeMap/codeMap.render.service"
 import { debounce } from "../../../../util/debounce"
@@ -31,6 +32,7 @@ export class LabelSettingsPanelComponent {
     private readonly showMetricLabelNameValueService = inject(ShowMetricLabelNameValueService)
     private readonly colorLabelsService = inject(ColorLabelsService)
     private readonly groupLabelCollisionsService = inject(GroupLabelCollisionsService)
+    private readonly labelsPerMapService = inject(LabelsPerMapService)
     private readonly stateAccessStore = inject(StateAccessStore)
     private readonly codeMapRenderService = inject(CodeMapRenderService)
 
@@ -46,7 +48,8 @@ export class LabelSettingsPanelComponent {
         "appSettings.showMetricLabelNameValue",
         "appSettings.colorLabels",
         "appSettings.labelMode",
-        "appSettings.groupLabelCollisions"
+        "appSettings.groupLabelCollisions",
+        "appSettings.labelsPerMap"
     ]
 
     readonly amountOfTopLabels = toSignal(this.amountOfTopLabelsService.amountOfTopLabels$(), { requireSync: true })
@@ -59,8 +62,15 @@ export class LabelSettingsPanelComponent {
     readonly labelMode = toSignal(this.labelModeService.labelMode$(), { requireSync: true })
     readonly colorCategoryCounts = toSignal(this.codeMapRenderService.colorCategoryCounts$, { requireSync: true })
     readonly groupLabelCollisions = toSignal(this.groupLabelCollisionsService.groupLabelCollisions$(), { requireSync: true })
+    readonly labelsPerMap = toSignal(this.labelsPerMapService.labelsPerMap$(), { requireSync: true })
+    readonly areMultipleMapsVisible = toSignal(this.stateAccessStore.areMultipleMapsVisible$, { requireSync: true })
 
     readonly showColorLabels = computed(() => this.labelMode() === LabelMode.Color && !this.isDeltaState())
+
+    readonly topLabelsTitle = computed(() => {
+        const base = `Display the labels of the ${this.amountOfTopLabels()} highest buildings`
+        return this.labelsPerMap() && this.areMultipleMapsVisible() ? `${base} per map` : base
+    })
 
     readonly applyDebouncedTopLabels = debounce((amountOfTopLabels: number) => {
         this.amountOfTopLabelsService.setAmountOfTopLabels(amountOfTopLabels)
@@ -116,6 +126,10 @@ export class LabelSettingsPanelComponent {
 
     setGroupLabelCollisions(event: Event) {
         this.groupLabelCollisionsService.setGroupLabelCollisions((event.target as HTMLInputElement).checked)
+    }
+
+    setLabelsPerMap(value: boolean) {
+        this.labelsPerMapService.setLabelsPerMap(value)
     }
 
     resetSettings() {

--- a/visualization/app/codeCharta/features/labelSettings/selectors/labelSettings.selectors.ts
+++ b/visualization/app/codeCharta/features/labelSettings/selectors/labelSettings.selectors.ts
@@ -14,3 +14,5 @@ export const showMetricLabelNameValueSelector = createSelector(appSettingsSelect
 export const colorLabelsSelector = createSelector(appSettingsSelector, appSettings => appSettings.colorLabels)
 
 export const groupLabelCollisionsSelector = createSelector(appSettingsSelector, appSettings => appSettings.groupLabelCollisions)
+
+export const labelsPerMapSelector = createSelector(appSettingsSelector, appSettings => appSettings.labelsPerMap)

--- a/visualization/app/codeCharta/features/labelSettings/services/labelCollision.service.spec.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelCollision.service.spec.ts
@@ -12,6 +12,9 @@ import { Store, StoreModule } from "@ngrx/store"
 import { appReducers, setStateMiddleware } from "../../../state/store/state.manager"
 import { StateAccessStore } from "../stores/stateAccess.store"
 import { setHeightMetric } from "../../../state/store/dynamicSettings/heightMetric/heightMetric.actions"
+import { setLabelsPerMap } from "../../../state/store/appSettings/labelsPerMap/labelsPerMap.actions"
+import { setFiles } from "../../../state/store/files/files.actions"
+import { FILE_STATES_TWO_FILES } from "../../../util/dataMocks"
 
 describe("LabelCollisionService", () => {
     let store: Store<CcState>
@@ -300,6 +303,70 @@ describe("LabelCollisionService", () => {
             const winnerContent = labelCreationService.getLabels()[0].labelElement.getContentElement()
             const badges = winnerContent.querySelectorAll("div")
             expect(badges.length).toBe(1)
+        })
+    })
+
+    describe("per-map collision grouping", () => {
+        beforeEach(() => {
+            store.dispatch(setShowMetricLabelNodeName({ value: true }))
+            store.dispatch(setHeightMetric({ value: "mcc" }))
+        })
+
+        function addOverlappingLabelsForMaps(pathOfFirst: string, pathOfSecond: string) {
+            const firstLeaf = { ...sampleLeaf, name: "first", path: pathOfFirst, attributes: { mcc: 100 } } as undefined as Node
+            const secondLeaf = { ...otherSampleLeaf, name: "second", path: pathOfSecond, attributes: { mcc: 10 } } as undefined as Node
+            labelCreationService.addLeafLabel(firstLeaf, 0)
+            labelCreationService.addLeafLabel(secondLeaf, 0)
+            const sharedRect = makeRect(100, 120, 50, 150)
+            stubRectsForLabels([sharedRect, sharedRect])
+        }
+
+        it("should not group overlapping labels from different maps when labelsPerMap is active", () => {
+            // Arrange
+            store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+            store.dispatch(setLabelsPerMap({ value: true }))
+            addOverlappingLabelsForMaps("/root/mapA/first", "/root/mapB/second")
+
+            // Act
+            labelCollisionService.updateLabelLayout()
+
+            // Assert — labels of different maps stay visible side by side
+            const contentFirst = labelCreationService.getLabels()[0].labelElement.getContentElement()
+            const contentSecond = labelCreationService.getLabels()[1].labelElement.getContentElement()
+            expect(contentFirst.style.opacity).toBe("1")
+            expect(contentSecond.style.opacity).toBe("1")
+        })
+
+        it("should still group overlapping labels of the same map when labelsPerMap is active", () => {
+            // Arrange
+            store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+            store.dispatch(setLabelsPerMap({ value: true }))
+            addOverlappingLabelsForMaps("/root/mapA/first", "/root/mapA/second")
+
+            // Act
+            labelCollisionService.updateLabelLayout()
+
+            // Assert
+            const contentFirst = labelCreationService.getLabels()[0].labelElement.getContentElement()
+            const contentSecond = labelCreationService.getLabels()[1].labelElement.getContentElement()
+            expect(contentFirst.style.opacity).toBe("1")
+            expect(contentSecond.style.opacity).toBe("0")
+        })
+
+        it("should group overlapping labels across maps when labelsPerMap is off", () => {
+            // Arrange
+            store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+            store.dispatch(setLabelsPerMap({ value: false }))
+            addOverlappingLabelsForMaps("/root/mapA/first", "/root/mapB/second")
+
+            // Act
+            labelCollisionService.updateLabelLayout()
+
+            // Assert
+            const contentFirst = labelCreationService.getLabels()[0].labelElement.getContentElement()
+            const contentSecond = labelCreationService.getLabels()[1].labelElement.getContentElement()
+            expect(contentFirst.style.opacity).toBe("1")
+            expect(contentSecond.style.opacity).toBe("0")
         })
     })
 

--- a/visualization/app/codeCharta/features/labelSettings/services/labelCollision.service.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelCollision.service.ts
@@ -6,6 +6,7 @@ import { LabelMode } from "../../../codeCharta.model"
 import { StateAccessStore } from "../stores/stateAccess.store"
 import { ConnectorDrawingService, LabelLayoutInfo } from "./connectorDrawing.service"
 import { LABEL_GAP_PX, MAX_DISPLACEMENT_PX, TOOLTIP_COLLISION_PADDING_PX } from "./label.constants"
+import { getTopLevelMapName } from "../../../util/nodePathHelper"
 
 @Injectable({ providedIn: "root" })
 export class LabelCollisionService {
@@ -94,7 +95,7 @@ export class LabelCollisionService {
             return
         }
 
-        const groups = this.buildCollisionGroups(activeInfos)
+        const groups = this.buildCollisionGroups(activeInfos, this.stateAccessStore.isLabelsPerMapActive())
         const { dynamicSettings } = this.stateAccessStore.getValue()
         const metric = appSettings.labelMode === LabelMode.Color ? dynamicSettings.colorMetric : dynamicSettings.heightMetric
 
@@ -115,9 +116,10 @@ export class LabelCollisionService {
         }
     }
 
-    private buildCollisionGroups(infos: LabelLayoutInfo[]): LabelLayoutInfo[][] {
+    private buildCollisionGroups(infos: LabelLayoutInfo[], groupPerMap: boolean): LabelLayoutInfo[][] {
         const n = infos.length
         const parent = Array.from({ length: n }, (_, i) => i)
+        const mapNames = groupPerMap ? infos.map(info => getTopLevelMapName(info.label.node.path)) : undefined
 
         const find = (x: number): number => {
             while (parent[x] !== x) {
@@ -137,6 +139,9 @@ export class LabelCollisionService {
 
         for (let i = 0; i < n; i++) {
             for (let j = i + 1; j < n; j++) {
+                if (mapNames !== undefined && mapNames[i] !== mapNames[j]) {
+                    continue
+                }
                 if (this.rectsOverlap(infos[i].rect, infos[j].rect)) {
                     union(i, j)
                 }

--- a/visualization/app/codeCharta/features/labelSettings/services/labelsPerMap.service.ts
+++ b/visualization/app/codeCharta/features/labelSettings/services/labelsPerMap.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core"
+import { LabelsPerMapStore } from "../stores/labelsPerMap.store"
+
+@Injectable({
+    providedIn: "root"
+})
+export class LabelsPerMapService {
+    constructor(private readonly labelsPerMapStore: LabelsPerMapStore) {}
+
+    labelsPerMap$() {
+        return this.labelsPerMapStore.labelsPerMap$
+    }
+
+    setLabelsPerMap(value: boolean) {
+        this.labelsPerMapStore.setLabelsPerMap(value)
+    }
+}

--- a/visualization/app/codeCharta/features/labelSettings/stores/labelsPerMap.store.ts
+++ b/visualization/app/codeCharta/features/labelSettings/stores/labelsPerMap.store.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@angular/core"
+import { Store } from "@ngrx/store"
+import { CcState } from "../../../codeCharta.model"
+import { labelsPerMapSelector } from "../selectors/labelSettings.selectors"
+import { setLabelsPerMap } from "../../../state/store/appSettings/labelsPerMap/labelsPerMap.actions"
+
+@Injectable({
+    providedIn: "root"
+})
+export class LabelsPerMapStore {
+    constructor(private readonly store: Store<CcState>) {}
+
+    labelsPerMap$ = this.store.select(labelsPerMapSelector)
+
+    setLabelsPerMap(value: boolean) {
+        this.store.dispatch(setLabelsPerMap({ value }))
+    }
+}

--- a/visualization/app/codeCharta/features/labelSettings/stores/stateAccess.store.ts
+++ b/visualization/app/codeCharta/features/labelSettings/stores/stateAccess.store.ts
@@ -3,6 +3,8 @@ import { Store, State } from "@ngrx/store"
 import { CcState } from "../../../codeCharta.model"
 import { mapColorsSelector } from "../../../state/store/appSettings/mapColors/mapColors.selector"
 import { isDeltaStateSelector } from "../../../state/selectors/isDeltaState.selector"
+import { areMultipleMapsVisibleSelector } from "../../../state/selectors/areMultipleMapsVisible.selector"
+import { labelsPerMapActiveSelector } from "../../../state/selectors/labelsPerMapActive.selector"
 import { getPartialDefaultState } from "../../../ui/resetSettingsButton/getPartialDefaultState"
 import { setState } from "../../../state/store/state.actions"
 import { defaultAmountOfTopLabels } from "../../../state/store/appSettings/amountOfTopLabels/amountOfTopLabels.reducer"
@@ -18,9 +20,14 @@ export class StateAccessStore {
 
     mapColors$ = this.store.select(mapColorsSelector)
     isDeltaState$ = this.store.select(isDeltaStateSelector)
+    areMultipleMapsVisible$ = this.store.select(areMultipleMapsVisibleSelector)
 
     getValue(): CcState {
         return this.state.getValue()
+    }
+
+    isLabelsPerMapActive(): boolean {
+        return labelsPerMapActiveSelector(this.state.getValue())
     }
 
     resetSettings(keys: string[]) {

--- a/visualization/app/codeCharta/services/loadInitialFile/loadInitialFile.service.ts
+++ b/visualization/app/codeCharta/services/loadInitialFile/loadInitialFile.service.ts
@@ -62,6 +62,7 @@ import { setIsColorMetricLinkedToHeightMetricAction } from "../../state/store/ap
 import { setEnableFloorLabels } from "../../state/store/appSettings/enableFloorLabels/enableFloorLabels.actions"
 import { setLabelMode } from "../../state/store/appSettings/labelMode/labelMode.actions"
 import { setGroupLabelCollisions } from "../../state/store/appSettings/groupLabelCollisions/groupLabelCollisions.actions"
+import { setLabelsPerMap } from "../../state/store/appSettings/labelsPerMap/labelsPerMap.actions"
 
 export const sampleFile1 = { fileName: "sample1.cc.json", fileSize: 3 * 1024, content: sample1 as ExportCCFile }
 export const sampleFile2 = { fileName: "sample2.cc.json", fileSize: 2 * 1024, content: sample2 as ExportCCFile }
@@ -237,7 +238,7 @@ export class LoadInitialFileService {
         return missingDynamicSettings
     }
 
-    private static readonly optionalAppSettingsKeys = new Set(["labelMode", "groupLabelCollisions", "labelSize"])
+    private static readonly optionalAppSettingsKeys = new Set(["labelMode", "groupLabelCollisions", "labelSize", "labelsPerMap"])
 
     private applyAppSettings(savedAppSettings: AppSettings) {
         const currentAppSettings = (this.state.getValue() as CcState).appSettings
@@ -415,6 +416,9 @@ export class LoadInitialFileService {
                 break
             case "groupLabelCollisions":
                 this.store.dispatch(setGroupLabelCollisions({ value }))
+                break
+            case "labelsPerMap":
+                this.store.dispatch(setLabelsPerMap({ value }))
                 break
             default: {
                 throw new Error(`Unhandled key: ${key}`)

--- a/visualization/app/codeCharta/state/effects/renderCodeMapEffect/actionsRequiringRerender.ts
+++ b/visualization/app/codeCharta/state/effects/renderCodeMapEffect/actionsRequiringRerender.ts
@@ -32,6 +32,7 @@ import { setSearchPattern } from "../../store/dynamicSettings/searchPattern/sear
 import { setMarkedPackages, markPackages, unmarkPackage } from "../../store/fileSettings/markedPackages/markedPackages.actions"
 import { setEnableFloorLabels } from "../../store/appSettings/enableFloorLabels/enableFloorLabels.actions"
 import { setGroupLabelCollisions } from "../../store/appSettings/groupLabelCollisions/groupLabelCollisions.actions"
+import { setLabelsPerMap } from "../../store/appSettings/labelsPerMap/labelsPerMap.actions"
 import { setLabelMode } from "../../store/appSettings/labelMode/labelMode.actions"
 import { setState } from "../../store/state.actions"
 import { setShowIncomingEdges } from "../../store/appSettings/showEdges/incoming/showIncomingEdges.actions"
@@ -76,6 +77,7 @@ export const actionsRequiringRerender = [
     unmarkPackage,
     setEnableFloorLabels,
     setGroupLabelCollisions,
+    setLabelsPerMap,
     setLabelMode,
     setState
 ]

--- a/visualization/app/codeCharta/state/selectors/areMultipleMapsVisible.selector.spec.ts
+++ b/visualization/app/codeCharta/state/selectors/areMultipleMapsVisible.selector.spec.ts
@@ -1,0 +1,41 @@
+import { areMultipleMapsVisibleSelector } from "./areMultipleMapsVisible.selector"
+import { FileSelectionState, FileState } from "../../model/files/files"
+import { FILE_STATES, FILE_STATES_TWO_FILES, TEST_FILE_DATA, TEST_FILE_DATA_JAVA } from "../../util/dataMocks"
+
+describe("areMultipleMapsVisibleSelector", () => {
+    it("should be true when more than one map is selected in standard mode", () => {
+        // Arrange
+        const visibleFileStates = FILE_STATES_TWO_FILES
+
+        // Act
+        const result = areMultipleMapsVisibleSelector.projector(visibleFileStates)
+
+        // Assert
+        expect(result).toBe(true)
+    })
+
+    it("should be false when only one map is selected", () => {
+        // Arrange
+        const visibleFileStates = FILE_STATES
+
+        // Act
+        const result = areMultipleMapsVisibleSelector.projector(visibleFileStates)
+
+        // Assert
+        expect(result).toBe(false)
+    })
+
+    it("should be false in delta mode", () => {
+        // Arrange
+        const visibleFileStates: FileState[] = [
+            { file: TEST_FILE_DATA, selectedAs: FileSelectionState.Reference },
+            { file: TEST_FILE_DATA_JAVA, selectedAs: FileSelectionState.Comparison }
+        ]
+
+        // Act
+        const result = areMultipleMapsVisibleSelector.projector(visibleFileStates)
+
+        // Assert
+        expect(result).toBe(false)
+    })
+})

--- a/visualization/app/codeCharta/state/selectors/areMultipleMapsVisible.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/areMultipleMapsVisible.selector.ts
@@ -1,0 +1,8 @@
+import { createSelector } from "@ngrx/store"
+import { isPartialState } from "../../model/files/files.helper"
+import { visibleFileStatesSelector } from "./visibleFileStates/visibleFileStates.selector"
+
+export const areMultipleMapsVisibleSelector = createSelector(
+    visibleFileStatesSelector,
+    visibleFileStates => visibleFileStates.length > 1 && isPartialState(visibleFileStates)
+)

--- a/visualization/app/codeCharta/state/selectors/labelsPerMapActive.selector.ts
+++ b/visualization/app/codeCharta/state/selectors/labelsPerMapActive.selector.ts
@@ -1,0 +1,9 @@
+import { createSelector } from "@ngrx/store"
+import { labelsPerMapSelector } from "../store/appSettings/labelsPerMap/labelsPerMap.selector"
+import { areMultipleMapsVisibleSelector } from "./areMultipleMapsVisible.selector"
+
+export const labelsPerMapActiveSelector = createSelector(
+    labelsPerMapSelector,
+    areMultipleMapsVisibleSelector,
+    (labelsPerMap, areMultipleMapsVisible) => labelsPerMap && areMultipleMapsVisible
+)

--- a/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/appSettings.actions.ts
@@ -8,6 +8,7 @@ import { setExperimentalFeaturesEnabled } from "./enableExperimentalFeatures/exp
 import { setEnableFloorLabels } from "./enableFloorLabels/enableFloorLabels.actions"
 import { setLabelMode } from "./labelMode/labelMode.actions"
 import { setGroupLabelCollisions } from "./groupLabelCollisions/groupLabelCollisions.actions"
+import { setLabelsPerMap } from "./labelsPerMap/labelsPerMap.actions"
 import { setHideFlatBuildings } from "./hideFlatBuildings/hideFlatBuildings.actions"
 import { setInvertArea } from "./invertArea/invertArea.actions"
 import { setInvertHeight } from "./invertHeight/invertHeight.actions"
@@ -61,5 +62,6 @@ export const appSettingsActions = [
     toggleIsColorMetricLinkedToHeightMetric,
     setEnableFloorLabels,
     setLabelMode,
-    setGroupLabelCollisions
+    setGroupLabelCollisions,
+    setLabelsPerMap
 ]

--- a/visualization/app/codeCharta/state/store/appSettings/appSettings.reducer.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/appSettings.reducer.ts
@@ -39,6 +39,7 @@ import {
 import { defaultEnableFloorLabels, enableFloorLabels } from "./enableFloorLabels/enableFloorLabels.reducer"
 import { defaultLabelMode, labelMode } from "./labelMode/labelMode.reducer"
 import { defaultGroupLabelCollisions, groupLabelCollisions } from "./groupLabelCollisions/groupLabelCollisions.reducer"
+import { defaultLabelsPerMap, labelsPerMap } from "./labelsPerMap/labelsPerMap.reducer"
 import { combineReducers } from "@ngrx/store"
 import { defaultShowIncomingEdges, showIncomingEdges } from "./showEdges/incoming/showIncomingEdges.reducer"
 import { defaultShowOutgoingEdges, showOutgoingEdges } from "./showEdges/outgoing/showOutgoingEdges.reducer"
@@ -74,7 +75,8 @@ export const appSettings = combineReducers({
     isColorMetricLinkedToHeightMetric,
     enableFloorLabels,
     labelMode,
-    groupLabelCollisions
+    groupLabelCollisions,
+    labelsPerMap
 })
 
 export const defaultAppSettings = {
@@ -108,5 +110,6 @@ export const defaultAppSettings = {
     isColorMetricLinkedToHeightMetric: defaultIsColorMetricLinkedToHeightMetric,
     enableFloorLabels: defaultEnableFloorLabels,
     labelMode: defaultLabelMode,
-    groupLabelCollisions: defaultGroupLabelCollisions
+    groupLabelCollisions: defaultGroupLabelCollisions,
+    labelsPerMap: defaultLabelsPerMap
 }

--- a/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.actions.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.actions.ts
@@ -1,0 +1,3 @@
+import { createAction, props } from "@ngrx/store"
+
+export const setLabelsPerMap = createAction("SET_LABELS_PER_MAP", props<{ value: boolean }>())

--- a/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.reducer.spec.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.reducer.spec.ts
@@ -1,0 +1,15 @@
+import { labelsPerMap } from "./labelsPerMap.reducer"
+import { setLabelsPerMap } from "./labelsPerMap.actions"
+
+describe("labelsPerMap", () => {
+    it("should set new labelsPerMap", () => {
+        // Arrange
+        const initialValue = false
+
+        // Act
+        const result = labelsPerMap(initialValue, setLabelsPerMap({ value: true }))
+
+        // Assert
+        expect(result).toBe(true)
+    })
+})

--- a/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.reducer.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.reducer.ts
@@ -1,0 +1,6 @@
+import { createReducer, on } from "@ngrx/store"
+import { setLabelsPerMap } from "./labelsPerMap.actions"
+import { setState } from "../../util/setState.reducer.factory"
+
+export const defaultLabelsPerMap = false
+export const labelsPerMap = createReducer(defaultLabelsPerMap, on(setLabelsPerMap, setState(defaultLabelsPerMap)))

--- a/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.selector.ts
+++ b/visualization/app/codeCharta/state/store/appSettings/labelsPerMap/labelsPerMap.selector.ts
@@ -1,0 +1,4 @@
+import { createSelector } from "@ngrx/store"
+import { appSettingsSelector } from "../appSettings.selector"
+
+export const labelsPerMapSelector = createSelector(appSettingsSelector, appSettings => appSettings.labelsPerMap)

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.spec.ts
@@ -7,6 +7,7 @@ import { Node, CodeMapNode, CcState, LabelMode } from "../../codeCharta.model"
 import {
     COLOR_TEST_NODES,
     DEFAULT_STATE,
+    FILE_STATES_TWO_FILES,
     INCOMING_NODE,
     METRIC_DATA,
     STATE,
@@ -27,6 +28,8 @@ import { klona } from "klona"
 import { ThreeStatsService } from "./threeViewer/threeStats.service"
 import { setColorLabels } from "../../state/store/appSettings/colorLabels/colorLabels.actions"
 import { setAmountOfTopLabels } from "../../state/store/appSettings/amountOfTopLabels/amountOfTopLabels.actions"
+import { setLabelsPerMap } from "../../state/store/appSettings/labelsPerMap/labelsPerMap.actions"
+import { setFiles } from "../../state/store/files/files.actions"
 import { setLabelMode } from "../../state/store/appSettings/labelMode/labelMode.actions"
 import { setHeightMetric } from "../../state/store/dynamicSettings/heightMetric/heightMetric.actions"
 import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
@@ -424,6 +427,82 @@ describe("codeMapRenderService", () => {
 
             // Assert
             expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledTimes(3)
+        })
+
+        describe("per-map top labels", () => {
+            function buildLeaf(name: string, mapName: string, height: number): Node {
+                return { ...TEST_NODE_LEAF, name, path: `/root/${mapName}/${name}`, isLeaf: true, height } as Node
+            }
+
+            let tallestOfMapA: Node
+            let shortestOfMapA: Node
+            let tallestOfMapB: Node
+            let shortestOfMapB: Node
+
+            beforeEach(() => {
+                store.dispatch(setAmountOfTopLabels({ value: 1 }))
+                tallestOfMapA = buildLeaf("tallest-a", "mapA", 100)
+                shortestOfMapA = buildLeaf("shortest-a", "mapA", 50)
+                tallestOfMapB = buildLeaf("tallest-b", "mapB", 20)
+                shortestOfMapB = buildLeaf("shortest-b", "mapB", 10)
+            })
+
+            it("should pick the top labels for each map when labelsPerMap is active", () => {
+                // Arrange
+                store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+                store.dispatch(setLabelsPerMap({ value: true }))
+
+                // Act
+                codeMapRenderService["setLabels"]([tallestOfMapA, shortestOfMapA, tallestOfMapB, shortestOfMapB])
+
+                // Assert — one label per map instead of one label overall
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledTimes(2)
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledWith(tallestOfMapA, expect.anything())
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledWith(tallestOfMapB, expect.anything())
+            })
+
+            it("should pick the top labels across all maps when labelsPerMap is off", () => {
+                // Arrange
+                store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+                store.dispatch(setLabelsPerMap({ value: false }))
+
+                // Act
+                codeMapRenderService["setLabels"]([tallestOfMapA, shortestOfMapA, tallestOfMapB, shortestOfMapB])
+
+                // Assert
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledTimes(1)
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledWith(tallestOfMapA, expect.anything())
+            })
+
+            it("should ignore labelsPerMap when only one map is visible", () => {
+                // Arrange
+                store.dispatch(setLabelsPerMap({ value: true }))
+
+                // Act
+                codeMapRenderService["setLabels"]([tallestOfMapA, shortestOfMapA, tallestOfMapB, shortestOfMapB])
+
+                // Assert
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledTimes(1)
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledWith(tallestOfMapA, expect.anything())
+            })
+
+            it("should pick the top color labels for each map when labelsPerMap is active in Color mode", () => {
+                // Arrange
+                store.dispatch(setFiles({ value: FILE_STATES_TWO_FILES }))
+                store.dispatch(setLabelsPerMap({ value: true }))
+                store.dispatch(setLabelMode({ value: LabelMode.Color }))
+                store.dispatch(setColorLabels({ value: { positive: true, negative: true, neutral: true } }))
+                const colorNodesPerMap = [tallestOfMapA, shortestOfMapA, tallestOfMapB, shortestOfMapB].map(
+                    node => ({ ...node, attributes: { mcc: node.height } }) as Node
+                )
+
+                // Act
+                codeMapRenderService["getNodesMatchingColorSelector"](colorNodesPerMap)
+                codeMapRenderService["setLabels"](colorNodesPerMap)
+
+                // Assert — one label per map instead of one label overall
+                expect(labelSettingsFacade.addLeafLabel).toHaveBeenCalledTimes(2)
+            })
         })
     })
 

--- a/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
+++ b/visualization/app/codeCharta/ui/codeMap/codeMap.render.service.ts
@@ -15,7 +15,9 @@ import { metricDataSelector } from "../../state/selectors/accumulatedData/metric
 import { blacklistMatcherSelector } from "../../state/store/fileSettings/blacklist/blacklistMatcher.selector"
 import { State, Store } from "@ngrx/store"
 import { setColorLabels } from "../../state/store/appSettings/colorLabels/colorLabels.actions"
-import { selectTopNByValue } from "../../util/selectTopNByValue"
+import { selectTopNByValue, selectTopNByValuePerGroup } from "../../util/selectTopNByValue"
+import { getTopLevelMapName } from "../../util/nodePathHelper"
+import { labelsPerMapActiveSelector } from "../../state/selectors/labelsPerMapActive.selector"
 
 export interface ColorCategoryCounts {
     positive: number
@@ -189,39 +191,47 @@ export class CodeMapRenderService implements OnDestroy {
             return
         }
 
+        const state = this.state.getValue() as CcState
         const {
             showMetricLabelNodeName,
             showMetricLabelNameValue,
             colorLabels: colorLabelOptions,
             amountOfTopLabels,
             labelMode
-        } = this.state.getValue().appSettings
+        } = state.appSettings
 
         if (showMetricLabelNodeName || showMetricLabelNameValue) {
             const highestNodeInSet = sortedNodes[0].height
+            const selectTopNodes = this.getTopNodeSelector(state, amountOfTopLabels)
 
             if (labelMode === LabelMode.Color) {
-                const { colorMetric } = this.state.getValue().dynamicSettings
-                const selectedColorNodes = selectTopNByValue(
+                const { colorMetric } = state.dynamicSettings
+                const selectedColorNodes = selectTopNodes(
                     colorLabelTypes
                         .filter(colorType => colorLabelOptions[colorType])
                         .flatMap(colorType => this.nodesByColor[colorType])
                         .filter(node => Number.isFinite(node.attributes[colorMetric])),
-                    node => node.attributes[colorMetric],
-                    amountOfTopLabels
+                    node => node.attributes[colorMetric]
                 )
                 this.setBuildingLabel(selectedColorNodes, highestNodeInSet)
             } else {
                 // rank by rendered height, not the raw metric: with invertHeight or
                 // direction-1 metrics the tallest buildings are not the highest values
-                const nodes = selectTopNByValue(
+                const nodes = selectTopNodes(
                     sortedNodes.filter(node => node.isLeaf),
-                    node => node.height ?? 0,
-                    amountOfTopLabels
+                    node => node.height ?? 0
                 )
                 this.setBuildingLabel(nodes, highestNodeInSet)
             }
         }
+    }
+
+    private getTopNodeSelector(state: CcState, amountOfTopLabels: number) {
+        if (labelsPerMapActiveSelector(state)) {
+            return (nodes: Node[], getValue: (node: Node) => number) =>
+                selectTopNByValuePerGroup(nodes, node => getTopLevelMapName(node.path), getValue, amountOfTopLabels)
+        }
+        return (nodes: Node[], getValue: (node: Node) => number) => selectTopNByValue(nodes, getValue, amountOfTopLabels)
     }
 
     private setArrows(sortedNodes: Node[]) {

--- a/visualization/app/codeCharta/util/dataMocks.ts
+++ b/visualization/app/codeCharta/util/dataMocks.ts
@@ -2216,7 +2216,8 @@ export const STATE: CcState = {
         sharpnessMode: SharpnessMode.Standard,
         maxTreeMapFiles: 200,
         labelMode: LabelMode.Height,
-        groupLabelCollisions: false
+        groupLabelCollisions: false,
+        labelsPerMap: false
     },
     files: [],
     appStatus: {
@@ -2276,7 +2277,8 @@ export const DEFAULT_STATE: CcState = {
         sharpnessMode: SharpnessMode.Standard,
         maxTreeMapFiles: 100,
         labelMode: LabelMode.Height,
-        groupLabelCollisions: false
+        groupLabelCollisions: false,
+        labelsPerMap: false
     },
     dynamicSettings: {
         areaMetric: null,

--- a/visualization/app/codeCharta/util/nodePathHelper.spec.ts
+++ b/visualization/app/codeCharta/util/nodePathHelper.spec.ts
@@ -1,0 +1,36 @@
+import { getTopLevelMapName } from "./nodePathHelper"
+
+describe("getTopLevelMapName", () => {
+    it("should return the first path segment below the root", () => {
+        // Arrange
+        const path = "/root/map-a.cc.json/src/main/file.ts"
+
+        // Act
+        const result = getTopLevelMapName(path)
+
+        // Assert
+        expect(result).toBe("map-a.cc.json")
+    })
+
+    it("should return the map name for a direct child of the root", () => {
+        // Arrange
+        const path = "/root/map-a.cc.json"
+
+        // Act
+        const result = getTopLevelMapName(path)
+
+        // Assert
+        expect(result).toBe("map-a.cc.json")
+    })
+
+    it("should return the path unchanged when it is not below the root", () => {
+        // Arrange
+        const path = "some/other/path"
+
+        // Act
+        const result = getTopLevelMapName(path)
+
+        // Assert
+        expect(result).toBe("some/other/path")
+    })
+})

--- a/visualization/app/codeCharta/util/nodePathHelper.ts
+++ b/visualization/app/codeCharta/util/nodePathHelper.ts
@@ -17,6 +17,15 @@ function isAbsoluteRootPath(path: string) {
     return path.startsWith(`${fileRoot.rootPath}/`)
 }
 
+export function getTopLevelMapName(path: string) {
+    if (!isAbsoluteRootPath(path)) {
+        return path
+    }
+    const start = fileRoot.rootPath.length + 1
+    const end = path.indexOf("/", start)
+    return end === -1 ? path.slice(start) : path.slice(start, end)
+}
+
 export function getParent<T>(hashMap: Map<string, T>, path: string): T {
     do {
         // TODO: Check what happens with Windows paths.

--- a/visualization/app/codeCharta/util/selectTopNByValue.spec.ts
+++ b/visualization/app/codeCharta/util/selectTopNByValue.spec.ts
@@ -1,4 +1,4 @@
-import { selectTopNByValue } from "./selectTopNByValue"
+import { selectTopNByValue, selectTopNByValuePerGroup } from "./selectTopNByValue"
 
 describe("selectTopNByValue", () => {
     const getValue = (item: { v: number }) => item.v
@@ -90,5 +90,55 @@ describe("selectTopNByValue", () => {
 
         // Assert
         expect(result.map(item => item.id)).toEqual(["a", "b"])
+    })
+})
+
+describe("selectTopNByValuePerGroup", () => {
+    const getValue = (item: { v: number; group: string }) => item.v
+    const getGroup = (item: { v: number; group: string }) => item.group
+
+    it("should select the n highest items of each group", () => {
+        // Arrange
+        const items = [
+            { v: 100, group: "a" },
+            { v: 50, group: "a" },
+            { v: 20, group: "b" },
+            { v: 10, group: "b" }
+        ]
+
+        // Act
+        const result = selectTopNByValuePerGroup(items, getGroup, getValue, 1)
+
+        // Assert
+        expect(result.map(getValue)).toEqual([100, 20])
+    })
+
+    it("should return all items of a group that has fewer items than n", () => {
+        // Arrange
+        const items = [
+            { v: 100, group: "a" },
+            { v: 50, group: "a" },
+            { v: 20, group: "b" }
+        ]
+
+        // Act
+        const result = selectTopNByValuePerGroup(items, getGroup, getValue, 2)
+
+        // Assert
+        expect(result.map(getValue)).toEqual([100, 50, 20])
+    })
+
+    it("should return an empty array when n is 0", () => {
+        // Arrange
+        const items = [
+            { v: 100, group: "a" },
+            { v: 20, group: "b" }
+        ]
+
+        // Act
+        const result = selectTopNByValuePerGroup(items, getGroup, getValue, 0)
+
+        // Assert
+        expect(result).toEqual([])
     })
 })

--- a/visualization/app/codeCharta/util/selectTopNByValue.ts
+++ b/visualization/app/codeCharta/util/selectTopNByValue.ts
@@ -1,3 +1,17 @@
+export function selectTopNByValuePerGroup<T>(items: T[], getGroup: (item: T) => string, getValue: (item: T) => number, n: number): T[] {
+    const itemsByGroup = new Map<string, T[]>()
+    for (const item of items) {
+        const group = getGroup(item)
+        const groupItems = itemsByGroup.get(group)
+        if (groupItems) {
+            groupItems.push(item)
+        } else {
+            itemsByGroup.set(group, [item])
+        }
+    }
+    return [...itemsByGroup.values()].flatMap(groupItems => selectTopNByValue(groupItems, getValue, n))
+}
+
 export function selectTopNByValue<T>(items: T[], getValue: (item: T) => number, n: number): T[] {
     const limit = Math.floor(n)
     if (Number.isNaN(limit) || limit <= 0) {


### PR DESCRIPTION
When more than one map is selected in standard mode, a new 'All maps | Per map' toggle in the label settings splits the node-selecting label computations per map: top-N labels are picked separately for each map (Height and Color mode), and overlapping labels are only grouped within the same map. Hidden for a single map and in delta mode; defaults to the previous global behavior.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Top labels scope" option in Label Settings with "All maps" and "Per map" modes
  * In "Per map" mode, top labels are selected separately for each map and label collision grouping is isolated per map
  * Option is only visible when multiple maps are selected and hidden in delta mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->