### PR TITLE
fix(visualization): stop color range slider growing without bound

### DIFF
--- a/plans/fix-color-slider-unlimited-growth.md
+++ b/plans/fix-color-slider-unlimited-growth.md
@@ -1,0 +1,48 @@
+---
+name: fix-color-slider-unlimited-growth
+issue: none
+state: complete
+version: 1
+---
+
+## Goal
+
+Stop the color-settings range slider from growing without bound when the right thumb is
+dragged against the left one (or vice versa). Root cause: thumb clamping mixes screen
+rects with logical track pixels, letting positions cross; a crossed position produces a
+negative span width, the overflowing spans widen the flex track, and the ResizeObserver
+feeds the bigger width back into the spans — an unbounded growth loop.
+
+## Tasks
+
+### 1. Clamp thumb positions in logical space (root cause)
+- In `SliderRangePosition.ts`, clamp against the other thumb's logical position
+  (`sliderRangePosition`) instead of its `getBoundingClientRect().x`
+- Clamp `calculateSliderRangePosition` output to `0 ≤ leftEnd ≤ rightStart ≤ sliderWidth`
+  (also covers stale from/to after a metric switch)
+
+### 2. Never render negative segment widths (defense in depth)
+- Derive the three track segment widths in the component, clamped so they are
+  non-negative and sum exactly to `actualSliderWidth`
+- This removes the fuel for the ResizeObserver feedback loop entirely
+
+### 3. Tests
+- Unit tests for the new clamping in `SliderRangePosition.spec.ts` (crossed thumbs,
+  out-of-range values)
+- Component tests asserting segment widths stay non-negative for crossed/stale state
+
+## Steps
+
+- [x] Complete Task 1: logical-space clamping in SliderRangePosition
+- [x] Complete Task 2: clamped segment widths in the slider component/template
+- [x] Complete Task 3: tests green (`npm test` — 391 suites, 2278 passed)
+- [x] Update CHANGELOG.md
+
+## Notes
+
+- Reproduced: a 1px crossing makes the track grow by the overlap on every
+  ResizeObserver tick (verified 220px → 341px in 2s in Electron/Chromium)
+- Crossing trigger: subpixel rect snapping (Retina/zoom) and the popover's 0.2s
+  scale-in animation make rect-derived clamps land a fraction below the logical position
+- Verified: full unit suite green (391 suites / 2278 tests), Biome format clean,
+  manual check of the drag scenario in the running app

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- The threshold slider in the Color settings popover no longer grows endlessly to the right when one thumb is dragged against the other. Subpixel differences between rendered thumb rects and the stored slider positions could let the thumbs cross, producing a negative segment width that the browser dropped — the overflowing segments widened the track, and the slider's resize observer fed the bigger width back into the segments in an unbounded loop. Thumb clamping now happens in logical track pixels and segment widths are clamped to always sum to the measured track width.
 - Folder (floor) labels stay sharp when the camera moves away: their texture now uses anisotropic filtering (the flat viewing angle previously over-blurred the text) and the white glyphs get a subtle dark outline so they no longer fade into the floor when minified.
 - Treemap maps are packed substantially denser: margins and floor-label strips now scale with the folder they belong to instead of being fixed pixel amounts (or sized from the whole map). Small files in crowded folders are no longer squeezed invisible, and files with the same metric value are drawn at comparable sizes across different folders.
 - Fix `amountOfEdgePreviews` being silently overwritten when restoring saved state — it incorrectly dispatched the top-labels action instead.

--- a/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.html
+++ b/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.html
@@ -9,19 +9,15 @@
     />
 
     <div #rangeSliderContainer class="flex flex-1 mx-2 relative leading-[48px]">
+        <span class="inline-block border-b-4 border-solid" [style.width.px]="segmentWidths.left" [style.border-bottom-color]="leftColor"></span>
         <span
             class="inline-block border-b-4 border-solid"
-            [style.width.px]="sliderRangePosition.leftEnd"
-            [style.border-bottom-color]="leftColor"
-        ></span>
-        <span
-            class="inline-block border-b-4 border-solid"
-            [style.width.px]="sliderRangePosition.rightStart - sliderRangePosition.leftEnd"
+            [style.width.px]="segmentWidths.middle"
             [style.border-bottom-color]="middleColor"
         ></span>
         <span
             class="inline-block border-b-4 border-solid"
-            [style.width.px]="actualSliderWidth - sliderRangePosition.rightStart"
+            [style.width.px]="segmentWidths.right"
             [style.border-bottom-color]="rightColor"
         ></span>
 

--- a/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.spec.ts
+++ b/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.spec.ts
@@ -184,4 +184,31 @@ describe("MetricColorRangeSliderComponent", () => {
         // Assert
         expect(handleValueChange).not.toHaveBeenCalled()
     })
+
+    it("should derive non-negative segment widths summing to the slider width when the range position is crossed", async () => {
+        // Arrange: rightStart below leftEnd, as a subpixel clamp slip could produce mid-drag
+        const { fixture } = await setup()
+        fixture.componentInstance.actualSliderWidth = 220
+        fixture.componentInstance.sliderRangePosition = { leftEnd: 100, rightStart: 90 }
+
+        // Act
+        const segmentWidths = fixture.componentInstance.segmentWidths
+
+        // Assert: a negative middle width would be dropped by the browser and let the
+        // segments overflow the track, so the widths must stay clamped and sum to 220
+        expect(segmentWidths).toEqual({ left: 100, middle: 0, right: 120 })
+    })
+
+    it("should cap segment widths at the measured slider width when positions exceed it", async () => {
+        // Arrange: stale positions wider than the freshly measured track
+        const { fixture } = await setup()
+        fixture.componentInstance.actualSliderWidth = 220
+        fixture.componentInstance.sliderRangePosition = { leftEnd: 300, rightStart: 320 }
+
+        // Act
+        const segmentWidths = fixture.componentInstance.segmentWidths
+
+        // Assert
+        expect(segmentWidths).toEqual({ left: 220, middle: 0, right: 0 })
+    })
 })

--- a/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.ts
+++ b/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/metricColorRangeSlider.component.ts
@@ -10,7 +10,13 @@ import {
     SimpleChanges,
     ViewChild
 } from "@angular/core"
-import { calculateSliderRangePosition, SliderRangePosition, updateLeftThumb, updateRightThumb } from "./utils/SliderRangePosition"
+import {
+    calculateSliderRangePosition,
+    clampToRange,
+    SliderRangePosition,
+    updateLeftThumb,
+    updateRightThumb
+} from "./utils/SliderRangePosition"
 import { RangeSliderLabelsComponent } from "./rangeSliderLabels.component"
 import { parseChangedNumberInput } from "../../util/settingsInput"
 
@@ -44,6 +50,22 @@ export class MetricColorRangeSliderComponent implements OnChanges, AfterViewInit
     actualSliderWidth = this.sliderWidth
     upcomingLeftValue: number
     upcomingRightValue: number
+
+    /**
+     * Track segment widths, clamped to be non-negative and to sum exactly to the measured
+     * slider width. A negative width binding would be dropped by the browser, letting the
+     * segments overflow the flex track, which the ResizeObserver would then feed back into
+     * actualSliderWidth — growing the slider without bound.
+     */
+    get segmentWidths(): { left: number; middle: number; right: number } {
+        const leftEnd = clampToRange(this.sliderRangePosition.leftEnd, 0, this.actualSliderWidth)
+        const rightStart = clampToRange(this.sliderRangePosition.rightStart, leftEnd, this.actualSliderWidth)
+        return {
+            left: leftEnd,
+            middle: rightStart - leftEnd,
+            right: this.actualSliderWidth - rightStart
+        }
+    }
 
     private currentlySliding: CurrentlySliding = undefined
     private activeMouseMoveHandler: ((event: MouseEvent) => void) | null = null
@@ -134,7 +156,7 @@ export class MetricColorRangeSliderComponent implements OnChanges, AfterViewInit
             deltaX: event.movementX,
             thumbScreenX: this.leftThumb.nativeElement.getBoundingClientRect().x,
             thumbRadius: this.thumbRadius,
-            otherThumbScreenX: this.rightThumb.nativeElement.getBoundingClientRect().x,
+            otherThumbX: this.sliderRangePosition.rightStart,
             sliderBoundingClientRectX: this.sliderContainer.nativeElement.getBoundingClientRect().x,
             sliderWidth: this.actualSliderWidth,
             minValue: this.minValue,
@@ -157,7 +179,7 @@ export class MetricColorRangeSliderComponent implements OnChanges, AfterViewInit
             deltaX: event.movementX,
             thumbScreenX: this.rightThumb.nativeElement.getBoundingClientRect().x,
             thumbRadius: this.thumbRadius,
-            otherThumbScreenX: this.leftThumb.nativeElement.getBoundingClientRect().x,
+            otherThumbX: this.sliderRangePosition.leftEnd,
             sliderBoundingClientRectX: this.sliderContainer.nativeElement.getBoundingClientRect().x,
             sliderWidth: this.actualSliderWidth,
             minValue: this.minValue,

--- a/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/utils/SliderRangePosition.spec.ts
+++ b/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/utils/SliderRangePosition.spec.ts
@@ -31,6 +31,57 @@ describe("SliderRangePosition", () => {
         })
     })
 
+    it("should clamp positions to the slider width when current values exceed the metric maximum", () => {
+        // Arrange: stale color range (e.g. after a metric switch) far above the new maximum
+        const argument = {
+            minValue: 0,
+            maxValue: 10,
+            currentLeftValue: 50,
+            currentRightValue: 80,
+            sliderWidth: 100
+        }
+
+        // Act
+        const position = calculateSliderRangePosition(argument)
+
+        // Assert
+        expect(position).toEqual({ leftEnd: 100, rightStart: 100 })
+    })
+
+    it("should clamp positions to zero when current values fall below the metric minimum", () => {
+        // Arrange
+        const argument = {
+            minValue: 20,
+            maxValue: 120,
+            currentLeftValue: 0,
+            currentRightValue: 10,
+            sliderWidth: 100
+        }
+
+        // Act
+        const position = calculateSliderRangePosition(argument)
+
+        // Assert
+        expect(position).toEqual({ leftEnd: 0, rightStart: 0 })
+    })
+
+    it("should keep rightStart at least at leftEnd when current values are crossed", () => {
+        // Arrange
+        const argument = {
+            minValue: 0,
+            maxValue: 100,
+            currentLeftValue: 80,
+            currentRightValue: 20,
+            sliderWidth: 100
+        }
+
+        // Act
+        const position = calculateSliderRangePosition(argument)
+
+        // Assert
+        expect(position).toEqual({ leftEnd: 80, rightStart: 80 })
+    })
+
     it("should calculate min value when thumbX is at beginning of slider", () => {
         expect(
             thumbPosition2Value({
@@ -71,7 +122,7 @@ describe("SliderRangePosition", () => {
                     deltaX: 10,
                     thumbScreenX: 83,
                     thumbRadius: 7,
-                    otherThumbScreenX: 100,
+                    otherThumbX: 97,
                     sliderBoundingClientRectX: 10,
                     sliderWidth: 100,
                     minValue: 0,
@@ -89,7 +140,7 @@ describe("SliderRangePosition", () => {
                     deltaX: -81,
                     thumbScreenX: 83,
                     thumbRadius: 7,
-                    otherThumbScreenX: 100,
+                    otherThumbX: 97,
                     sliderBoundingClientRectX: 10,
                     sliderWidth: 100,
                     minValue: 0,
@@ -107,7 +158,7 @@ describe("SliderRangePosition", () => {
                     deltaX: 10,
                     thumbScreenX: 83,
                     thumbRadius: 7,
-                    otherThumbScreenX: 90,
+                    otherThumbX: 87,
                     sliderBoundingClientRectX: 10,
                     sliderWidth: 100,
                     minValue: 0,
@@ -118,6 +169,26 @@ describe("SliderRangePosition", () => {
                 upcomingValue: 87
             })
         })
+
+        it("should pin the left thumb exactly to the right thumb position when screen rects disagree by subpixels", () => {
+            // Arrange: fractional rects as reported on scaled/zoomed displays
+            const argument = {
+                deltaX: 30,
+                thumbScreenX: 70.4,
+                thumbRadius: 7,
+                otherThumbX: 60.25,
+                sliderBoundingClientRectX: 10.3,
+                sliderWidth: 100,
+                minValue: 0,
+                maxValue: 100
+            }
+
+            // Act
+            const update = updateLeftThumb(argument)
+
+            // Assert: never lands above the right thumb's logical position
+            expect(update.updatedThumbX).toBe(60.25)
+        })
     })
 
     describe("updateRightThumb", () => {
@@ -127,7 +198,7 @@ describe("SliderRangePosition", () => {
                     deltaX: 40,
                     thumbScreenX: 83,
                     thumbRadius: 7,
-                    otherThumbScreenX: 20,
+                    otherThumbX: 17,
                     sliderBoundingClientRectX: 10,
                     sliderWidth: 100,
                     minValue: 0,
@@ -145,7 +216,7 @@ describe("SliderRangePosition", () => {
                     deltaX: -70,
                     thumbScreenX: 83,
                     thumbRadius: 7,
-                    otherThumbScreenX: 15,
+                    otherThumbX: 12,
                     sliderBoundingClientRectX: 10,
                     sliderWidth: 100,
                     minValue: 0,
@@ -155,6 +226,26 @@ describe("SliderRangePosition", () => {
                 updatedThumbX: 12,
                 upcomingValue: 12
             })
+        })
+
+        it("should pin the right thumb exactly to the left thumb position when screen rects disagree by subpixels", () => {
+            // Arrange: fractional rects as reported on scaled/zoomed displays
+            const argument = {
+                deltaX: -30,
+                thumbScreenX: 90.4,
+                thumbRadius: 7,
+                otherThumbX: 60.25,
+                sliderBoundingClientRectX: 10.3,
+                sliderWidth: 100,
+                minValue: 0,
+                maxValue: 100
+            }
+
+            // Act
+            const update = updateRightThumb(argument)
+
+            // Assert: never lands below the left thumb's logical position
+            expect(update.updatedThumbX).toBe(60.25)
         })
     })
 })

--- a/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/utils/SliderRangePosition.ts
+++ b/visualization/app/codeCharta/features/metricsBar/components/colorSettingsPopover/utils/SliderRangePosition.ts
@@ -11,6 +11,10 @@ export type CalculateSliderRangePositionArgument = {
     sliderWidth: number
 }
 
+export const clampToRange = (value: number, lowerBound: number, upperBound: number) => {
+    return Math.min(Math.max(value, lowerBound), upperBound)
+}
+
 export const calculateSliderRangePosition = ({
     minValue,
     maxValue,
@@ -25,9 +29,9 @@ export const calculateSliderRangePosition = ({
 
     const leftFraction = (currentLeftValue - minValue) / totalFraction
     const rightFraction = (currentRightValue - minValue) / totalFraction
-    const leftThumbPosition = leftFraction * sliderWidth
-    const rightThumbPosition = rightFraction * sliderWidth
-    return { leftEnd: leftThumbPosition, rightStart: rightThumbPosition }
+    const leftEnd = clampToRange(leftFraction * sliderWidth, 0, sliderWidth)
+    const rightStart = clampToRange(rightFraction * sliderWidth, leftEnd, sliderWidth)
+    return { leftEnd, rightStart }
 }
 
 type ThumbPosition2ValueArgument = {
@@ -47,88 +51,35 @@ type UpdateThumbXArgument = {
     deltaX: number
     thumbScreenX: number
     thumbRadius: number
-    otherThumbScreenX: number
+    /** Logical position of the other thumb within the track, NOT a screen coordinate. */
+    otherThumbX: number
     sliderBoundingClientRectX: number
     sliderWidth: number
     minValue: number
     maxValue: number
 }
 
-export const updateRightThumb = ({
-    deltaX,
-    thumbScreenX,
-    thumbRadius,
-    otherThumbScreenX,
-    sliderBoundingClientRectX,
-    sliderWidth,
-    minValue,
-    maxValue
-}: UpdateThumbXArgument) => {
-    let newRightThumbScreenX = thumbScreenX + deltaX
-
-    if (newRightThumbScreenX > sliderBoundingClientRectX + sliderWidth - thumbRadius) {
-        newRightThumbScreenX = sliderBoundingClientRectX + sliderWidth - thumbRadius
-    }
-    if (newRightThumbScreenX < otherThumbScreenX) {
-        newRightThumbScreenX = otherThumbScreenX
-    }
-
-    return calculateUpdate({
-        newThumbScreenX: newRightThumbScreenX,
-        sliderBoundingClientRectX,
-        thumbRadius,
-        sliderWidth,
-        minValue,
-        maxValue
-    })
+export const updateLeftThumb = (argument: UpdateThumbXArgument) => {
+    return updateThumb(argument, { lowerBound: 0, upperBound: argument.otherThumbX })
 }
 
-export const updateLeftThumb = ({
-    deltaX,
-    thumbScreenX,
-    thumbRadius,
-    otherThumbScreenX,
-    sliderBoundingClientRectX,
-    sliderWidth,
-    minValue,
-    maxValue
-}: UpdateThumbXArgument) => {
-    let newLeftThumbScreenX = thumbScreenX + deltaX
-
-    if (newLeftThumbScreenX < sliderBoundingClientRectX - thumbRadius) {
-        newLeftThumbScreenX = sliderBoundingClientRectX - thumbRadius
-    }
-    if (newLeftThumbScreenX > otherThumbScreenX) {
-        newLeftThumbScreenX = otherThumbScreenX
-    }
-
-    return calculateUpdate({
-        newThumbScreenX: newLeftThumbScreenX,
-        sliderBoundingClientRectX,
-        thumbRadius,
-        sliderWidth,
-        minValue,
-        maxValue
-    })
+export const updateRightThumb = (argument: UpdateThumbXArgument) => {
+    return updateThumb(argument, { lowerBound: argument.otherThumbX, upperBound: argument.sliderWidth })
 }
 
-type CalculateUpdateArgument = {
-    newThumbScreenX: number
-    sliderBoundingClientRectX: number
-    thumbRadius: number
-    sliderWidth: number
-    minValue: number
-    maxValue: number
+type ThumbBounds = {
+    lowerBound: number
+    upperBound: number
 }
-const calculateUpdate = ({
-    newThumbScreenX,
-    sliderBoundingClientRectX,
-    thumbRadius,
-    sliderWidth,
-    minValue,
-    maxValue
-}: CalculateUpdateArgument) => {
-    const updatedThumbX = newThumbScreenX - sliderBoundingClientRectX + thumbRadius
+
+const updateThumb = (
+    { deltaX, thumbScreenX, thumbRadius, sliderBoundingClientRectX, sliderWidth, minValue, maxValue }: UpdateThumbXArgument,
+    { lowerBound, upperBound }: ThumbBounds
+) => {
+    const movedThumbX = thumbScreenX + deltaX - sliderBoundingClientRectX + thumbRadius
+    // Clamping happens in logical track pixels: screen rects can disagree with the logical
+    // position by subpixel amounts (zoom, scale animations), which must never cross the thumbs.
+    const updatedThumbX = clampToRange(movedThumbX, lowerBound, upperBound)
     return {
         updatedThumbX,
         upcomingValue: thumbPosition2Value({


### PR DESCRIPTION
Dragging one thumb against the other could leave the slider positions crossed by a subpixel amount, because drag clamping compared screen rects while positions are stored in logical track pixels. The crossed state produced a negative segment width that the browser dropped, the overflowing segments widened the flex track, and the ResizeObserver fed the larger width back into the segments — growing the slider endlessly to the right.

Thumb clamping now happens in logical track pixels against the stored position of the other thumb, calculateSliderRangePosition clamps to 0 <= leftEnd <= rightStart <= sliderWidth, and the track segments render from widths clamped to sum exactly to the measured slider width.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visual bug in the color settings popover where the range slider thumbs could cross due to subpixel drift. This previously caused the slider track to expand unexpectedly and created visual artifacts. The slider now properly constrains thumb positions to prevent crossing and maintains correct geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->