### PR TITLE
fix(visualization): unblock desktop packaging on Node 24 (yauzl@3)

### DIFF
--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -11195,15 +11195,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -16649,8 +16640,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/percent-round": {
       "version": "2.3.1",
@@ -20772,22 +20762,14 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
+        "pend": "~1.2.0"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/visualization/package.json
+++ b/visualization/package.json
@@ -135,5 +135,10 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.24.2"
+  },
+  "overrides": {
+    "extract-zip": {
+      "yauzl": "^3.4.0"
+    }
   }
 }

--- a/visualization/script/appMain.js
+++ b/visualization/script/appMain.js
@@ -27,8 +27,21 @@ async function main() {
     await prepareZips()
 }
 
+let finished = false
+
+// Guard against a silent failure: if a packaging step leaves an unsettled promise (e.g. a stalled
+// stream that never emits 'end'), the event loop drains and Node would otherwise exit 0 without
+// producing any package. Turn that into a loud, non-zero exit so CI fails on the producing step.
+process.on("beforeExit", () => {
+    if (!finished) {
+        console.error("Error: packaging exited before completing — event loop drained with work still pending.")
+        process.exit(1)
+    }
+})
+
 main()
     .then(() => {
+        finished = true
         console.log("Done!")
         process.exit(0)
     })


### PR DESCRIPTION
The release build's `npm run package` silently exited 0 producing no dist/packages. @electron/packager extracts the electron binary via extract-zip -> yauzl@2.10.0 -> fd-slicer@1.1.0, whose read stream stalls on Node 24.16.0 and never emits 'end'. The awaited packager() promise never settles, the event loop drains, and Node exits 0 — so the next unguarded "List build artifacts" step fails on the missing dist/packages.

- Override extract-zip's yauzl to ^3.4.0 (drops fd-slicer); verified the win32/ia32 extraction and full appMain.js packaging resolve on Node 24.16.0, and Node 22 still works.
- Guard appMain.js with a beforeExit check so an unsettled packaging promise fails loudly (exit 1) instead of silently exiting 0.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability to detect and prevent false success when packaging operations leave incomplete asynchronous tasks.

* **Chores**
  * Updated dependency resolution to ensure correct package versions during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->