### PR TITLE
feat(analysis): add Rust support to UnifiedParser (.rs)

### DIFF
--- a/analysis/CHANGELOG.md
+++ b/analysis/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added 🚀
 
+- Add Rust support to UnifiedParser (.rs)
 - Add JSX support to UnifiedParser
 - Add TSX support to UnifiedParser
 

--- a/analysis/analysers/parsers/UnifiedParser/README.md
+++ b/analysis/analysers/parsers/UnifiedParser/README.md
@@ -25,6 +25,7 @@ The Unified Parser is parser to generate code metrics from a source code file or
 | Bash         | .sh                                    |
 | Vue          | .vue                                   |
 | Delphi       | .pas, .dpr                             |
+| Rust         | .rs                                    |
 
 ## Supported Metrics
 

--- a/analysis/analysers/parsers/UnifiedParser/build.gradle.kts
+++ b/analysis/analysers/parsers/UnifiedParser/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(libs.kotter.test)
 
     // TreesitterLibrary provides all TreeSitter dependencies and metric calculation
-    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.7.0")
+    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.12.0")
 
     testImplementation(libs.jsonassert)
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/AvailableCollectors.kt
@@ -26,5 +26,6 @@ enum class AvailableCollectors(
     SWIFT(FileExtension.SWIFT, { TreeSitterLibraryCollector(Language.SWIFT) }),
     BASH(FileExtension.BASH, { TreeSitterLibraryCollector(Language.BASH) }),
     VUE(FileExtension.VUE, { TreeSitterLibraryCollector(Language.VUE) }),
-    DELPHI(FileExtension.DELPHI, { TreeSitterLibraryCollector(Language.DELPHI) })
+    DELPHI(FileExtension.DELPHI, { TreeSitterLibraryCollector(Language.DELPHI) }),
+    RUST(FileExtension.RUST, { TreeSitterLibraryCollector(Language.RUST) })
 }

--- a/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapter.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/main/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapter.kt
@@ -65,6 +65,7 @@ object TreeSitterAdapter {
         FileExtension.OBJECTIVE_C -> Language.OBJECTIVE_C
         FileExtension.VUE -> Language.VUE
         FileExtension.DELPHI -> Language.DELPHI
+        FileExtension.RUST -> Language.RUST
         else -> null
     }
 

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/UnifiedParserTest.kt
@@ -46,7 +46,8 @@ class UnifiedParserTest {
             Arguments.of("swift", ".swift"),
             Arguments.of("typescript", ".ts"),
             Arguments.of("tsx", ".tsx"),
-            Arguments.of("vue", ".vue")
+            Arguments.of("vue", ".vue"),
+            Arguments.of("rust", ".rs")
         )
     }
 

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/RustCollectorTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/RustCollectorTest.kt
@@ -1,0 +1,207 @@
+package de.maibornwolff.codecharta.analysers.parsers.unified.metriccollectors
+
+import de.maibornwolff.treesitter.excavationsite.api.AvailableFileMetrics
+import de.maibornwolff.treesitter.excavationsite.api.Language
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class RustCollectorTest {
+    private val collector = TreeSitterLibraryCollector(Language.RUST)
+
+    private fun createTestFile(content: String): File {
+        val tempFile = File.createTempFile("testFile", ".txt")
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+
+    @Test
+    fun `should count control flow and logical operators for complexity`() {
+        // given
+        val fileContent = """
+            fn f(x: i32, y: i32, z: i32) -> bool {
+                if x > 0 && y < 10 || z == 5 {
+                    return true;
+                }
+                false
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        // function (1) + if (1) + && (1) + || (1)
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `should count each match arm including wildcard for complexity`() {
+        // given
+        val fileContent = """
+            fn f(x: i32) -> i32 {
+                match x {
+                    1 => 10,
+                    2 => 20,
+                    _ => 0,
+                }
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        // function (1) + three match arms (3)
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `should count closure for complexity but not as a function`() {
+        // given
+        val fileContent = """
+            fn f() {
+                let add = |a: i32, b: i32| a + b;
+                let _ = add;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMPLEXITY.metricName]).isEqualTo(2.0)
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should count line doc and block comments for comment_lines`() {
+        // given
+        val fileContent = """
+            //! Module doc comment.
+
+            // A line comment.
+            /// A doc comment.
+            fn f() {
+                /* a block comment */
+                let x = 1;
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.COMMENT_LINES.metricName]).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `should count function items and trait signatures but not closures for number of functions`() {
+        // given
+        val fileContent = """
+            fn free() {}
+
+            trait T {
+                fn required(&self) -> i32;
+                fn provided(&self) -> i32 {
+                    let f = || 1;
+                    f()
+                }
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.NUMBER_OF_FUNCTIONS.metricName]).isEqualTo(3.0)
+    }
+
+    @Test
+    fun `should not count self as a parameter`() {
+        // given
+        val fileContent = """
+            struct Foo;
+            impl Foo {
+                fn method(&self, a: i32, b: i32) -> i32 {
+                    a + b
+                }
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes["max_parameters_per_function"]).isEqualTo(2.0)
+        Assertions.assertThat(result.attributes["min_parameters_per_function"]).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `should correctly calculate rloc per function metric`() {
+        // given
+        val fileContent = """
+            fn function_one() {
+                // a comment
+                let first = 1;
+                // another comment
+                let second = first + 1;
+            }
+
+            fn function_two(x: i32) -> i32 {
+                x * 2
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes["max_rloc_per_function"]).isEqualTo(2.0)
+        Assertions.assertThat(result.attributes["min_rloc_per_function"]).isEqualTo(1.0)
+        Assertions.assertThat(result.attributes["mean_rloc_per_function"]).isEqualTo(1.5)
+        Assertions.assertThat(result.attributes["median_rloc_per_function"]).isEqualTo(1.5)
+    }
+
+    @Test
+    fun `should detect message chains with 4 or more method calls`() {
+        // given
+        val fileContent = """
+            fn f(obj: Thing) {
+                obj.a().b().c().d();
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.MESSAGE_CHAINS.metricName]).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `should not count short message chains`() {
+        // given
+        val fileContent = """
+            fn f(obj: Thing) {
+                obj.a().b();
+            }
+        """.trimIndent()
+        val input = createTestFile(fileContent)
+
+        // when
+        val result = collector.collectMetricsForFile(input)
+
+        // then
+        Assertions.assertThat(result.attributes[AvailableFileMetrics.MESSAGE_CHAINS.metricName]).isEqualTo(0.0)
+    }
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapterTest.kt
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/kotlin/de/maibornwolff/codecharta/analysers/parsers/unified/metriccollectors/TreeSitterAdapterTest.kt
@@ -77,7 +77,8 @@ class TreeSitterAdapterTest {
             FileExtension.C to Language.C,
             FileExtension.OBJECTIVE_C to Language.OBJECTIVE_C,
             FileExtension.VUE to Language.VUE,
-            FileExtension.DELPHI to Language.DELPHI
+            FileExtension.DELPHI to Language.DELPHI,
+            FileExtension.RUST to Language.RUST
         )
 
         // Act & Assert
@@ -162,7 +163,8 @@ class TreeSitterAdapterTest {
             FileExtension.C,
             FileExtension.OBJECTIVE_C,
             FileExtension.VUE,
-            FileExtension.DELPHI
+            FileExtension.DELPHI,
+            FileExtension.RUST
         )
 
         // Act & Assert

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/rustSample.cc.json
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/rustSample.cc.json
@@ -1,0 +1,307 @@
+{
+  "data": {
+    "projectName": "",
+    "nodes": [
+      {
+        "name": "root",
+        "type": "Folder",
+        "attributes": {},
+        "link": "",
+        "children": [
+          {
+            "name": "rustSample.rs",
+            "type": "File",
+            "attributes": {
+              "complexity": 6.0,
+              "logic_complexity": 0.0,
+              "comment_lines": 11.0,
+              "number_of_functions": 6.0,
+              "message_chains": 0.0,
+              "rloc": 50.0,
+              "loc": 76.0,
+              "long_method": 0.0,
+              "long_parameter_list": 0.0,
+              "excessive_comments": 1.0,
+              "comment_ratio": 0.22,
+              "max_parameters_per_function": 2.0,
+              "min_parameters_per_function": 0.0,
+              "mean_parameters_per_function": 0.67,
+              "median_parameters_per_function": 0.0,
+              "max_complexity_per_function": 0.0,
+              "min_complexity_per_function": 0.0,
+              "mean_complexity_per_function": 0.0,
+              "median_complexity_per_function": 0.0,
+              "max_rloc_per_function": 4.0,
+              "min_rloc_per_function": 0.0,
+              "mean_rloc_per_function": 1.33,
+              "median_rloc_per_function": 1.0
+            },
+            "link": "",
+            "children": [],
+            "checksum": "9e702c9c893d5493"
+          }
+        ]
+      }
+    ],
+    "apiVersion": "1.5",
+    "edges": [],
+    "attributeTypes": {},
+    "attributeDescriptors": {
+      "complexity": {
+        "title": "Complexity",
+        "description": "Complexity of the file representing how much cognitive load is needed to overview the whole file",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "logic_complexity": {
+        "title": "Logic complexity",
+        "description": "Complexity of the file based on number of paths through the code, similar to cyclomatic complexity",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_lines": {
+        "title": "Comment lines",
+        "description": "Number of lines containing either a comment or commented-out code",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "loc": {
+        "title": "Lines of Code",
+        "description": "Lines of code including empty lines and comments",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "rloc": {
+        "title": "Real Lines of Code",
+        "description": "Number of lines that contain at least one character which is neither a whitespace nor a tabulation nor part of a comment",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "number_of_functions": {
+        "title": "Number of functions",
+        "description": "The number of functions or methods present in the file. Does not include anonymous or lambda functions.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_parameters_per_function": {
+        "title": "Maximum parameters per function",
+        "description": "The maximum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_parameters_per_function": {
+        "title": "Minimum parameters per function",
+        "description": "The minimum number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_parameters_per_function": {
+        "title": "Median parameters per function",
+        "description": "The median number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_parameters_per_function": {
+        "title": "Mean parameters per function",
+        "description": "The mean number of parameters a function or method has for this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_complexity_per_function": {
+        "title": "Maximum complexity per function",
+        "description": "The maximum complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_complexity_per_function": {
+        "title": "Minimum complexity per function",
+        "description": "The minimum number of complexity in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_complexity_per_function": {
+        "title": "Mean complexity per function",
+        "description": "The mean complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_complexity_per_function": {
+        "title": "Median complexity per function",
+        "description": "The median complexity found in the body of a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "max_rloc_per_function": {
+        "title": "Maximum real lines of code in a function",
+        "description": "The maximum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "min_rloc_per_function": {
+        "title": "Minimum real lines of code in a function",
+        "description": "The minimum number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "mean_rloc_per_function": {
+        "title": "Mean real lines of code in a function",
+        "description": "The mean number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "median_rloc_per_function": {
+        "title": "Median real lines of code in a function",
+        "description": "The median number of real lines of code in a function of this file.",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_method": {
+        "title": "Long Method",
+        "description": "Code smell showing the number of functions with more than 10 real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "long_parameter_list": {
+        "title": "Long Parameter List",
+        "description": "Code smell showing the number of functions with more than 4 parameters",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "excessive_comments": {
+        "title": "Excessive Comments",
+        "description": "Code smell showing whether a file has more than 10 comment lines",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "comment_ratio": {
+        "title": "Comment Ratio",
+        "description": "The ratio of comment lines to real lines of code (rloc)",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": 0,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      },
+      "message_chains": {
+        "title": "Message Chains",
+        "description": "Code smell showing occurrences of method call chains with 4 or more consecutive calls suggesting tight coupling",
+        "hintLowValue": "",
+        "hintHighValue": "",
+        "link": "https://codecharta.com/docs/parser/unified",
+        "direction": -1,
+        "analyzers": [
+          "unifiedParser"
+        ]
+      }
+    },
+    "blacklist": []
+  },
+  "checksum": "c86faa4b88b0906477b0290dcc619d03"
+}

--- a/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/rustSample.rs
+++ b/analysis/analysers/parsers/UnifiedParser/src/test/resources/languageSamples/rustSample.rs
@@ -1,0 +1,76 @@
+//! Module-level documentation comment for the sample crate.
+
+// A normal line comment.
+use std::collections::HashMap;
+
+/// The maximum number of retries allowed.
+const MAX_RETRIES: u32 = 3;
+
+static GREETING: &str = "hello";
+
+/// Represents a geometric shape.
+pub struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+/// A color enumeration.
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+    Custom(u8, u8, u8),
+}
+
+/// A union of numeric representations.
+pub union Number {
+    integer: i64,
+    floating: f64,
+}
+
+/// Behavior shared by drawable shapes.
+pub trait Drawable {
+    /// Returns the area of the shape.
+    fn area(&self) -> f64;
+
+    fn describe(&self) -> String;
+}
+
+type ShapeMap = HashMap<String, Rectangle>;
+
+impl Rectangle {
+    /// Creates a new rectangle.
+    pub fn new(width: f64, height: f64) -> Rectangle {
+        Rectangle { width, height }
+    }
+}
+
+impl Drawable for Rectangle {
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+
+    fn describe(&self) -> String {
+        let label = "rectangle";
+        let raw = r#"a "raw" string"#;
+        let initial = 'R';
+        format!("{} {} {}", label, raw, initial)
+    }
+}
+
+/// Computes the sum of two integers.
+fn add(a: i32, b: i32) -> i32 {
+    let result = a + b;
+    result
+}
+
+mod geometry {
+    /* A block comment inside a module. */
+    pub const PI: f64 = 3.14159;
+}
+
+macro_rules! square {
+    ($x:expr) => {
+        $x * $x
+    };
+}

--- a/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
+++ b/analysis/model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt
@@ -31,5 +31,6 @@ enum class FileExtension(
     SWIFT(".swift"),
     BASH(".sh"),
     VUE(".vue"),
-    DELPHI(".pas", setOf(".dpr"))
+    DELPHI(".pas", setOf(".dpr")),
+    RUST(".rs")
 }

--- a/gh-pages/src/content/docs/docs/parser/unified.md
+++ b/gh-pages/src/content/docs/docs/parser/unified.md
@@ -28,6 +28,7 @@ CodeCharta. It generates a cc.json file (compressed by default, or uncompressed 
 | Bash         | .sh                                    |
 | Vue          | .vue                                   |
 | Delphi       | .pas, .dpr                             |
+| Rust         | .rs                                    |
 
 ### Supported Metrics
 
@@ -239,6 +240,13 @@ contribute to complexity:
 - **Functions**: `defProc` (procedure/function implementation), `lambda`
 - **Logical operators**: `kAnd`, `kOr`, `kXor` in `exprBinary`
 
+##### Rust (.rs)
+
+- **Control flow**: `if_expression`, `while_expression`, `for_expression`, `loop_expression`, `match_arm` (the
+  `if`/`while` nodes also cover `if let`/`while let`; the `_` wildcard arm counts like any other arm)
+- **Functions**: `function_item`, `function_signature_item` (bodyless trait method signatures), `closure_expression`
+- **Logical operators**: `&&`, `||` in binary expressions
+
 #### Comment Lines
 
 Comment lines are counted based on language-specific comment syntax:
@@ -256,6 +264,7 @@ Comment lines are counted based on language-specific comment syntax:
 - **Swift**: `comment`, `multiline_comment`
 - **Bash**: `comment`
 - **Delphi**: `comment` (covers `//` line, `{ }` brace, and `(* *)` star comments)
+- **Rust**: `line_comment`, `block_comment` (cover `//`, `///`, `//!` and `/* */`, `/** */`, `/*! */`)
 
 #### Number of Functions
 
@@ -338,6 +347,11 @@ Function counting identifies different types of function definitions per languag
 - **Functions**: `defProc` (procedure/function implementation in the `implementation` section). Forward declarations in the `interface` section
   (`declProc`) are not counted, and `lambda` contributes only to complexity.
 
+##### Rust (.rs)
+
+- **Functions**: `function_item` (free functions, `impl` methods, trait default methods) and `function_signature_item`
+  (bodyless trait method signatures). `closure_expression` contributes only to complexity and is not counted as a function.
+
 #### Lines of Code (LOC)
 
 LOC is calculated as the total number of lines in the file, including empty lines and comments. This metric is language-independent and
@@ -371,6 +385,7 @@ Parameters per function counts the number of parameters declared for each functi
 - **Swift**: `parameter`
 - **Bash**: Parameters are counted from function definitions
 - **Delphi**: `declArg`
+- **Rust**: `parameter` (the `self` receiver is a distinct `self_parameter` node and is excluded)
 
 #### Message Chains
 
@@ -451,6 +466,11 @@ Message chains are not applicable to Bash as it does not support method chaining
 - **Chain nodes**: `exprCall`, `exprDot`
 - **Call nodes**: `exprCall`, `exprDot` (paren-less `Obj.M1.M2.M3.M4` chains). When `exprDot` is wrapped in `exprCall` (e.g.
   `Obj.M1().M2().M3().M4()`), only `exprCall` counts, preventing double-counting of message-chain calls.
+
+##### Rust (.rs)
+
+- **Chain nodes**: `call_expression`, `field_expression`
+- **Call nodes**: `call_expression`
 
 #### Code Smells
 

--- a/plans/2026-06-29-rust-unifiedparser-support.md
+++ b/plans/2026-06-29-rust-unifiedparser-support.md
@@ -1,0 +1,241 @@
+---
+date: 2026-06-29T09:35:11Z
+git_commit: 76da06841d62ca271bdaea778fe890eb898cce5e
+branch: main
+topic: "Rust metrics support for the UnifiedParser"
+tags: [plan, analysis, UnifiedParser, gh-pages, rust, treesitter]
+status: complete
+---
+
+# Rust metrics support for the UnifiedParser Implementation Plan
+
+## Overview
+
+Add Rust (`.rs`) code-metrics support to CodeCharta's `unifiedparser`, consuming the new Rust
+metrics from TreeSitterExcavationSite (TSE). During development CodeCharta builds against a **local
+TSE** via a Gradle composite build; once TSE releases a version containing Rust metrics, a final
+deferred phase swaps the local override for the released JitPack coordinate.
+
+## Current State Analysis
+
+- **TSE is ready.** `Language.RUST` (`.rs`) exists and `TreeSitterMetrics.parse(content, Language.RUST)`
+  returns populated metrics. This lives on TSE branch `feat/rust-metric-support` and is **not yet
+  released** (latest tag `v0.11.0`; Rust metrics unreleased).
+- **CodeCharta pins an old TSE.** `analysis/analysers/parsers/UnifiedParser/build.gradle.kts:12`:
+  `implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.7.0")` — too old to contain
+  `Language.RUST`, so the Rust code changes will not compile until CodeCharta points at local TSE.
+- **Integration is small and additive.** Metrics are language-agnostic string keys copied straight
+  through (`TreeSitterAdapter.convertToMutableNode`), so no new metric names / `AttributeDescriptors`
+  are needed. Adding a language end-to-end touches three production files:
+  - `analysis/model/.../serialization/FileExtension.kt:34` (central extension enum; ends at `DELPHI`)
+  - `analysis/analysers/parsers/UnifiedParser/.../metriccollectors/AvailableCollectors.kt:29`
+    (the enum `ProjectScanner.findCollectorForFileType` iterates to decide parsable files — the
+    functional gate)
+  - `analysis/analysers/parsers/UnifiedParser/.../metriccollectors/TreeSitterAdapter.kt:67`
+    (`getLanguageForExtension` `when`; has `else -> null`)
+- **No hidden compile risk.** The only other `when(FileExtension)` (`model/.../OutputFileHandler.kt`)
+  has an `else`, so a new enum value does not break exhaustiveness.
+- **Tests follow one consistent pattern** (golden `.cc.json` per language sample + parameterized
+  test + mapping lists). See `UnifiedParserTest.kt:29`, `TreeSitterAdapterTest.kt`, and the
+  `*CollectorTest.kt` files.
+- **Build env:** Gradle 9.3.1; TSE pins `jvmToolchain(17)`, so a JDK 17 toolchain must be available
+  for the composite build (already installed in this sandbox).
+
+## Desired End State
+
+`ccsh unifiedparser` parses `.rs` files and emits a `cc.json` with the same metric set as every other
+language. Rust appears in `provideSupportedLanguages()` with a committed golden, in both mapping
+lists, in the README/gh-pages support tables, in the gh-pages detailed-metric subsections, and in
+`analysis/CHANGELOG.md`. During development everything is green against local TSE; the merge-ready
+state (Phase 5) resolves Rust from a released TSE tag with no composite build.
+
+## What We're NOT Doing
+
+- No new metrics, `AttributeDescriptors`, or metric calculators (Rust reuses the language-agnostic set).
+- No changes to TSE itself (already done on `feat/rust-metric-support`).
+- No dependency/extraction-graph (DependaCharta) work — this is UnifiedParser **metrics** only.
+- No visualization/frontend changes (it has no hardcoded UnifiedParser language list).
+- Phase 5 (released-version switch) is **not executed now** — it is blocked on a TSE release.
+
+## Architecture and Code Reuse
+
+```
+ccsh unifiedparser <path>
+   └─ ProjectScanner.findCollectorForFileType(ext)   ── gate: AvailableCollectors
+        └─ TreeSitterLibraryCollector(Language.RUST)
+             └─ TreeSitterAdapter.collectMetricsForFile(file)
+                  └─ getLanguageForFile() → Language.fromExtension(".rs")  [TSE, already works]
+                  └─ TreeSitterMetrics.parse(content, Language.RUST)        [TSE, already works]
+                  └─ convertToMutableNode() → metrics copied verbatim       [language-agnostic]
+```
+
+Composite-build override (chosen approach — keeps the JitPack line untouched; one-place toggle):
+
+```kotlin
+// analysis/settings.gradle.kts
+includeBuild("../../TreeSitterExcavationSite") {
+    dependencySubstitution {
+        substitute(module("com.github.MaibornWolff:TreeSitterExcavationSite"))
+            .using(project(":"))
+    }
+}
+```
+
+Affected files:
+
+- `analysis/`
+  - `settings.gradle.kts` — add `includeBuild` + `dependencySubstitution` block (Phase 1; removed in Phase 5)
+  - `model/src/main/kotlin/de/maibornwolff/codecharta/serialization/FileExtension.kt` — add `RUST(".rs")`
+  - `analysers/parsers/UnifiedParser/`
+    - `build.gradle.kts` — **unchanged** in Phases 1–4; version bump only in Phase 5
+    - `src/main/kotlin/.../metriccollectors/AvailableCollectors.kt` — add `RUST` collector entry
+    - `src/main/kotlin/.../metriccollectors/TreeSitterAdapter.kt` — add `FileExtension.RUST -> Language.RUST`
+    - `src/test/kotlin/.../metriccollectors/RustCollectorTest.kt` — new (mirror `GoCollectorTest`)
+    - `src/test/kotlin/.../UnifiedParserTest.kt` — add `Arguments.of("rust", ".rs")`
+    - `src/test/kotlin/.../metriccollectors/TreeSitterAdapterTest.kt` — add to `expectedMappings` + `supportedExtensions`
+    - `src/test/resources/languageSamples/rustSample.rs` — new fixture
+    - `src/test/resources/languageSamples/rustSample.cc.json` — new golden (generated by the parser)
+    - `README.md` — add Rust row to Supported Languages
+- `gh-pages/src/content/docs/docs/parser/unified.md` — table row + Rust entries in detailed subsections
+- `analysis/CHANGELOG.md` — `## [unreleased] → ### Added 🚀` entry
+
+## Performance Considerations
+
+None. One additional enum entry and one already-supported grammar; per-file parsing cost is unchanged.
+
+## Migration Notes
+
+- Implement on a CodeCharta feature branch (e.g. `feat/rust-unifiedparser-support`); do not work on `main`.
+- The composite-build override in `settings.gradle.kts` is **machine-specific** (relative path to a
+  sibling checkout) and must not reach `main`. It is intentionally committed on the feature branch for
+  reviewability and removed in Phase 5.
+- The branch is not mergeable until TSE releases a Rust-metrics tag (Phase 5), because the committed
+  Rust code requires a TSE version that contains `Language.RUST` with populated metrics.
+
+## Phase 1: Wire CodeCharta to local TSE (composite build)
+
+Unblocks compilation against the new Rust API. No CodeCharta code changes yet.
+
+**Tasks**:
+- [x] In `analysis/settings.gradle.kts`, add the `includeBuild("../../TreeSitterExcavationSite")`
+      block with the `dependencySubstitution` mapping `com.github.MaibornWolff:TreeSitterExcavationSite`
+      → `project(":")` (see Architecture snippet). Leave `UnifiedParser/build.gradle.kts:12` unchanged.
+- [x] Ensure the local TSE checkout is on a branch containing Rust metrics (`feat/rust-metric-support`).
+
+**Automated Verification**:
+- [x] `./gradlew :analysers:parsers:UnifiedParser:dependencies --configuration runtimeClasspath` shows
+      TSE resolved from the included build (`v0.7.0 -> project :TreeSitterExcavationSite`), not JitPack.
+- [x] `./gradlew :analysers:parsers:UnifiedParser:compileKotlin` succeeds (TSE built locally under JDK 17).
+- [x] `./gradlew :analysers:parsers:UnifiedParser:test` (existing suite) still passes against local TSE.
+
+---
+
+## Phase 2: Register Rust in the UnifiedParser
+
+Dependencies: **Phase 1**
+
+The three additive production changes plus a CodeCharta-side collector unit test.
+
+**Tasks**:
+- [x] `FileExtension.kt`: add a comma after the `DELPHI(...)` entry and add `RUST(".rs")` as the last constant.
+- [x] `AvailableCollectors.kt`: add `RUST(FileExtension.RUST, { TreeSitterLibraryCollector(Language.RUST) })`
+      (after the `DELPHI` entry; add the preceding comma).
+- [x] `TreeSitterAdapter.kt` `getLanguageForExtension`: add `FileExtension.RUST -> Language.RUST` before `else -> null`.
+- [x] Add `RustCollectorTest.kt` mirroring `GoCollectorTest.kt` (9 cases: complexity for if/&&/||, match arms,
+      closure, comment_lines, number_of_functions incl. trait signatures, parameters excl. self, rloc-per-function, message chains).
+
+```kotlin
+// sanity examples (exact values verified against TSE RustMetricsTest)
+collector.collectMetricsForFile(rs("fn f(x:i32){ if x>0 { } }"))
+    .attributes[AvailableFileMetrics.COMPLEXITY.metricName]   // == 2.0 (1 fn + 1 if)
+```
+
+**Automated Verification**:
+- [x] `RustCollectorTest` (Unit) passes (9/9).
+- [x] `./gradlew :analysers:parsers:UnifiedParser:compileKotlin` and `:model:compileKotlin` succeed.
+- [x] `./gradlew :model:ktlintCheck :analysers:parsers:UnifiedParser:ktlintCheck` passes.
+
+---
+
+## Phase 3: Golden fixture + parameterized & adapter tests
+
+Dependencies: **Phase 2**
+
+Wire Rust into the existing parameterized golden test and mapping-list tests.
+
+**Tasks**:
+- [x] Create `src/test/resources/languageSamples/rustSample.rs` — reused TSE's curated `rust_sample.rs`
+      verbatim so values cross-check against TSE's verified golden.
+- [x] Generate `rustSample.cc.json` via `ccsh unifiedparser .../rustSample.rs`. Sanity-checked:
+      complexity 6.0, logic_complexity 0.0, comment_lines 11.0, number_of_functions 6.0,
+      message_chains 0.0, rloc 50.0, loc 76.0 — all match TSE's golden exactly.
+- [x] `UnifiedParserTest.kt` `provideSupportedLanguages()`: add `Arguments.of("rust", ".rs")`.
+- [x] `TreeSitterAdapterTest.kt`: add `FileExtension.RUST to Language.RUST` to `expectedMappings`
+      and `FileExtension.RUST` to the `supportedExtensions` list.
+
+**Automated Verification**:
+- [x] `UnifiedParserTest` parameterized case `[21] "rust", ".rs"` (Integration) passes (golden matches, `NON_EXTENSIBLE`).
+- [x] `TreeSitterAdapterTest` mapping + supported-extensions tests (Unit) pass with the Rust entry.
+- [x] `./gradlew :analysers:parsers:UnifiedParser:test` (full module suite) passes; `ktlintCheck` clean.
+
+**Manual Verification**:
+- [-] `ccsh unifiedparser path/to/rustSample.rs` produces a `cc.json` whose Rust file node carries
+      non-zero `complexity`/`number_of_functions`/`comment_lines` + `*_per_function` aggregations.
+      (Executed during golden generation — values above; awaiting user confirmation.)
+
+---
+
+## Phase 4: Documentation
+
+Dependencies: **Phase 2** (extensions/behaviour finalized)
+
+**Tasks**:
+- [x] `analysis/analysers/parsers/UnifiedParser/README.md`: add `| Rust | .rs |` to the Supported Languages table.
+- [x] `gh-pages/.../parser/unified.md` — Supported Languages table: add `| Rust | .rs |`.
+- [x] `gh-pages/.../parser/unified.md` — detailed subsections, mirroring the existing per-language format:
+  - [x] **Complexity** `##### Rust (.rs)` — Control flow: `if_expression`, `while_expression`,
+        `for_expression`, `loop_expression`, `match_arm`; Functions: `function_item`,
+        `function_signature_item`, `closure_expression`; Logical operators: `&&`, `||` in binary expressions.
+  - [x] **Comment Lines** — add `**Rust**: line_comment, block_comment`.
+  - [x] **Number of Functions** `##### Rust (.rs)` — `function_item`, `function_signature_item`
+        (closures add complexity only; `self` is a distinct receiver node).
+  - [x] **Parameters per Function** — add `**Rust**: parameter (self_parameter excluded)`.
+  - [x] **Message Chains** `##### Rust (.rs)` — Chain nodes: `call_expression`, `field_expression`; Call nodes: `call_expression`.
+- [x] `analysis/CHANGELOG.md` under `## [unreleased] → ### Added 🚀`: `- Add Rust support to UnifiedParser (.rs)`.
+
+**Automated Verification**:
+- [-] gh-pages site build (`npm run build`): NOT run in sandbox (no `node_modules`, needs `npm install`).
+      Changes are pure-markdown additions (table row + `#####` headings + bullets); deferred to CI.
+
+---
+
+## Phase 5: Switch to released TSE (DEFERRED — blocked on TSE release)
+
+Dependencies: **Phase 1–4**, **TSE release containing Rust metrics**
+
+Executed only after TSE merges `feat/rust-metric-support` and publishes a tag (here called `vX.Y.Z`).
+This produces the merge-ready CodeCharta state (no composite build, resolves from JitPack).
+
+Executed: TSE released as **v0.12.0** (tag commit `83c3ede` "feat(rust): add Rust code-metrics support").
+
+**Tasks**:
+- [x] Remove the `includeBuild(...)`/`dependencySubstitution` block from `analysis/settings.gradle.kts`.
+- [x] Bump `UnifiedParser/build.gradle.kts:12` `v0.7.0` → `v0.12.0`.
+- [x] Confirm the JitPack repository is still present (it is, in the root `buildscript`/`allprojects` repos).
+
+**Automated Verification**:
+- [x] `./gradlew :analysers:parsers:UnifiedParser:dependencies` shows `com.github.MaibornWolff:TreeSitterExcavationSite:v0.12.0` (JitPack), not a local project.
+- [x] `./gradlew :analysers:parsers:UnifiedParser:test` passes against released TSE (`[21] "rust"` + 9 RustCollectorTest); `:model:test` + `ktlintCheck` clean.
+- [-] Full multi-module `./gradlew build`: NOT run in sandbox (heavy). Only changed modules are `model`
+      (FileExtension enum addition) and `UnifiedParser`, both verified green; deferred to CI.
+
+---
+
+## References
+
+- TSE Rust metrics: `TreeSitterExcavationSite/plans/add-rust-metric-support.md`; branch `feat/rust-metric-support`
+- TSE composite-build guidance: `TreeSitterExcavationSite/.claude/rules/dependency-migration.md` ("Composite Build (for local testing)")
+- Integration call site: `analysis/analysers/parsers/UnifiedParser/.../metriccollectors/TreeSitterAdapter.kt:32`
+- Parsable-file gate: `analysis/analysers/parsers/UnifiedParser/.../AvailableCollectors.kt` + `ProjectScanner.findCollectorForFileType`
+- Golden test pattern: `analysis/analysers/parsers/UnifiedParser/src/test/kotlin/.../UnifiedParserTest.kt:82`
+- Docs to update: `analysis/.../UnifiedParser/README.md`, `gh-pages/src/content/docs/docs/parser/unified.md`, `analysis/CHANGELOG.md`


### PR DESCRIPTION
Register Rust in the UnifiedParser so it parses .rs files and emits the standard metric set, backed by TreeSitterExcavationSite v0.12.0 (which adds Rust code metrics).

- FileExtension: add RUST(".rs")
- AvailableCollectors + TreeSitterAdapter: map .rs -> Language.RUST
- bump TSE dependency v0.7.0 -> v0.12.0
- tests: RustCollectorTest (9 cases) and the parameterized golden (rustSample.rs / rustSample.cc.json), plus TreeSitterAdapter mapping lists
- docs: README + gh-pages supported-languages table and per-metric subsections, CHANGELOG

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust files (`.rs`) in the Unified Parser.
  * Rust is now included in supported-language listings and parser coverage.

* **Bug Fixes**
  * Rust files are now recognized and processed instead of being treated as unsupported.

* **Documentation**
  * Updated parser documentation and changelog to reflect Rust support.

* **Tests**
  * Added and updated test coverage for Rust parsing and metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->