### PR TITLE
fix(gh-pages): deploy docs/visualization by anchoring clean-exclude

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths:
       - 'gh-pages/**'
+      # Changes to the deploy step itself must republish, otherwise a fixed workflow
+      # only takes effect on the next unrelated docs change.
+      - '.github/workflows/deploy-github-pages.yml'
     branches:
       - main
 
@@ -34,10 +37,15 @@ jobs:
         run: npm run build
 
       # Publishes the built static site (gh-pages/dist) to the gh-pages branch.
-      # The Web Studio app (visualization/) and staging (stg/) are deployed to the same
-      # branch by other workflows, so they are preserved via clean-exclude.
+      # The Web Studio app (visualization/app/), the archived visualization coverage report
+      # (visualization/coverage/, linked from the README) and staging (stg/) live on the same
+      # branch but are not built here, so they are preserved via clean-exclude.
       # dist/ already contains CNAME and .nojekyll (from public/), the latter stops
       # GitHub Pages from running Jekyll over the _astro/ asset directory.
+      # The clean-exclude patterns must be anchored with a leading slash and name the folder
+      # exactly: they are passed to rsync, which matches an unanchored pattern against the
+      # end of every path, so `visualization/**` also excluded docs/visualization/** and the
+      # site's own /visualization redirect from the upload.
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
@@ -45,5 +53,6 @@ jobs:
           branch: gh-pages
           folder: gh-pages/dist
           clean-exclude: |
-            stg/**
-            visualization/**
+            /stg
+            /visualization/app
+            /visualization/coverage


### PR DESCRIPTION
The clean-exclude entries are passed to rsync, which matches an unanchored pattern against the end of every path. `visualization/**` therefore excluded docs/visualization/** and assets/images/docs/visualization/** from the upload, not just the Web Studio app at the branch root, so every page under the Visualization sidebar section 404ed on the live site while the rest worked.

Anchor the patterns and name the preserved folders exactly. This also lets the site's own /visualization redirect page deploy. visualization/coverage/ is excluded as well: it is linked from the README, still served, and is not rebuilt here.

Add the workflow to its own push path filter, otherwise this fix would only take effect on the next unrelated gh-pages/** change.

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to run when its workflow configuration changes.
  * Refined deployment path exclusions to preserve only the staging, visualization app, and visualization coverage areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->