### PR TITLE
Grey out wordless nodes

### DIFF
--- a/plans/2026-09-02-domain-view-grey-out-wordless-nodes.md
+++ b/plans/2026-09-02-domain-view-grey-out-wordless-nodes.md
@@ -1,7 +1,7 @@
 ---
 name: Grey out wordless folders and files in the domain view
 issue: <#issueid>
-state: todo
+state: complete
 version: 1
 ---
 
@@ -46,14 +46,18 @@ glance which parts of the tree the domain lens actually says something about.
 
 ## Steps
 
-- [ ] Complete Task 4: Tidy first — rename the reason-specific inactive colour constant
-- [ ] Complete Task 1: Selector for paths carrying domain words (+ tests)
-- [ ] Complete Task 2: Explorer row lens dims wordless rows (+ tests)
-- [ ] Complete Task 3: Domain view row projection feeds the set (+ tests)
-- [ ] Run the visualization test suite and format
+- [x] Complete Task 4: Tidy first — rename the reason-specific inactive colour constant
+- [x] Complete Task 1: Selector for paths carrying domain words (+ tests)
+- [x] Complete Task 2: Explorer row lens dims wordless rows (+ tests)
+- [x] Complete Task 3: Domain view row projection feeds the set (+ tests)
+- [x] Run the visualization test suite and format
 
 ## Notes
 
+- Implemented in two commits, structural first: the icon component's `NO_AREA_COLOR` rename, then the
+  behavioural change.
+- Verified: full visualization unit suite green (398 suites, 2684 tests), `tsc --noEmit` clean,
+  `npm run format:check` clean.
 - The domain view has no 3D map; "folders/files" here are the sidebar explorer tree rows.
 - Decisions taken with the user: metrics-identical look (dim + italic + title), rows stay selectable,
   dim everything when no domain data is present, no hide-toggle setting.

--- a/plans/2026-09-02-domain-view-grey-out-wordless-nodes.md
+++ b/plans/2026-09-02-domain-view-grey-out-wordless-nodes.md
@@ -1,0 +1,59 @@
+---
+name: Grey out wordless folders and files in the domain view
+issue: <#issueid>
+state: todo
+version: 1
+---
+
+## Goal
+
+In the domain view's sidebar explorer, folders and files that carry no domain words are dimmed the
+same way the metrics view dims nodes without area for the chosen metric, so a reader can tell at a
+glance which parts of the tree the domain lens actually says something about.
+
+## Tasks
+
+### 1. Expose the paths that carry domain words
+
+- Add a selector to the domain lens (`lenses/domain/store/domain.selectors.ts`) that derives the set
+  of node paths with a non-empty word list from `domainWordsSelector`, and export it from
+  `domainLens.facade.ts`.
+- A folder needs no special handling: the analysis side already rolls file words up into every parent
+  directory, so a folder has an entry exactly when something beneath it has words.
+- Deriving a `Set` once in a memoized selector keeps the per-row lookup O(1) for large trees.
+
+### 2. Let the explorer row lens dim a wordless row
+
+- Extend `ExplorerRowInputs` with an optional set of paths that carry domain words; when it is
+  omitted (metrics view) nothing changes.
+- Both dimming reasons — no area, no words — end in the same projection (`isInactive`, `isItalic`,
+  a `title` hint), so fold them into one helper that returns the hint text and drive `isInactive`
+  off it, instead of adding a second parallel branch.
+- Hint text for a wordless row: "No domain words" (matches the existing hover-tooltip wording in
+  `domainExplorerSelection.ts`).
+
+### 3. Feed the set from the domain view's row projection
+
+- `DomainExplorerRow` reads the new selector and passes the set into `projectExplorerRow`.
+- Rows stay selectable and keep their hover tooltip — the dimming is informational only.
+- With no domain data loaded at all, every node is wordless and the whole tree dims; that is the
+  intended, literal behaviour.
+
+### 4. Tidy first
+
+- The icon component's `NO_AREA_COLOR` now serves a second reason for dimming; rename it to an
+  intent-revealing, reason-free name in its own structural commit before the behavioural change.
+
+## Steps
+
+- [ ] Complete Task 4: Tidy first — rename the reason-specific inactive colour constant
+- [ ] Complete Task 1: Selector for paths carrying domain words (+ tests)
+- [ ] Complete Task 2: Explorer row lens dims wordless rows (+ tests)
+- [ ] Complete Task 3: Domain view row projection feeds the set (+ tests)
+- [ ] Run the visualization test suite and format
+
+## Notes
+
+- The domain view has no 3D map; "folders/files" here are the sidebar explorer tree rows.
+- Decisions taken with the user: metrics-identical look (dim + italic + title), rows stay selectable,
+  dim everything when no domain data is present, no hide-toggle setting.

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Added 🚀
+
+- **Domain view marks nodes without domain words**: Folders and files the domain lens has no words for are now greyed out and italicised in the domain view's file explorer, the same way the metric view marks nodes without area for the chosen metric, with a "No domain words" hint on hover. They stay selectable.
+
 ## [2.0.0] - 2026-09-02
 
 ### Added 🚀

--- a/visualization/app/codeCharta/features/sidebarExplorer/components/explorerTreeItemIcon/explorerTreeItemIcon.component.ts
+++ b/visualization/app/codeCharta/features/sidebarExplorer/components/explorerTreeItemIcon/explorerTreeItemIcon.component.ts
@@ -9,7 +9,7 @@ import { isLeaf } from "../../../../util/codeMapHelper"
 })
 export class ExplorerTreeItemIconComponent {
     private static readonly DEFAULT_FOLDER_COLOR = "#000000"
-    private static readonly NO_AREA_COLOR = "#BDBDBD"
+    private static readonly INACTIVE_ROW_COLOR = "#BDBDBD"
 
     readonly node = input.required<CodeMapNode>()
     readonly isOpen = input.required<boolean>()
@@ -26,7 +26,7 @@ export class ExplorerTreeItemIconComponent {
 
     readonly iconColor = computed((): string | undefined => {
         if (this.isInactive()) {
-            return ExplorerTreeItemIconComponent.NO_AREA_COLOR
+            return ExplorerTreeItemIconComponent.INACTIVE_ROW_COLOR
         }
         if (isLeaf(this.node())) {
             return undefined

--- a/visualization/app/codeCharta/lenses/domain/domainLens.facade.ts
+++ b/visualization/app/codeCharta/lenses/domain/domainLens.facade.ts
@@ -2,5 +2,6 @@ export {
     createWordsForSelectedNodeSelector,
     hasDomainDataSelector,
     hasTfidfDataSelector,
-    isLoadedFileSetWithoutDomainLensSelector
+    isLoadedFileSetWithoutDomainLensSelector,
+    pathsWithDomainWordsSelector
 } from "./store/domain.selectors"

--- a/visualization/app/codeCharta/lenses/domain/store/domain.selectors.spec.ts
+++ b/visualization/app/codeCharta/lenses/domain/store/domain.selectors.spec.ts
@@ -5,7 +5,8 @@ import {
     createWordsForSelectedNodeSelector,
     hasDomainDataSelector,
     hasTfidfDataSelector,
-    isLoadedFileSetWithoutDomainLensSelector
+    isLoadedFileSetWithoutDomainLensSelector,
+    pathsWithDomainWordsSelector
 } from "./domain.selectors"
 
 describe("domain lens selectors", () => {
@@ -49,6 +50,41 @@ describe("domain lens selectors", () => {
 
             // Assert
             expect(result).toBe(true)
+        })
+    })
+
+    describe("pathsWithDomainWordsSelector", () => {
+        it("should be empty when no domain words are present", () => {
+            // Arrange
+            const state = stateWithWords({})
+
+            // Act
+            const result = pathsWithDomainWordsSelector(state)
+
+            // Assert
+            expect(result).toEqual(new Set())
+        })
+
+        it("should list every path carrying at least one word", () => {
+            // Arrange
+            const state = stateWithWords({ "/root": rootWords, "/root/nodeA": leafWords })
+
+            // Act
+            const result = pathsWithDomainWordsSelector(state)
+
+            // Assert
+            expect(result).toEqual(new Set(["/root", "/root/nodeA"]))
+        })
+
+        it("should not list a path whose word list is empty", () => {
+            // Arrange
+            const state = stateWithWords({ "/root": rootWords, "/root/nodeA": [] })
+
+            // Act
+            const result = pathsWithDomainWordsSelector(state)
+
+            // Assert
+            expect(result).toEqual(new Set(["/root"]))
         })
     })
 

--- a/visualization/app/codeCharta/lenses/domain/store/domain.selectors.ts
+++ b/visualization/app/codeCharta/lenses/domain/store/domain.selectors.ts
@@ -1,10 +1,15 @@
 import { createSelector } from "@ngrx/store"
-import { FileState } from "../../../model/codeCharta.model"
+import { DomainLensData, FileState } from "../../../model/codeCharta.model"
 import { domainWordsSelector } from "../../../stores/domainLensSource/domainLensSource.read.facade"
 import { visibleFileStatesWithCurrentSettingsSelector } from "../../../stores/fileStore/fileStore.facade"
 import { fileRoot } from "../../../util/fileRoot"
 
 export const hasDomainDataSelector = createSelector(domainWordsSelector, words => Object.keys(words).length > 0)
+
+const pathsCarryingWords = (words: DomainLensData): ReadonlySet<string> =>
+    new Set(Object.entries(words).flatMap(([path, wordList]) => (wordList.length > 0 ? [path] : [])))
+
+export const pathsWithDomainWordsSelector = createSelector(domainWordsSelector, pathsCarryingWords)
 
 export const hasTfidfDataSelector = createSelector(domainWordsSelector, words =>
     Object.values(words).some(wordList => wordList.some(word => word.tfidf !== undefined))

--- a/visualization/app/codeCharta/lenses/explorerRow/store/explorerRow.projection.spec.ts
+++ b/visualization/app/codeCharta/lenses/explorerRow/store/explorerRow.projection.spec.ts
@@ -104,6 +104,39 @@ describe("projectExplorerRow", () => {
         })
     })
 
+    describe("with the domain inputs", () => {
+        const inputs = { pathsWithDomainWords: new Set([LEAF_WITH_BUILDING.path]) }
+
+        it("should dim and italicize a row whose node carries no domain words", () => {
+            // Arrange & Act
+            const projection = projectExplorerRow(LEAF_WITHOUT_BUILDING, inputs)
+
+            // Assert
+            expect(projection).toMatchObject({ isInactive: true, isItalic: true, title: "No domain words" })
+        })
+
+        it("should leave a row carrying domain words undimmed and untitled", () => {
+            // Arrange & Act
+            const projection = projectExplorerRow(LEAF_WITH_BUILDING, inputs)
+
+            // Assert
+            expect(projection).toMatchObject({ isInactive: false, isItalic: false, title: "" })
+        })
+
+        it("should keep a row carrying no domain words selectable", () => {
+            // Arrange & Act & Assert
+            expect(projectExplorerRow(LEAF_WITHOUT_BUILDING, inputs).isSelectable).toBe(true)
+        })
+
+        it("should dim every row when no path carries domain words", () => {
+            // Arrange & Act
+            const projection = projectExplorerRow(LEAF_WITH_BUILDING, { pathsWithDomainWords: new Set<string>() })
+
+            // Assert
+            expect(projection).toMatchObject({ isInactive: true, isItalic: true, title: "No domain words" })
+        })
+    })
+
     describe("with no inputs (a view with no 3D map)", () => {
         it("should render the trivial projection: selectable, undimmed, no decoration", () => {
             // Arrange & Act

--- a/visualization/app/codeCharta/lenses/explorerRow/store/explorerRow.projection.ts
+++ b/visualization/app/codeCharta/lenses/explorerRow/store/explorerRow.projection.ts
@@ -3,6 +3,7 @@ import { getMarkingColor, isAreaValid, isLeaf } from "../../../util/codeMapHelpe
 import { formatCompactNumber } from "../../../util/formatCompactNumber"
 
 const NO_AREA_HINT = "No Node Area for Chosen Metric"
+const NO_DOMAIN_WORDS_HINT = "No domain words"
 
 export interface ExplorerRowProjection {
     isSelectable: boolean
@@ -17,6 +18,7 @@ export interface ExplorerRowProjection {
 
 export interface ExplorerRowInputs {
     areaMetric?: string
+    pathsWithDomainWords?: ReadonlySet<string>
     buildingIds?: ReadonlySet<number>
     rootUnary?: number | null
     showsFlattenedState?: boolean
@@ -26,17 +28,28 @@ export interface ExplorerRowInputs {
 
 export function projectExplorerRow(node: CodeMapNode, inputs: ExplorerRowInputs): ExplorerRowProjection {
     const isSelectable = computeSelectable(node, inputs.buildingIds)
-    const hasArea = inputs.areaMetric === undefined || isAreaValid(node, inputs.areaMetric)
+    const inactiveHint = computeInactiveHint(node, inputs)
+    const isInactive = inactiveHint !== ""
     return {
         isSelectable,
-        isInactive: !hasArea,
-        isItalic: !hasArea || !isSelectable,
+        isInactive,
+        isItalic: isInactive || !isSelectable,
         isFlattened: Boolean(inputs.showsFlattenedState && node.isFlattened),
         isHidden: Boolean(inputs.hidesExcludedNodes && node.isExcluded),
-        title: hasArea ? "" : NO_AREA_HINT,
+        title: inactiveHint,
         decoration: computeDecoration(node, inputs.rootUnary),
         markingColor: computeMarkingColor(node, inputs.markedPackages)
     }
+}
+
+function computeInactiveHint(node: CodeMapNode, inputs: ExplorerRowInputs): string {
+    if (inputs.areaMetric !== undefined && !isAreaValid(node, inputs.areaMetric)) {
+        return NO_AREA_HINT
+    }
+    if (inputs.pathsWithDomainWords !== undefined && !inputs.pathsWithDomainWords.has(node.path)) {
+        return NO_DOMAIN_WORDS_HINT
+    }
+    return ""
 }
 
 function computeSelectable(node: CodeMapNode, buildingIds: ReadonlySet<number> | undefined): boolean {

--- a/visualization/app/codeCharta/views/domainView/explorer/domainExplorerRow.spec.ts
+++ b/visualization/app/codeCharta/views/domainView/explorer/domainExplorerRow.spec.ts
@@ -1,16 +1,39 @@
+import { TestBed } from "@angular/core/testing"
+import { provideMockStore } from "@ngrx/store/testing"
+import { pathsWithDomainWordsSelector } from "../../../lenses/domain/domainLens.facade"
+import { provideMockState } from "../../../mocks/state.mocks"
 import { CodeMapNode, NodeType } from "../../../model/codeCharta.model"
 import { DomainExplorerRow } from "./domainExplorerRow"
 
-const LEAF = { name: "a.ts", path: "/root/a.ts", id: 1, type: NodeType.FILE, attributes: { rloc: 0 } } as unknown as CodeMapNode
-const EXCLUDED_LEAF = { ...LEAF, name: "b.ts", path: "/root/b.ts", isExcluded: true } as CodeMapNode
+const LEAF_WITH_WORDS = {
+    name: "a.ts",
+    path: "/root/a.ts",
+    id: 1,
+    type: NodeType.FILE,
+    attributes: { rloc: 0 }
+} as unknown as CodeMapNode
+const LEAF_WITHOUT_WORDS = { ...LEAF_WITH_WORDS, name: "b.ts", path: "/root/b.ts" } as CodeMapNode
+const EXCLUDED_LEAF_WITH_WORDS = { ...LEAF_WITH_WORDS, isExcluded: true } as CodeMapNode
 
 describe("DomainExplorerRow", () => {
-    it("should render the trivial projection, since there is no 3D map to gate on", () => {
-        // Arrange
-        const row = new DomainExplorerRow()
+    let row: DomainExplorerRow
 
-        // Act
-        const projection = row.project(LEAF)
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                DomainExplorerRow,
+                provideMockState(),
+                provideMockStore({
+                    selectors: [{ selector: pathsWithDomainWordsSelector, value: new Set([LEAF_WITH_WORDS.path]) }]
+                })
+            ]
+        })
+        row = TestBed.inject(DomainExplorerRow)
+    })
+
+    it("should render a node carrying domain words undimmed", () => {
+        // Arrange & Act
+        const projection = row.project(LEAF_WITH_WORDS)
 
         // Assert
         expect(projection).toEqual({
@@ -25,12 +48,25 @@ describe("DomainExplorerRow", () => {
         })
     })
 
-    it("should keep a node excluded by the metrics blacklist visible, since the domain view cannot manage exclusions", () => {
-        // Arrange
-        const row = new DomainExplorerRow()
+    it("should dim and italicize a node carrying no domain words", () => {
+        // Arrange & Act
+        const projection = row.project(LEAF_WITHOUT_WORDS)
 
-        // Act
-        const projection = row.project(EXCLUDED_LEAF)
+        // Assert
+        expect(projection).toMatchObject({ isInactive: true, isItalic: true, title: "No domain words" })
+    })
+
+    it("should keep a node carrying no domain words selectable, since dimming is informational only", () => {
+        // Arrange & Act
+        const projection = row.project(LEAF_WITHOUT_WORDS)
+
+        // Assert
+        expect(projection.isSelectable).toBe(true)
+    })
+
+    it("should keep a node excluded by the metrics blacklist visible, since the domain view cannot manage exclusions", () => {
+        // Arrange & Act
+        const projection = row.project(EXCLUDED_LEAF_WITH_WORDS)
 
         // Assert
         expect(projection.isHidden).toBe(false)

--- a/visualization/app/codeCharta/views/domainView/explorer/domainExplorerRow.ts
+++ b/visualization/app/codeCharta/views/domainView/explorer/domainExplorerRow.ts
@@ -1,11 +1,18 @@
-import { Injectable } from "@angular/core"
+import { Injectable, inject } from "@angular/core"
+import { toSignal } from "@angular/core/rxjs-interop"
+import { Store } from "@ngrx/store"
 import { ExplorerRow } from "../../../features/sidebarExplorer/facade"
+import { pathsWithDomainWordsSelector } from "../../../lenses/domain/domainLens.facade"
 import { ExplorerRowProjection, projectExplorerRow } from "../../../lenses/explorerRow/explorerRowLens.facade"
 import { CodeMapNode } from "../../../model/codeCharta.model"
 
 @Injectable()
 export class DomainExplorerRow implements ExplorerRow {
+    private readonly store = inject(Store)
+
+    private readonly pathsWithDomainWords = toSignal(this.store.select(pathsWithDomainWordsSelector), { requireSync: true })
+
     project(node: CodeMapNode): ExplorerRowProjection {
-        return projectExplorerRow(node, {})
+        return projectExplorerRow(node, { pathsWithDomainWords: this.pathsWithDomainWords() })
     }
 }


### PR DESCRIPTION
- **refactor(visualization): name the explorer icon's inactive colour by intent**
- **feat(visualization): grey out wordless nodes in the domain explorer**
- **docs(visualization): note the domain explorer's wordless-node dimming**

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Domain view explorer items without assigned domain words are now greyed out and italicized.
  - Hovering over these items displays a “No domain words” hint.
  - Items remain selectable despite their inactive visual styling.
  - Items with domain words retain their normal appearance, while existing area-related indicators continue to take precedence.

- **Documentation**
  - Added release documentation describing the updated domain explorer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->