### PR TITLE
fix(visualization): keep the top bar out of map screenshots

### DIFF
--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed 🐞
 
+- **Map screenshot showed the top bar's drawer handle**: the small handle hanging below the center of the top bar was captured in map screenshots, and — sitting at the very top of the image — it also kept a wide empty band above the map when the screenshot was cropped. The top bar is now left out of the capture as a whole, so nothing overhanging it can end up in the image. The domain view's word-cloud screenshot was never affected.
 - **Context menu actions were swallowed after a view switch**: once a view had been left with its node context menu open, the router kept that view — and its rendered menu — alive off screen, where it closed the menu of the view on screen on the first click. Picking an entry there did nothing, so "Show in Domain" appeared to be ignored. A menu that is off screen no longer dismisses anything.
 - **Endless spinner on the first visit to the metric view**: starting the app on the domain view and then switching to the metric view left its loading spinner up for the rest of the session, with the map never drawn. The deferred map build ran before the view had mounted the canvas the floor labels measure, and the resulting error ended the render stream that both the map and the spinner hang off. The build now waits for that canvas, reads the current map data rather than the last data-plus-action pair, and reports a failed render instead of ending the stream.
 

--- a/visualization/app/codeCharta/features/screenshot/services/screenshot.service.spec.ts
+++ b/visualization/app/codeCharta/features/screenshot/services/screenshot.service.spec.ts
@@ -149,6 +149,20 @@ describe("ScreenshotService", () => {
         )
     })
 
+    it("should ignore cc-nav-bar in screenshots so its view-mode-bar handle is not captured", async () => {
+        // Arrange
+        configure()
+        jest.spyOn(CanvasRenderingContext2D.prototype, "getImageData").mockImplementation(() => createMockImageData().imageData)
+
+        // Act
+        await service.makeScreenshotToFile()
+
+        // Assert
+        const ignoreElements = mockHtml2Canvas.mock.calls[0][1].ignoreElements as (element: Element) => boolean
+        const fakeNavBar = document.createElement("cc-nav-bar")
+        expect(ignoreElements(fakeNavBar)).toBe(true)
+    })
+
     it("should ignore cc-bottom-bar in screenshots", async () => {
         // Arrange
         configure()

--- a/visualization/app/codeCharta/features/screenshot/services/screenshot.service.ts
+++ b/visualization/app/codeCharta/features/screenshot/services/screenshot.service.ts
@@ -72,11 +72,12 @@ export class ScreenshotService implements ScreenshotCapture {
         const tagsNamesToIgnore = new Set([
             "cc-logo",
             "cc-tool-bar",
+            "cc-nav-bar",
             "cc-view-cube",
             "cc-metrics-bar",
             "cc-file-extension-bar",
             "cc-sidebar-inspector",
-            "cc-loading-file-progess-spinner",
+            "cc-loading-file-progress-spinner",
             "cc-bottom-bar",
             "cc-sidebar-explorer"
         ])


### PR DESCRIPTION
The view switcher's drawer handle hangs below the nav bar (top-full), so scrolling the nav bar out of the capture left the handle inside it — and at the very top of the image, where the transparent-margin crop kept an empty band above the map. Ignore cc-nav-bar as a whole instead.

Also fix the misspelled cc-loading-file-progess-spinner entry in the same ignore set, which never matched the rendered tag.


Claude-Session: https://claude.ai/code/session_01CaDqJHEevXBeDogJrMzLiY

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Map screenshots no longer include the top navigation bar or its drawer handle.
  - Loading indicators are correctly excluded from captured screenshots.
  - Domain-view word-cloud screenshots remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->