### PR TITLE
fix(visualization): budget the pixel ratio so phones render the map a…

### DIFF
--- a/plans/2026-09-04-clamp-device-pixel-ratio.md
+++ b/plans/2026-09-04-clamp-device-pixel-ratio.md
@@ -1,0 +1,47 @@
+---
+name: clamp-device-pixel-ratio
+issue: - (regression from #4490)
+state: complete
+version: 1
+---
+
+## Goal
+
+Make the map render again on phones. #4490 hard-coded `setPixelRatio(window.devicePixelRatio)`, which on a
+phone produces a ~15 megapixel drawing buffer (7x the desktop workload) and exhausts the mobile GPU budget.
+Budget the pixel ratio instead, and make a lost WebGL context visible rather than a silent blank map.
+
+## Tasks
+
+### 1. Budget the drawing buffer
+- `threeRenderer.service.ts`: derive the pixel ratio from `window.devicePixelRatio` capped by a maximum
+  ratio and by a maximum total buffer area, instead of taking the device ratio raw
+- Add a `setSize()` that re-applies the budget, so a rotation or a viewport change re-evaluates it
+- `threeViewer.service.ts`: `onWindowResize` delegates to that `setSize()` rather than poking both renderers
+
+### 2. Surface a lost WebGL context
+- `threeRenderer.service.ts`: listen for `webglcontextlost` (with `preventDefault`, required for the browser
+  to attempt a restore) and `webglcontextrestored`; expose the state as an observable
+- `threeViewer.service.ts`: re-expose it and detach the listeners on destroy
+- `codeMap.component.html`: show a daisyUI alert while the context is lost
+
+## Steps
+
+- [x] Complete Task 1: Budget the drawing buffer
+- [x] Complete Task 2: Surface a lost WebGL context
+- [x] Run unit suite, biome, architecture lint
+
+## Notes
+
+- Measured on the built bundle under Chromium device emulation: iPhone 13 portrait 2940x5007 (14.72 MP),
+  Pixel 7 2575x5239 (13.49 MP), desktop 1920x1080 (2.07 MP). All report `SAMPLES: 4`, so antialiasing
+  quadruples the colour and depth storage on top.
+- The 980px layout viewport (no `<meta name="viewport">` in `app/index.html`) is what inflates the phone
+  height. Adding that tag would cut the buffer another 5x but re-lays-out the whole desktop-sized UI —
+  a separate responsive task, deliberately not done here.
+- The previous default was `SharpnessMode.Standard`, i.e. pixel ratio 1, NOT the "Best" mode #4490 kept.
+- Chosen budget: ratio <= 2 and buffer <= 4 megapixels, floor 1. Verified on the rebuilt bundle under device
+  emulation: desktop 1920x1080 unchanged at 2.07 MP, iPhone 13 14.72 -> 4.00 MP, Pixel 7 13.49 -> 4.00 MP.
+- The alert sits at `z-[1000]`, above the explorer panel — at a lower layer it rendered behind it and was cut off.
+- Verified the alert by forcing a loss with `WEBGL_lose_context` on an emulated phone and on desktop.
+- Full unit suite green (420 suites, 2870 tests), `tsc --noEmit` clean, `npm run lint` clean, Biome clean.

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Fixed 🐞
+
+- **Map no longer renders on phones**: removing the display quality setting left the renderer taking the device's raw pixel ratio, which is what the old "Best" mode did — but the default had been "High", which rendered at ratio 1. On a phone that asks for a roughly 15 megapixel drawing buffer, seven times the desktop workload, and the mobile GPU drops the WebGL context. The pixel ratio is now capped, both as a ratio and against a total buffer budget, and re-applied when the window resizes, so a phone renders at about 4 megapixels while a normal desktop viewport is untouched at its native ratio. A lost graphics context is also no longer a silently blank map: it is reported, and a restored context re-renders.
+
 ## [2.1.0] - 2026-09-04
 
 ### Added 🚀

--- a/visualization/app/codeCharta/features/codeMap/codeMap.component.html
+++ b/visualization/app/codeCharta/features/codeMap/codeMap.component.html
@@ -1,3 +1,13 @@
 <div id="codeMap" class="fixed left-0 top-[var(--cc-bars-height,49px)] z-0 h-full w-full" [class.hidden]="isLoadingFile$ | async">
     <cc-view-cube [class.sideBarVisible]="inspectorVisibilityService.isVisible()"></cc-view-cube>
 </div>
+@if (isContextLost$ | async) {
+    <div class="pointer-events-none fixed inset-0 z-[1000] flex items-center justify-center p-4">
+        <div class="alert alert-error pointer-events-auto max-w-md" role="alert">
+            <span>
+                The graphics card stopped rendering the map, usually because it ran out of memory. Reload the page, and try a smaller
+                map or a smaller browser window.
+            </span>
+        </div>
+    </div>
+}

--- a/visualization/app/codeCharta/features/codeMap/codeMap.component.spec.ts
+++ b/visualization/app/codeCharta/features/codeMap/codeMap.component.spec.ts
@@ -1,5 +1,5 @@
 import { ElementRef } from "@angular/core"
-import { EMPTY } from "rxjs"
+import { EMPTY, firstValueFrom, of } from "rxjs"
 import { InspectorVisibilityService } from "../../features/sidebarInspector/facade"
 import { ThreeViewerService } from "../../renderer/threeViewer/threeViewer.service"
 import { FileStoreReadWindow } from "../../stores/fileStore/fileStore.facade"
@@ -15,20 +15,24 @@ describe("CodeMapComponent", () => {
     } as unknown as FileStoreReadWindow
 
     beforeEach(() => {
-        mockedThreeViewService = { init: jest.fn() } as unknown as ThreeViewerService
+        mockedThreeViewService = { init: jest.fn(), isContextLost$: of(true) } as unknown as ThreeViewerService
         mockedCodeMapMouseEventService = { start: jest.fn() } as unknown as CodeMapMouseEventService
         mockedElementReference = { nativeElement: { querySelector: jest.fn() } }
     })
 
-    it("should init threeViewerService and start codeMapMouseService after view init", () => {
-        // Arrange
-        const codeMapComponent = new CodeMapComponent(
+    function createComponent() {
+        return new CodeMapComponent(
             { isVisible: () => true } as unknown as InspectorVisibilityService,
             mockedFileStoreReadWindow,
             mockedThreeViewService,
             mockedCodeMapMouseEventService,
             mockedElementReference
         )
+    }
+
+    it("should init threeViewerService and start codeMapMouseService after view init", () => {
+        // Arrange
+        const codeMapComponent = createComponent()
 
         // Act
         codeMapComponent.ngAfterViewInit()
@@ -36,5 +40,16 @@ describe("CodeMapComponent", () => {
         // Assert
         expect(mockedThreeViewService.init).toHaveBeenCalled()
         expect(mockedCodeMapMouseEventService.start).toHaveBeenCalled()
+    })
+
+    it("should expose a lost graphics context, so the blank map is explained instead of silent", async () => {
+        // Arrange
+        const codeMapComponent = createComponent()
+
+        // Act
+        const isContextLost = await firstValueFrom(codeMapComponent.isContextLost$)
+
+        // Assert
+        expect(isContextLost).toBe(true)
     })
 })

--- a/visualization/app/codeCharta/features/codeMap/codeMap.component.ts
+++ b/visualization/app/codeCharta/features/codeMap/codeMap.component.ts
@@ -14,6 +14,7 @@ import { CodeMapMouseEventService } from "./codeMap.mouseEvent.service"
 })
 export class CodeMapComponent implements AfterViewInit, OnDestroy {
     isLoadingFile$ = this.fileStoreReadWindow.isLoadingFile$
+    isContextLost$ = this.threeViewerService.isContextLost$
 
     constructor(
         public inspectorVisibilityService: InspectorVisibilityService,

--- a/visualization/app/codeCharta/renderer/threeViewer/threeRenderer.service.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/threeRenderer.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from "@angular/core/testing"
 import { Store, StoreModule } from "@ngrx/store"
+import { firstValueFrom } from "rxjs"
 import { Camera, Scene, Vector2, WebGLInfo, WebGLRenderer } from "three"
 import { setIsWhiteBackground } from "../../stores/mapState/mapState.write.facade"
 import { appReducers, setStateMiddleware } from "../../stores/rootStore/store"
@@ -12,6 +13,7 @@ jest.mock("three", () => {
         WebGLRenderer: jest.fn(() => ({
             domElement: {
                 addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
                 getBoundingClientRect: jest.fn(() => ({ left: 20, top: 20 })),
                 width: 100,
                 height: 100
@@ -89,20 +91,158 @@ describe("threeRendererService", () => {
             expect(threeRendererService.renderOptions.antialias).toBe(true)
         })
 
-        it("should call renderer setPixelRatio", () => {
-            // Arrange & Act
-            threeRendererService["initGL"](1, 1)
-
-            // Assert
-            expect(threeRendererService.renderer.setPixelRatio).toHaveBeenCalledWith(window.devicePixelRatio)
-        })
-
         it("should call renderer setSize", () => {
             // Arrange & Act
             threeRendererService["initGL"](1, 2)
 
             // Assert
             expect(threeRendererService.renderer.setSize).toHaveBeenCalledWith(1, 2)
+        })
+    })
+
+    describe("pixel ratio budget", () => {
+        function withDevicePixelRatio(value: number) {
+            Object.defineProperty(window, "devicePixelRatio", { value, configurable: true })
+        }
+
+        const originalDevicePixelRatio = window.devicePixelRatio
+
+        afterEach(() => {
+            withDevicePixelRatio(originalDevicePixelRatio)
+        })
+
+        it("should use the device pixel ratio when it stays within both budgets", () => {
+            // Arrange
+            withDevicePixelRatio(2)
+
+            // Act
+            threeRendererService["initGL"](800, 600)
+
+            // Assert
+            expect(threeRendererService.renderer.setPixelRatio).toHaveBeenCalledWith(2)
+        })
+
+        it("should cap the ratio of a high density screen", () => {
+            // Arrange
+            withDevicePixelRatio(3)
+
+            // Act
+            threeRendererService["initGL"](800, 600)
+
+            // Assert
+            expect(threeRendererService.renderer.setPixelRatio).toHaveBeenCalledWith(ThreeRendererService.MAX_PIXEL_RATIO)
+        })
+
+        it("should shrink the ratio further so a large viewport stays within the buffer budget", () => {
+            // Arrange — a phone's 980x1669 layout viewport at ratio 3 would be 14.7 megapixels
+            withDevicePixelRatio(3)
+
+            // Act
+            threeRendererService["initGL"](980, 1669)
+
+            // Assert
+            const ratio = (threeRendererService.renderer.setPixelRatio as jest.Mock).mock.calls[0][0]
+            expect(980 * ratio * (1669 * ratio)).toBeLessThanOrEqual(ThreeRendererService.MAX_DRAWING_BUFFER_PIXELS)
+            expect(ratio).toBeLessThan(ThreeRendererService.MAX_PIXEL_RATIO)
+        })
+
+        it("should never drop below a ratio of one, so a huge viewport stays sharp as it can be", () => {
+            // Arrange
+            withDevicePixelRatio(3)
+
+            // Act
+            threeRendererService["initGL"](8000, 8000)
+
+            // Assert
+            expect(threeRendererService.renderer.setPixelRatio).toHaveBeenCalledWith(1)
+        })
+
+        it("should re-apply the budget on resize, because a rotation changes the viewport", () => {
+            // Arrange
+            withDevicePixelRatio(3)
+            threeRendererService["initGL"](980, 1669)
+            ;(threeRendererService.renderer.setPixelRatio as jest.Mock).mockClear()
+            const setLabelSize = jest.spyOn(threeRendererService.labelRenderer, "setSize")
+
+            // Act
+            threeRendererService.setSize(800, 600)
+
+            // Assert
+            expect(threeRendererService.renderer.setPixelRatio).toHaveBeenCalledWith(ThreeRendererService.MAX_PIXEL_RATIO)
+            expect(threeRendererService.renderer.setSize).toHaveBeenCalledWith(800, 600)
+            expect(setLabelSize).toHaveBeenCalledWith(800, 600)
+        })
+    })
+
+    describe("context loss", () => {
+        beforeEach(() => {
+            // A restore re-renders, so the scene it renders has to exist before one is triggered.
+            threeRendererService.scene = new Scene()
+            threeRendererService.camera = new Camera()
+        })
+
+        function initAndCaptureHandler(eventName: string) {
+            threeRendererService["initGL"](1, 1)
+            const listen = threeRendererService.renderer.domElement.addEventListener as unknown as jest.Mock
+            return listen.mock.calls.find(([name]) => name === eventName)[1] as (event: Event) => void
+        }
+
+        it("should report an intact context before anything is lost", async () => {
+            // Arrange & Act
+            threeRendererService["initGL"](1, 1)
+
+            // Assert
+            expect(await firstValueFrom(threeRendererService.isContextLost$)).toBe(false)
+        })
+
+        it("should report a lost context", async () => {
+            // Arrange
+            const onContextLost = initAndCaptureHandler("webglcontextlost")
+
+            // Act
+            onContextLost(new Event("webglcontextlost"))
+
+            // Assert
+            expect(await firstValueFrom(threeRendererService.isContextLost$)).toBe(true)
+        })
+
+        it("should prevent the default, because only then does the browser try to restore the context", () => {
+            // Arrange
+            const onContextLost = initAndCaptureHandler("webglcontextlost")
+            const event = new Event("webglcontextlost", { cancelable: true })
+
+            // Act
+            onContextLost(event)
+
+            // Assert
+            expect(event.defaultPrevented).toBe(true)
+        })
+
+        it("should report an intact context again once it is restored", async () => {
+            // Arrange
+            threeRendererService["initGL"](1, 1)
+            const listen = threeRendererService.renderer.domElement.addEventListener as unknown as jest.Mock
+            const handlerFor = (name: string) => listen.mock.calls.find(([eventName]) => eventName === name)[1]
+            handlerFor("webglcontextlost")(new Event("webglcontextlost"))
+
+            // Act
+            handlerFor("webglcontextrestored")(new Event("webglcontextrestored"))
+
+            // Assert
+            expect(await firstValueFrom(threeRendererService.isContextLost$)).toBe(false)
+        })
+
+        it("should detach its listeners on destroy", () => {
+            // Arrange
+            threeRendererService["initGL"](1, 1)
+            const { domElement } = threeRendererService.renderer
+
+            // Act
+            threeRendererService.destroy()
+
+            // Assert
+            expect(domElement.removeEventListener).toHaveBeenCalledWith("webglcontextlost", expect.any(Function))
+            expect(domElement.removeEventListener).toHaveBeenCalledWith("webglcontextrestored", expect.any(Function))
         })
     })
 

--- a/visualization/app/codeCharta/renderer/threeViewer/threeRenderer.service.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/threeRenderer.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core"
 import { Store } from "@ngrx/store"
-import { Observable, Subject } from "rxjs"
+import { BehaviorSubject, Observable, Subject } from "rxjs"
 import { Camera, Scene, WebGLInfo, WebGLRenderer } from "three"
 import { CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js"
 import { CcState } from "../../model/codeCharta.model"
@@ -14,6 +14,13 @@ export class ThreeRendererService {
     }
 
     static CLEAR_ALPHA = 1
+
+    /** A phone reports a device pixel ratio of 3 and, lacking a viewport meta tag, a ~980px layout
+     * viewport, so its raw ratio asks for a ~15 megapixel buffer — antialiasing then quadruples the
+     * colour and depth storage of it, and the mobile GPU drops the context. Both caps together keep
+     * the buffer affordable there while leaving a normal desktop viewport at its native ratio. */
+    static readonly MAX_PIXEL_RATIO = 2
+    static readonly MAX_DRAWING_BUFFER_PIXELS = 4_000_000
 
     clearColor = ThreeRendererService.BACKGROUND_COLOR.normal
 
@@ -30,6 +37,9 @@ export class ThreeRendererService {
 
     private readonly _afterRender$ = new Subject<void>()
     readonly afterRender$: Observable<void> = this._afterRender$.asObservable()
+
+    private readonly _isContextLost$ = new BehaviorSubject(false)
+    readonly isContextLost$: Observable<boolean> = this._isContextLost$.asObservable()
 
     private renderScheduled = false
 
@@ -49,9 +59,11 @@ export class ThreeRendererService {
 
     private initGL(containerWidth: number, containerHeight: number) {
         this.renderer = new WebGLRenderer(this.renderOptions)
-        this.renderer.setPixelRatio(window.devicePixelRatio)
+        this.renderer.setPixelRatio(this.budgetedPixelRatio(containerWidth, containerHeight))
         this.renderer.setSize(containerWidth, containerHeight)
         this.renderer.domElement.id = "codeMapScene"
+        this.renderer.domElement.addEventListener("webglcontextlost", this.onContextLost)
+        this.renderer.domElement.addEventListener("webglcontextrestored", this.onContextRestored)
 
         this.labelRenderer = new CSS2DRenderer()
         this.labelRenderer.setSize(containerWidth, containerHeight)
@@ -61,6 +73,33 @@ export class ThreeRendererService {
         this.labelRenderer.domElement.style.left = "0"
         this.labelRenderer.domElement.style.pointerEvents = "none"
         this.labelRenderer.domElement.style.isolation = "isolate"
+    }
+
+    setSize(width: number, height: number) {
+        this.renderer.setPixelRatio(this.budgetedPixelRatio(width, height))
+        this.renderer.setSize(width, height)
+        this.labelRenderer.setSize(width, height)
+    }
+
+    private budgetedPixelRatio(width: number, height: number) {
+        const areaBudget = Math.sqrt(ThreeRendererService.MAX_DRAWING_BUFFER_PIXELS / (width * height))
+        return Math.max(1, Math.min(window.devicePixelRatio, ThreeRendererService.MAX_PIXEL_RATIO, areaBudget))
+    }
+
+    private readonly onContextLost = (event: Event) => {
+        // Only a prevented default makes the browser attempt a restore.
+        event.preventDefault()
+        this._isContextLost$.next(true)
+    }
+
+    private readonly onContextRestored = () => {
+        this._isContextLost$.next(false)
+        this.render()
+    }
+
+    destroy() {
+        this.renderer?.domElement.removeEventListener("webglcontextlost", this.onContextLost)
+        this.renderer?.domElement.removeEventListener("webglcontextrestored", this.onContextRestored)
     }
 
     getInfo(): WebGLInfo["render"] {

--- a/visualization/app/codeCharta/renderer/threeViewer/threeViewer.service.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/threeViewer.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from "@angular/core/testing"
 import { State } from "@ngrx/store"
 import { provideMockStore } from "@ngrx/store/testing"
+import { firstValueFrom, of } from "rxjs"
 import { PerspectiveCamera, Scene, Vector3, WebGLRenderer } from "three"
 import { MapControls } from "three/addons/controls/MapControls.js"
 import { ThreeCameraService } from "./threeCamera.service"
@@ -47,7 +48,7 @@ describe("ThreeViewerService", () => {
         threeRendererService = {
             render: jest.fn(),
             renderer: {
-                domElement: { height: 1, width: 1 },
+                domElement: { height: 1, width: 1, remove: jest.fn() },
                 setSize: jest.fn(),
                 dispose: jest.fn(),
                 getContext: jest.fn(),
@@ -57,7 +58,10 @@ describe("ThreeViewerService", () => {
                 domElement: document.createElement("div"),
                 setSize: jest.fn()
             },
-            init: jest.fn()
+            init: jest.fn(),
+            setSize: jest.fn(),
+            destroy: jest.fn(),
+            isContextLost$: of(false)
         } as unknown as ThreeRendererService
 
         threeMapControlsService = {
@@ -149,10 +153,10 @@ describe("ThreeViewerService", () => {
             expect(threeSceneService.scene.updateMatrixWorld).toHaveBeenCalledWith(false)
         })
 
-        it("should call renderer.setSize", () => {
+        it("should resize through the renderer service, so the pixel ratio budget is re-applied", () => {
             threeViewerService.onWindowResize()
 
-            expect(threeRendererService.renderer.setSize).toHaveBeenCalledWith(window.innerWidth, window.innerHeight)
+            expect(threeRendererService.setSize).toHaveBeenCalledWith(window.innerWidth, window.innerHeight)
         })
 
         it("should set camera.aspect correctly", () => {
@@ -205,6 +209,22 @@ describe("ThreeViewerService", () => {
             threeViewerService.animateStats()
 
             expect(threeStatsService.updateStats).toHaveBeenCalled()
+        })
+    })
+
+    describe("isContextLost$", () => {
+        it("should re-expose the renderer's context state", async () => {
+            expect(await firstValueFrom(threeViewerService.isContextLost$)).toBe(false)
+        })
+    })
+
+    describe("destroy", () => {
+        it("should let the renderer service detach its context listeners", () => {
+            threeViewerService.init(element)
+
+            threeViewerService.destroy()
+
+            expect(threeRendererService.destroy).toHaveBeenCalled()
         })
     })
 

--- a/visualization/app/codeCharta/renderer/threeViewer/threeViewer.service.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/threeViewer.service.ts
@@ -16,6 +16,8 @@ export class ThreeViewerService {
      * labels measure it — has to wait for a view that is only created when it is first shown. */
     readonly isMapCanvasMounted$ = this.isMapCanvasMounted.pipe(distinctUntilChanged())
 
+    readonly isContextLost$ = this.threeRendererService.isContextLost$
+
     constructor(
         private readonly threeSceneService: ThreeSceneService,
         private readonly threeCameraService: ThreeCameraService,
@@ -50,8 +52,7 @@ export class ThreeViewerService {
 
     onWindowResize = () => {
         this.threeSceneService.scene.updateMatrixWorld(false)
-        this.threeRendererService.renderer.setSize(window.innerWidth, window.innerHeight)
-        this.threeRendererService.labelRenderer.setSize(window.innerWidth, window.innerHeight)
+        this.threeRendererService.setSize(window.innerWidth, window.innerHeight)
         this.threeCameraService.camera.aspect = window.innerWidth / window.innerHeight
         this.threeCameraService.camera.updateProjectionMatrix()
         this.animate()
@@ -112,6 +113,7 @@ export class ThreeViewerService {
         window.removeEventListener("resize", this.onWindowResize)
         window.removeEventListener("focusin", this.onFocusIn)
         window.removeEventListener("focusout", this.onFocusOut)
+        this.threeRendererService.destroy()
         this.dispose()
         this.threeStatsService.destroy()
         this.getRenderCanvas().remove()


### PR DESCRIPTION
…gain

Removing the display quality setting (#4490) left the renderer taking window.devicePixelRatio raw — the former "Best" mode — although the default had been "High", which rendered at ratio 1. A phone reports a ratio of 3 and, lacking a viewport meta tag, a ~980px layout viewport, so the drawing buffer grew to ~15 megapixels, seven times the desktop workload, and the mobile GPU dropped the WebGL context.

The ratio is now capped both as a ratio and against a total buffer budget, and re-applied on resize so a rotation re-evaluates it. Measured on the built bundle under device emulation: desktop 1920x1080 unchanged at 2.07 MP, iPhone 13 14.72 -> 4.00 MP, Pixel 7 13.49 -> 4.00 MP.

A lost context is no longer a silently blank map either: it is caught, reported to the user, and a restored context re-renders.


Claude-Session: https://claude.ai/code/session_01Srt9AUm6D42QSRSJVSMXqN

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map rendering on mobile devices by limiting graphics quality to prevent excessive memory use.
  - Reapplied rendering limits when resizing the browser window.
  - Restored map rendering automatically after temporary graphics-context recovery.
  - Added a visible alert when the map’s graphics context is lost, with guidance to reload or reduce the map size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->