### PR TITLE
fix(visualization): migrate saved sessions to carry metric rules

### DIFF
--- a/plans/migrate-persisted-metric-rules.md
+++ b/plans/migrate-persisted-metric-rules.md
@@ -1,0 +1,31 @@
+---
+name: Migrate persisted state to carry metric rules
+issue: -
+state: complete
+version: -
+---
+
+## Goal
+
+A session saved by a version without metric rules (vis-2.2.0, DB v19) reports `metricRules` as "not restored" on
+load. Migrate the persisted state forward instead, so an upgrade restores silently.
+
+## Tasks
+
+### 1. v20 migration
+- Seed `sharedView.metricRules` with its default when the persisted `sharedView` lacks it
+- Bump `DB_VERSION` to 20 and register the step
+
+### 2. Tests
+- Unit tests for the v20 step (seeds, leaves existing rules, passes nullish through)
+- Upgrade test: a v19 blob without `metricRules` reads back with `metricRules: []`
+
+## Steps
+
+- [x] Complete Task 1: v20 migration
+- [x] Complete Task 2: Tests
+
+## Notes
+
+- stg and prd share one origin, so once stg opens the DB at v20, prd (v19) cannot open it until the next release
+- No changelog entry: metric rules are unreleased, so the false "not restored" dialog never shipped

--- a/visualization/app/codeCharta/stores/rootStore/indexedDB/indexedDBWriter.spec.ts
+++ b/visualization/app/codeCharta/stores/rootStore/indexedDB/indexedDBWriter.spec.ts
@@ -1,4 +1,5 @@
 import "fake-indexeddb/auto"
+import { IDBFactory } from "fake-indexeddb"
 import { openDB } from "idb"
 import { AttributeTypeValue, ColorMode, LayoutAlgorithm } from "../../../model/codeCharta.model"
 import { defaultDependencyLensSource } from "../../dependencyLensSource/dependencyLensSource.read.facade"
@@ -31,6 +32,7 @@ import {
     migrateCcStateRecordToV17,
     migrateCcStateRecordToV18,
     migrateCcStateRecordToV19,
+    migrateCcStateRecordToV20,
     readCcState,
     SCENARIOS_STORE_NAME,
     writeCcState
@@ -792,6 +794,50 @@ describe("migrateCcStateRecordToV19 (domain words backfill on persisted files)",
     })
 })
 
+describe("migrateCcStateRecordToV20 (metric rules seed on the persisted shared view)", () => {
+    it("should seed empty metric rules on a shared view persisted before metric rules", () => {
+        // Arrange
+        const oldShapeState = { sharedView: { searchPattern: "needle", blacklist: [] } }
+
+        // Act
+        const migrated = migrateCcStateRecordToV20(oldShapeState) as unknown as {
+            sharedView: { searchPattern: string; metricRules: unknown }
+        }
+
+        // Assert
+        expect(migrated.sharedView.metricRules).toEqual([])
+        expect(migrated.sharedView.searchPattern).toBe("needle")
+    })
+
+    it("should leave existing metric rules untouched", () => {
+        // Arrange
+        const metricRules = [{ id: "rule", metric: "rloc", operator: ">", threshold: 100, action: "exclude" }]
+        const alreadyMigrated = { sharedView: { metricRules } }
+
+        // Act
+        const migrated = migrateCcStateRecordToV20(alreadyMigrated) as unknown as { sharedView: { metricRules: unknown } }
+
+        // Assert
+        expect(migrated.sharedView.metricRules).toBe(metricRules)
+    })
+
+    it("should pass a blob without a shared view through unchanged", () => {
+        // Arrange
+        const withoutSharedView = { domainState: { topN: 25 } }
+
+        // Act
+        const migrated = migrateCcStateRecordToV20(withoutSharedView)
+
+        // Assert
+        expect(migrated).toBe(withoutSharedView)
+    })
+
+    it("should pass a nullish blob through unchanged", () => {
+        // Arrange & Act & Assert
+        expect(migrateCcStateRecordToV20(null)).toBeNull()
+    })
+})
+
 describe("openCodeChartaDB upgrade (v2 blob → chained v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 transforms)", () => {
     it("should re-home a persisted v2-shaped CcState blob when the DB upgrades", async () => {
         // Runs first (before any higher-version connection is opened) so a fresh fake-indexeddb starts at v2.
@@ -911,6 +957,41 @@ describe("openCodeChartaDB upgrade (v2 blob → chained v3 + v4 + v5 + v6 + v7 +
         // now persists only the flat map it owns)
         expect(migratedState.metricsLensSource.attributeTypes).toEqual({ rloc: AttributeTypeValue.absolute })
         expect(migratedState.dependencyLensSource.attributeTypes).toEqual({})
+    })
+})
+
+describe("openCodeChartaDB upgrade (v19 blob → v20 transform)", () => {
+    const sharedFactory = globalThis.indexedDB
+
+    beforeEach(() => {
+        globalThis.indexedDB = new IDBFactory()
+    })
+
+    afterEach(() => {
+        globalThis.indexedDB = sharedFactory
+    })
+
+    it("should restore a session saved before metric rules with no metric rules", async () => {
+        // Arrange
+        const v19Database = await openDB(DB_NAME, 19, {
+            upgrade(database) {
+                database.createObjectStore(CCSTATE_STORE_NAME, { keyPath: CCSTATE_PRIMARY_KEY })
+                database.createObjectStore(SCENARIOS_STORE_NAME, { keyPath: "id" })
+            }
+        })
+        const v19SharedView = { ...defaultSharedView }
+        delete (v19SharedView as { metricRules?: unknown }).metricRules
+        await v19Database.put(CCSTATE_STORE_NAME, {
+            [CCSTATE_PRIMARY_KEY]: CCSTATE_STATE_ID,
+            state: { ...defaultState, sharedView: v19SharedView }
+        })
+        v19Database.close()
+
+        // Act
+        const migratedState = await readCcState()
+
+        // Assert
+        expect(migratedState.sharedView.metricRules).toEqual([])
     })
 })
 

--- a/visualization/app/codeCharta/stores/rootStore/indexedDB/indexedDBWriter.ts
+++ b/visualization/app/codeCharta/stores/rootStore/indexedDB/indexedDBWriter.ts
@@ -9,7 +9,7 @@ import { defaultPreferences, defaultSorting } from "../../preferences/preference
 import { defaultSharedView } from "../../sharedView/sharedView.read.facade"
 
 export const DB_NAME = "CodeCharta"
-export const DB_VERSION = 19
+export const DB_VERSION = 20
 export const CCSTATE_STORE_NAME = "ccstate"
 export const SCENARIOS_STORE_NAME = "scenarios"
 export const CCSTATE_PRIMARY_KEY = "id"
@@ -442,6 +442,19 @@ function withSeededDomainWords(fileState: unknown): unknown {
     }
 }
 
+// v20: a sharedView persisted before metric rules carries no metricRules
+export function migrateCcStateRecordToV20<T>(state: T): T {
+    if (!state || typeof state !== "object") {
+        return state
+    }
+    const record = state as Record<string, unknown>
+    const sharedView = record["sharedView"]
+    if (!sharedView || typeof sharedView !== "object" || "metricRules" in sharedView) {
+        return state
+    }
+    return { ...record, sharedView: { ...sharedView, metricRules: defaultSharedView.metricRules } } as T
+}
+
 export async function writeCcState(state: CcState) {
     const database = await openCodeChartaDB()
     // Strict durability: the default (relaxed) reports success before the data reaches disk, so a
@@ -486,7 +499,8 @@ const CCSTATE_RECORD_MIGRATIONS: ReadonlyArray<{ version: number; migrate: (stat
     { version: 16, migrate: migrateCcStateRecordToV16 },
     { version: 17, migrate: migrateCcStateRecordToV17 },
     { version: 18, migrate: migrateCcStateRecordToV18 },
-    { version: 19, migrate: migrateCcStateRecordToV19 }
+    { version: 19, migrate: migrateCcStateRecordToV19 },
+    { version: 20, migrate: migrateCcStateRecordToV20 }
 ]
 
 function migrateCcStateRecord(state: unknown, oldVersion: number): unknown {


### PR DESCRIPTION
A session saved by a version without metric rules has no metricRules in its shared view, so loading it reported the key as "not restored" even though there was nothing to restore. A v20 migration seeds the empty default, so an upgrade restores silently.


Claude-Session: https://claude.ai/code/session_016E8E4rf64qfEtznEEFJobW

# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing saved visualization states now correctly receive default metric rules when those rules are missing.
  * Saved states from the previous database version are upgraded automatically while preserving any existing metric rules.

* **Tests**
  * Added coverage for database upgrades, default rule initialization, existing rules, and incomplete or empty saved states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->