### PR TITLE
Fix/metric rules count missing as zero

### DIFF
--- a/plans/2026-09-11-metric-rules-missing-as-zero.md
+++ b/plans/2026-09-11-metric-rules-missing-as-zero.md
@@ -1,0 +1,41 @@
+---
+name: Metric rules count a missing value as 0
+issue: none
+state: complete
+version: vis-2.3.0
+---
+
+## Goal
+
+A metric rule sees the same number the map shows: a file without a value for a metric that is on the
+map counts as 0, so `mcc < 1` also catches files that have no mcc.
+
+## Tasks
+
+### 1. One source for every count (refactor, behaviour-neutral)
+- The rules list counts from `metricValuesSelector` with `matchesMetricRule`, like the editor does
+
+### 2. Missing value = 0 for metrics on the map
+- `createMetricRuleMatcher(rules, metricsOnMap)`: absent value of a known metric evaluates as 0; a
+  metric no file has still matches nothing
+- `NodeDecorator.decorateMap` passes the `nodeMetricData` names; traversal order stays
+- `metricValuesSelector` emits one value per file for every metric, 0 where absent
+- Editor reads "N of M files"
+- Update stale comments, CHANGELOG entry under Changed
+
+## Steps
+
+- [x] Complete Task 1: One source for every count
+- [x] Complete Task 2: Missing value = 0 for metrics on the map
+- [x] Unit tests, e2e `clearRules.e2e.ts`, check in the running app
+
+## Notes
+
+- Decision (user): "like the map", no per-rule toggle — anything else is confusing
+- The views define "on the map" as "some file has the metric", the decorator as `nodeMetricData`
+  (files not excluded by path). They differ only when every file carrying a metric is excluded by
+  path; accepted
+- The histogram now shows a large 0 bucket for metrics many files lack — correct under this model
+- Verified on a fresh build (scratch copy with Linux `npm ci`; the repo's node_modules are darwin):
+  default samples, `pairingRate < 1` reads "4 of 8 files" (the sample2 files without it) and moves
+  the chips to Shown 4 / Flattened 4; sidebar explorer e2e green

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
+### Changed
+
+- **Metric rules include files without a value**: a file with no value for the rule's metric counts as 0, so `mcc < 1` also flattens or hides files that have no mcc, including in rules you saved earlier.
+
 ## [2.3.0] - 2026-09-10
 
 ### Added 🚀

--- a/visualization/app/codeCharta/features/sidebarExplorer/components/metricRuleEditor/metricRuleEditor.component.html
+++ b/visualization/app/codeCharta/features/sidebarExplorer/components/metricRuleEditor/metricRuleEditor.component.html
@@ -70,7 +70,7 @@
 
         <div class="mt-2 rounded-md bg-base-200 px-2 py-1.5 text-xs" data-testid="metric-rule-editor-match-count">
             <span class="font-semibold">{{ matchCount() }}</span>
-            of {{ fileCount() }} files with a {{ metric() }} value
+            of {{ fileCount() }} files
         </div>
 
         <div class="flex items-center gap-1.5 mt-2">

--- a/visualization/app/codeCharta/features/sidebarExplorer/components/metricRuleEditor/metricRuleEditor.component.spec.ts
+++ b/visualization/app/codeCharta/features/sidebarExplorer/components/metricRuleEditor/metricRuleEditor.component.spec.ts
@@ -176,7 +176,7 @@ describe("MetricRuleEditorComponent", () => {
         fixture.detectChanges()
 
         // Assert
-        expect(screen.getByTestId("metric-rule-editor-match-count").textContent).toContain("with a mcc value")
+        expect(screen.getByTestId("metric-rule-editor-match-count").textContent).toContain("of 5 files")
     })
 
     it("should add nothing when there is no metric to build a rule from", async () => {

--- a/visualization/app/codeCharta/util/metricRule/metricRuleMatcher.spec.ts
+++ b/visualization/app/codeCharta/util/metricRule/metricRuleMatcher.spec.ts
@@ -10,10 +10,14 @@ const flattenRule = (overrides: Partial<MetricRule> = {}): MetricRule => ({
     ...overrides
 })
 
+const METRICS_ON_MAP: ReadonlySet<string> = new Set(["mcc", "rloc"])
+
+const matcherFor = (rules: MetricRule[]) => createMetricRuleMatcher(rules, METRICS_ON_MAP)
+
 describe("createMetricRuleMatcher", () => {
     it("should match nothing when there are no rules", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([])
+        const matcher = matcherFor([])
 
         // Act
         const classification = matcher.classify({ mcc: 500 })
@@ -22,9 +26,20 @@ describe("createMetricRuleMatcher", () => {
         expect(classification).toEqual({ isFlattened: false, isExcluded: false })
     })
 
-    it("should not match a file that has no value for the metric", () => {
+    it("should read a missing value of a metric on the map as 0", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "lt", value: 10 })])
+        const matcher = matcherFor([flattenRule({ operator: "lt", value: 1 })])
+
+        // Act
+        const classification = matcher.classify({ rloc: 3 })
+
+        // Assert
+        expect(classification.isFlattened).toBe(true)
+    })
+
+    it("should not match a missing value when 0 is outside the condition", () => {
+        // Arrange
+        const matcher = matcherFor([flattenRule({ operator: "gt", value: 0 })])
 
         // Act
         const classification = matcher.classify({ rloc: 3 })
@@ -33,12 +48,23 @@ describe("createMetricRuleMatcher", () => {
         expect(classification.isFlattened).toBe(false)
     })
 
-    it("should not match a file that has no attributes at all", () => {
+    it("should read a file without any attributes as 0 for every metric on the map", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "lt", value: 10 })])
+        const matcher = matcherFor([flattenRule({ operator: "lt", value: 1 })])
 
         // Act
         const classification = matcher.classify(undefined)
+
+        // Assert
+        expect(classification.isFlattened).toBe(true)
+    })
+
+    it("should match no file for a metric the map does not have", () => {
+        // Arrange
+        const matcher = matcherFor([flattenRule({ metric: "coverage", operator: "lt", value: 1 })])
+
+        // Act
+        const classification = matcher.classify({ mcc: 0 })
 
         // Assert
         expect(classification.isFlattened).toBe(false)
@@ -46,7 +72,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should flatten a file above the threshold when the operator is greater than", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule()])
+        const matcher = matcherFor([flattenRule()])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 11 }).isFlattened).toBe(true)
@@ -55,7 +81,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should include the threshold itself when the operator is at least", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "gte" })])
+        const matcher = matcherFor([flattenRule({ operator: "gte" })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 10 }).isFlattened).toBe(true)
@@ -64,7 +90,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should flatten a file below the threshold when the operator is less than", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "lt" })])
+        const matcher = matcherFor([flattenRule({ operator: "lt" })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 9 }).isFlattened).toBe(true)
@@ -73,7 +99,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should include the threshold itself when the operator is at most", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "lte" })])
+        const matcher = matcherFor([flattenRule({ operator: "lte" })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 10 }).isFlattened).toBe(true)
@@ -82,7 +108,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should match only the exact value when the operator is equals", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "eq" })])
+        const matcher = matcherFor([flattenRule({ operator: "eq" })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 10 }).isFlattened).toBe(true)
@@ -91,7 +117,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should include both ends of the range when the operator is between", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "between", value: 5, upperValue: 20 })])
+        const matcher = matcherFor([flattenRule({ operator: "between", value: 5, upperValue: 20 })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 5 }).isFlattened).toBe(true)
@@ -102,7 +128,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should match a between range whose bounds were entered the wrong way round", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "between", value: 20, upperValue: 5 })])
+        const matcher = matcherFor([flattenRule({ operator: "between", value: 20, upperValue: 5 })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 7 }).isFlattened).toBe(true)
@@ -110,7 +136,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should match nothing for a between rule that is missing its upper bound", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "between", value: 5 })])
+        const matcher = matcherFor([flattenRule({ operator: "between", value: 5 })])
 
         // Act & Assert
         expect(matcher.classify({ mcc: 5 }).isFlattened).toBe(false)
@@ -118,7 +144,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should report an exclude rule as excluded rather than flattened", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ type: "exclude" })])
+        const matcher = matcherFor([flattenRule({ type: "exclude" })])
 
         // Act
         const classification = matcher.classify({ mcc: 11 })
@@ -129,7 +155,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should apply every rule, so a file matched by any of them is affected", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([
+        const matcher = matcherFor([
             flattenRule({ id: "a", metric: "mcc", operator: "gt", value: 100 }),
             flattenRule({ id: "b", metric: "rloc", operator: "lt", value: 5, type: "exclude" })
         ])
@@ -143,7 +169,7 @@ describe("createMetricRuleMatcher", () => {
 
     it("should ignore a non-numeric value so a broken attribute cannot hide a file", () => {
         // Arrange
-        const matcher = createMetricRuleMatcher([flattenRule({ operator: "lt", value: 10 })])
+        const matcher = matcherFor([flattenRule({ operator: "lt", value: 10 })])
 
         // Act
         const classification = matcher.classify({ mcc: Number.NaN })

--- a/visualization/app/codeCharta/util/metricRule/metricRuleMatcher.ts
+++ b/visualization/app/codeCharta/util/metricRule/metricRuleMatcher.ts
@@ -15,25 +15,19 @@ export interface MetricRuleMatcher {
 
 const NOTHING_MATCHED: MetricRuleClassification = { isFlattened: false, isExcluded: false }
 
-/**
- * Evaluates metric rules against one file's attributes. A file with no value for a rule's metric is
- * never matched: the decorator runs this before missing metrics are defaulted to 0, so "no data"
- * cannot be read as "zero" and quietly hide a whole language's files.
- */
-export function createMetricRuleMatcher(rules: MetricRule[]): MetricRuleMatcher {
+/** A file without a value for a metric on the map is read as 0, the value the map shows for it. */
+export function createMetricRuleMatcher(rules: MetricRule[], metricsOnMap: ReadonlySet<string>): MetricRuleMatcher {
     if (rules.length === 0) {
         return { classify: () => NOTHING_MATCHED }
     }
 
     return {
         classify: attributes => {
-            if (attributes === undefined) {
-                return NOTHING_MATCHED
-            }
             let isFlattened = false
             let isExcluded = false
             for (const rule of rules) {
-                if (!matchesMetricRule(rule, attributes[rule.metric])) {
+                const value = metricsOnMap.has(rule.metric) ? (attributes?.[rule.metric] ?? 0) : undefined
+                if (!matchesMetricRule(rule, value)) {
                     continue
                 }
                 if (rule.type === "flatten") {

--- a/visualization/app/codeCharta/util/nodeDecorator.spec.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.spec.ts
@@ -91,7 +91,21 @@ describe("nodeDecorator", () => {
             }
         })
 
-        it("should not match a file that has no value for the metric", () => {
+        it("should match a file without a value for a metric on the map as if it were 0", () => {
+            // Arrange
+            const fileWithoutMcc = leavesOf(map)[0]
+            delete fileWithoutMcc.attributes.mcc
+            const rules = [{ id: "r1", metric: "mcc", operator: "lt" as const, value: 1, type: "flatten" as const }]
+
+            // Act
+            NodeDecorator.decorateMap(map, metricData, [], rules)
+
+            // Assert
+            expect(fileWithoutMcc.isFlattened).toBe(true)
+            expect(fileWithoutMcc.attributes.mcc).toBe(0)
+        })
+
+        it("should match no file for a metric the map does not have", () => {
             // Arrange
             const rules = [{ id: "r1", metric: "notInAnyFile", operator: "lt" as const, value: 10, type: "flatten" as const }]
 

--- a/visualization/app/codeCharta/util/nodeDecorator.ts
+++ b/visualization/app/codeCharta/util/nodeDecorator.ts
@@ -27,9 +27,8 @@ export const NodeDecorator = {
         metricRules: MetricRule[] = []
     ) {
         const matcher = createBlacklistMatcher(blacklist)
-        // Runs before decorateMapWithMetricData defaults absent metrics to 0, so a file with no
-        // value for a rule's metric is still recognisably without one and stays unmatched.
-        const metricRuleMatcher = createMetricRuleMatcher(metricRules)
+        const metricsOnMap = new Set(metricData.nodeMetricData.map(({ name }) => name))
+        const metricRuleMatcher = createMetricRuleMatcher(metricRules, metricsOnMap)
         for (const { data } of hierarchy(map)) {
             const isLeafNode = isLeaf(data)
             const { isFlattened, isExcluded } = matcher.classify(data.path, isLeafNode)

--- a/visualization/app/codeCharta/views/metricsView/explorer/metricRuleLeaves.selector.ts
+++ b/visualization/app/codeCharta/views/metricsView/explorer/metricRuleLeaves.selector.ts
@@ -4,11 +4,6 @@ import { structureTreeSelector } from "../../../lenses/structure/structure.facad
 import { CodeMapNode } from "../../../model/codeCharta.model"
 import { isLeaf } from "../../../util/codeMapHelper"
 
-/**
- * The files as they came out of the cc.json, before NodeDecorator defaults absent metrics to 0.
- * Metric rules are evaluated at that same point, so every count and distribution shown in the UI
- * has to be read from here — decorated leaves can no longer tell "has no mcc" from "mcc is 0".
- */
 export const metricRuleLeavesSelector = createSelector(structureTreeSelector, structureTree => {
     if (!structureTree?.map) {
         return [] as CodeMapNode[]

--- a/visualization/app/codeCharta/views/metricsView/explorer/metricRulesWithCount.selector.spec.ts
+++ b/visualization/app/codeCharta/views/metricsView/explorer/metricRulesWithCount.selector.spec.ts
@@ -1,12 +1,6 @@
-import { CodeMapNode, MetricRule, NodeType } from "../../../model/codeCharta.model"
+import { MetricValues } from "../../../features/sidebarExplorer/facade"
+import { MetricRule } from "../../../model/codeCharta.model"
 import { excludeMetricRulesWithCountSelector, flattenMetricRulesWithCountSelector } from "./metricRulesWithCount.selector"
-
-const leaf = (path: string, attributes: Record<string, number>): CodeMapNode => ({
-    name: path.split("/").pop() ?? path,
-    path,
-    type: NodeType.FILE,
-    attributes
-})
 
 const rule = (overrides: Partial<MetricRule> = {}): MetricRule => ({
     id: "rule-1",
@@ -17,17 +11,15 @@ const rule = (overrides: Partial<MetricRule> = {}): MetricRule => ({
     ...overrides
 })
 
-const leaves: CodeMapNode[] = [
-    leaf("/root/a.ts", { mcc: 30 }),
-    leaf("/root/b.ts", { mcc: 11 }),
-    leaf("/root/c.ts", { mcc: 4 }),
-    leaf("/root/d.ts", { rloc: 200 })
-]
+const metricValues: MetricValues = new Map([
+    ["mcc", [30, 11, 4]],
+    ["rloc", [200]]
+])
 
 describe("metricRulesWithCount.selector", () => {
     it("should count the files a flatten rule matches", () => {
         // Arrange & Act
-        const result = flattenMetricRulesWithCountSelector.projector([rule()], leaves)
+        const result = flattenMetricRulesWithCountSelector.projector([rule()], metricValues)
 
         // Assert
         expect(result).toHaveLength(1)
@@ -36,19 +28,22 @@ describe("metricRulesWithCount.selector", () => {
 
     it("should label a rule by what it removes", () => {
         // Arrange & Act
-        const result = flattenMetricRulesWithCountSelector.projector([rule()], leaves)
+        const result = flattenMetricRulesWithCountSelector.projector([rule()], metricValues)
 
         // Assert
         expect(result[0].label).toBe("mcc > 10")
         expect(result[0].kind).toBe("METRIC")
     })
 
-    it("should not count a file that has no value for the metric", () => {
+    it("should count nothing for a metric no file has", () => {
         // Arrange & Act
-        const result = flattenMetricRulesWithCountSelector.projector([rule({ operator: "lt", value: 100 })], leaves)
+        const result = flattenMetricRulesWithCountSelector.projector(
+            [rule({ metric: "coverage", operator: "lt", value: 100 })],
+            metricValues
+        )
 
-        // Assert — d.ts has no mcc at all and must stay out of the count
-        expect(result[0].affectedCount).toBe(3)
+        // Assert
+        expect(result[0].affectedCount).toBe(0)
     })
 
     it("should keep flatten and exclude rules in their own lists", () => {
@@ -56,8 +51,8 @@ describe("metricRulesWithCount.selector", () => {
         const rules = [rule({ id: "f" }), rule({ id: "e", type: "exclude" })]
 
         // Act & Assert
-        expect(flattenMetricRulesWithCountSelector.projector(rules, leaves).map(entry => entry.id)).toEqual(["f"])
-        expect(excludeMetricRulesWithCountSelector.projector(rules, leaves).map(entry => entry.id)).toEqual(["e"])
+        expect(flattenMetricRulesWithCountSelector.projector(rules, metricValues).map(entry => entry.id)).toEqual(["f"])
+        expect(excludeMetricRulesWithCountSelector.projector(rules, metricValues).map(entry => entry.id)).toEqual(["e"])
     })
 
     it("should count each of several active rules on its own", () => {
@@ -65,7 +60,7 @@ describe("metricRulesWithCount.selector", () => {
         const rules = [rule({ id: "a", operator: "gt", value: 10 }), rule({ id: "b", operator: "lt", value: 5 })]
 
         // Act
-        const result = flattenMetricRulesWithCountSelector.projector(rules, leaves)
+        const result = flattenMetricRulesWithCountSelector.projector(rules, metricValues)
 
         // Assert
         expect(result.map(entry => entry.affectedCount)).toEqual([2, 1])

--- a/visualization/app/codeCharta/views/metricsView/explorer/metricRulesWithCount.selector.ts
+++ b/visualization/app/codeCharta/views/metricsView/explorer/metricRulesWithCount.selector.ts
@@ -1,38 +1,29 @@
 import { createSelector } from "@ngrx/store"
-import { RuleWithCount } from "../../../features/sidebarExplorer/facade"
-import { BlacklistType, CodeMapNode, MetricRule } from "../../../model/codeCharta.model"
+import { MetricValues, RuleWithCount } from "../../../features/sidebarExplorer/facade"
+import { BlacklistType, MetricRule } from "../../../model/codeCharta.model"
 import { metricRulesSelector } from "../../../stores/sharedView/sharedView.read.facade"
 import { describeMetricRule } from "../../../util/metricRule/describeMetricRule"
-import { createMetricRuleMatcher } from "../../../util/metricRule/metricRuleMatcher"
-import { metricRuleLeavesSelector } from "./metricRuleLeaves.selector"
+import { matchesMetricRule } from "../../../util/metricRule/metricRuleMatcher"
+import { metricValuesSelector } from "./metricValues.selector"
 
-const countFilesMatching = (rule: MetricRule, leaves: CodeMapNode[]): number => {
-    const matcher = createMetricRuleMatcher([rule])
-    let count = 0
-    for (const leaf of leaves) {
-        const { isFlattened, isExcluded } = matcher.classify(leaf.attributes)
-        if (isFlattened || isExcluded) {
-            count++
-        }
-    }
-    return count
-}
+const countFilesMatching = (rule: MetricRule, metricValues: MetricValues): number =>
+    (metricValues.get(rule.metric) ?? []).filter(value => matchesMetricRule(rule, value)).length
 
-const buildMetricRulesWithCount = (rules: MetricRule[], leaves: CodeMapNode[], type: BlacklistType): RuleWithCount[] =>
+const buildMetricRulesWithCount = (rules: MetricRule[], metricValues: MetricValues, type: BlacklistType): RuleWithCount[] =>
     rules
         .filter(rule => rule.type === type)
         .map(rule => ({
             id: rule.id,
             label: describeMetricRule(rule),
-            affectedCount: countFilesMatching(rule, leaves),
+            affectedCount: countFilesMatching(rule, metricValues),
             kind: "METRIC" as const,
             metricRule: rule
         }))
 
-export const flattenMetricRulesWithCountSelector = createSelector(metricRulesSelector, metricRuleLeavesSelector, (rules, leaves) =>
-    buildMetricRulesWithCount(rules, leaves, "flatten")
+export const flattenMetricRulesWithCountSelector = createSelector(metricRulesSelector, metricValuesSelector, (rules, metricValues) =>
+    buildMetricRulesWithCount(rules, metricValues, "flatten")
 )
 
-export const excludeMetricRulesWithCountSelector = createSelector(metricRulesSelector, metricRuleLeavesSelector, (rules, leaves) =>
-    buildMetricRulesWithCount(rules, leaves, "exclude")
+export const excludeMetricRulesWithCountSelector = createSelector(metricRulesSelector, metricValuesSelector, (rules, metricValues) =>
+    buildMetricRulesWithCount(rules, metricValues, "exclude")
 )

--- a/visualization/app/codeCharta/views/metricsView/explorer/metricValues.selector.spec.ts
+++ b/visualization/app/codeCharta/views/metricsView/explorer/metricValues.selector.spec.ts
@@ -19,7 +19,7 @@ describe("metricValuesSelector", () => {
 
         // Assert
         expect(values.get("mcc")).toEqual([3, 9])
-        expect(values.get("rloc")).toEqual([40])
+        expect(values.get("rloc")).toEqual([40, 0])
     })
 
     it("should leave out the synthetic unary metric", () => {
@@ -33,7 +33,7 @@ describe("metricValuesSelector", () => {
         expect(values.has(UNARY_METRIC)).toBe(false)
     })
 
-    it("should contribute nothing for a file without a value", () => {
+    it("should count a file without a value as 0, the way the map shows it", () => {
         // Arrange
         const leaves = [leaf("a.ts", { mcc: 3 }), leaf("b.ts", { rloc: 1 })]
 
@@ -41,7 +41,8 @@ describe("metricValuesSelector", () => {
         const values = metricValuesSelector.projector(leaves)
 
         // Assert
-        expect(values.get("mcc")).toEqual([3])
+        expect(values.get("mcc")).toEqual([3, 0])
+        expect(values.get("rloc")).toEqual([0, 1])
     })
 
     it("should ignore a broken attribute value", () => {

--- a/visualization/app/codeCharta/views/metricsView/explorer/metricValues.selector.ts
+++ b/visualization/app/codeCharta/views/metricsView/explorer/metricValues.selector.ts
@@ -1,23 +1,30 @@
 import { createSelector } from "@ngrx/store"
 import { MetricValues } from "../../../features/sidebarExplorer/facade"
+import { CodeMapNode } from "../../../model/codeCharta.model"
 import { UNARY_METRIC } from "../../../util/metric/unaryMetric"
 import { metricRuleLeavesSelector } from "./metricRuleLeaves.selector"
 
+/** One value per file for every metric some file has, 0 where a file has none — as the map shows it. */
 export const metricValuesSelector = createSelector(metricRuleLeavesSelector, (leaves): MetricValues => {
     const valuesByMetric = new Map<string, number[]>()
-    for (const leaf of leaves) {
-        for (const [metric, value] of Object.entries(leaf.attributes ?? {})) {
-            // Every file is one unary, so a rule on it can only match all or nothing.
-            if (metric === UNARY_METRIC || typeof value !== "number" || Number.isNaN(value)) {
-                continue
-            }
-            const values = valuesByMetric.get(metric)
-            if (values === undefined) {
-                valuesByMetric.set(metric, [value])
-            } else {
-                values.push(value)
-            }
-        }
+    for (const metric of metricsOfLeaves(leaves)) {
+        valuesByMetric.set(
+            metric,
+            leaves.map(leaf => leaf.attributes?.[metric] ?? 0).filter(value => typeof value === "number" && !Number.isNaN(value))
+        )
     }
     return valuesByMetric
 })
+
+function metricsOfLeaves(leaves: CodeMapNode[]): Set<string> {
+    const metrics = new Set<string>()
+    for (const leaf of leaves) {
+        for (const metric of Object.keys(leaf.attributes ?? {})) {
+            // Every file is one unary, so a rule on it can only match all or nothing.
+            if (metric !== UNARY_METRIC) {
+                metrics.add(metric)
+            }
+        }
+    }
+    return metrics
+}


### PR DESCRIPTION
# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Metric rules now treat missing values as `0` when the metric exists on the map. For example, `mcc < 1` can now include files without an `mcc` value.
  - This behavior also applies to previously saved rules.
  - Metric rule counts now consistently reflect matching files, including files with missing metric values.
  - The rule editor displays matching file counts in a simplified format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->