### PR TITLE
Fix/flattening and loading overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,24 @@ Each state slice has dedicated actions, reducers, and selectors. Effects (`state
 
 Example: `feat(visualization): add dark mode toggle (#123)`
 
+### Checks Before Committing
+
+Run the whole set before every commit and before every push, not only the tests. CI fails on each of
+the first three, and none of them covers another:
+
+```bash
+# repo root: Biome formatting AND lint rules for the whole repo (`biome format` skips the lint rules)
+npm run format:check
+
+# visualization/
+npm test                            # unit tests with the coverage gate
+npm run lint                        # dependency-cruiser, component styles, knip
+npx tsc --noEmit -p tsconfig.json   # neither Jest nor the build type-checks spec files
+
+# analysis/, when Kotlin changed
+./gradlew ktlintCheck test
+```
+
 ### Pull Requests
 
 - Name PR like branch name

--- a/plans/flattened-buildings-stay-flat.md
+++ b/plans/flattened-buildings-stay-flat.md
@@ -1,0 +1,39 @@
+---
+name: Flattened buildings stay flat
+issue: -
+state: complete
+version: -
+---
+
+## Goal
+
+A flattened building always renders at the minimum building height, whatever the height metric, its maximum, or
+height inversion. Today it is drawn as if its height metric were 2, so it grows with the height scale and ignores
+inversion. Delta rendering stays as it is.
+
+## Tasks
+
+### 1. Tests first
+- Treemap: a flattened leaf is `MIN_BUILDING_HEIGHT` tall with a large height scale, also when inverted
+- Treemap: a flattened leaf keeps its height delta
+- Street layout: a flattened leaf is `MIN_BUILDING_HEIGHT` tall with a large height scale
+
+### 2. Height of a flattened leaf
+- `getHeightValue` stops special-casing flattened nodes
+- Treemap and street `buildNodeFrom` use `MIN_BUILDING_HEIGHT` for a flattened leaf instead of scaling a fake
+  metric value (treemap still multiplies by the map-size factor, like the floor of any other leaf)
+
+### 3. Changelog
+- Fixed entry in `visualization/CHANGELOG.md`
+
+## Steps
+
+- [x] Complete Task 1: Tests first
+- [x] Complete Task 2: Height of a flattened leaf
+- [x] Complete Task 3: Changelog
+
+## Notes
+
+- The flat branch has returned `MIN_BUILDING_HEIGHT` as a metric-space value since before 2020; no test pinned the
+  resulting height.
+- Delta mode keeps its behaviour: `heightDelta` of a flattened building is unchanged.

--- a/plans/flattening-keeps-layout.md
+++ b/plans/flattening-keeps-layout.md
@@ -1,0 +1,32 @@
+---
+name: Flattening keeps the layout
+issue: -
+state: complete
+version: -
+---
+
+## Goal
+
+Flattening or unflattening buildings changes only their height and colour. Today the map canvas shrinks with every
+flattened node, because the estimate of nodes per side counts flattened nodes as removed, so the whole layout shifts.
+
+## Tasks
+
+### 1. Tests first
+- Treemap and fixed-folder layouts give every node the same footprint with and without flattened leaves
+
+### 2. Count only excluded nodes
+- `getEstimatedNodesPerSide` subtracts excluded nodes only; flattened nodes keep their area and their place
+
+### 3. Changelog
+- Fixed entry in `visualization/CHANGELOG.md`
+
+## Steps
+
+- [x] Complete Task 1: Tests first
+- [x] Complete Task 2: Count only excluded nodes
+- [x] Complete Task 3: Changelog
+
+## Notes
+
+- Flattened nodes were counted since the 2020 split of `isBlacklisted` into `isExcluded`/`isFlattened` (`468158702`).

--- a/plans/single-flatten-spinner.md
+++ b/plans/single-flatten-spinner.md
@@ -1,0 +1,44 @@
+---
+name: Single flatten settles like a rule
+issue: -
+state: complete
+version: -
+---
+
+## Goal
+
+Flattening, unflattening or excluding a single path keeps the loading overlay up for at least 350 ms after the map
+has rendered, so it fades in; a metric rule clears it as soon as the map is drawn. Make path entries behave like
+rules.
+
+## Tasks
+
+### 1. Tests first
+- `LoadingIndicatorEffect`: a path-entry action no longer marks the views stale
+
+### 2. Stop marking views stale on path entries
+- Drop the blacklist actions from `markViewsStaleOnDataChange$`; every path-entry change already goes through
+  `dispatchAfterPaint`, whose flag the render clears
+- The domain view does not read path entries and cannot change them, so it needs no stale mark
+
+### 3. Verify in the browser
+- Right-click flatten: overlay never visible on the sample map
+
+### 4. Changelog
+- Extend the existing Fixed entry for the loading flash
+
+## Steps
+
+- [x] Complete Task 1: Tests first
+- [x] Complete Task 2: Stop marking views stale on path entries
+- [x] Complete Task 3: Verify in the browser
+- [x] Complete Task 4: Changelog
+
+## Notes
+
+- The removed test said "so the hidden view rebuilds on switch"; that still holds for file-set changes, not path
+  entries. Domain words come from `domainWordsSelector` (file data) and `viewIndependentTreeSelector`; neither reads
+  path entries. The domain view cannot create them (`showRules: false`, flatten/exclude inside
+  `@if (showMapActions)`), so the metrics view is never hidden when one changes.
+- Every dispatch of the path-entry actions goes through `dispatchAfterPaint`, directly or via an effect reacting to
+  an action that did (file-extension bar, search-pattern rules, empty-map guard).

--- a/plans/spinner-fade-in.md
+++ b/plans/spinner-fade-in.md
@@ -1,0 +1,44 @@
+---
+name: Fade the loading overlay in
+issue: -
+state: complete
+version: -
+---
+
+## Goal
+
+Adding or removing a metric rule flashes the full-screen loading overlay for a few frames, because
+`dispatchAfterPaint` shows it before every heavy dispatch and a fast render hides it again at once. Keep showing it
+first, but fade it in after a short delay, so quick changes finish before it becomes visible and slow ones still get
+it while the page is blocked.
+
+## Tasks
+
+### 1. Tests first
+- Component spec: loading → overlay visible with the delayed fade-in; not loading → hidden, no fade
+
+### 2. Delayed fade-in
+- `fade-in-delayed` animation in the Tailwind `@theme` (opacity only, so the compositor runs it while the main
+  thread is blocked)
+- Spinner template applies it while loading
+
+### 3. Verify in the browser
+- Fast change: overlay never reaches visible opacity; slow blocking change: overlay fades in during the block
+
+### 4. Changelog
+- Fixed entry in `visualization/CHANGELOG.md`
+
+## Steps
+
+- [x] Complete Task 1: Tests first
+- [x] Complete Task 2: Delayed fade-in
+- [x] Complete Task 3: Verify in the browser
+- [x] Complete Task 4: Changelog
+
+## Notes
+
+- Measured with a CDP screencast in headless Chromium (software WebGL) on the sample map, adding `rloc > 50`:
+  without the fade the overlay stays on screen ~180 ms (the frame that removes it waits for the map render);
+  with the fade no frame shows it. With a 2 s main-thread block the overlay fades in and stays up throughout,
+  so the compositor runs the animation while the page is blocked.
+- The 200 ms delay is the knob: renders that keep the overlay up longer show it, which is intended.

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - **Flattened buildings stay flat**: a flattened building always has the lowest building height, whatever the height metric and whether height is inverted.
 - **Flattening keeps the map in place**: flattening or unflattening buildings changes only their height and colour, and every building stays where it was.
+- **No loading flash on quick changes**: the loading overlay only appears when a change takes a moment, so adding or removing a rule no longer makes the map blink.
 
 ## [2.3.0] - 2026-09-10
 

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - **Metric rules include files without a value**: a file with no value for the rule's metric counts as 0, so `mcc < 1` also flattens or hides files that have no mcc, including in rules you saved earlier.
 
+### Fixed 🐞
+
+- **Flattened buildings stay flat**: a flattened building always has the lowest building height, whatever the height metric and whether height is inverted.
+
 ## [2.3.0] - 2026-09-10
 
 ### Added 🚀

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 ### Fixed 🐞
 
 - **Flattened buildings stay flat**: a flattened building always has the lowest building height, whatever the height metric and whether height is inverted.
+- **Flattening keeps the map in place**: flattening or unflattening buildings changes only their height and colour, and every building stays where it was.
 
 ## [2.3.0] - 2026-09-10
 

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [unreleased] (Added 🚀 | Changed | Removed  | Fixed 🐞 | Chore 👨‍💻 👩‍💻)
 
-## [2.3.1] - 2026-09-11
-
-### Changed
-
-- **Metric rules include files without a value**: a file with no value for the rule's metric counts as 0, so `mcc < 1` also flattens or hides files that have no mcc, including in rules you saved earlier.
-
 ### Fixed 🐞
 
 - **Flattened buildings stay flat**: a flattened building always has the lowest building height, whatever the height metric and whether height is inverted.
 - **Flattening keeps the map in place**: flattening or unflattening buildings changes only their height and colour, and every building stays where it was.
 - **No loading flash on quick changes**: the loading overlay only appears when a change takes a moment, so adding or removing a rule, or flattening or excluding a single building or file extension, no longer makes the map blink.
+
+## [2.3.1] - 2026-09-11
+
+### Changed
+
+- **Metric rules include files without a value**: a file with no value for the rule's metric counts as 0, so `mcc < 1` also flattens or hides files that have no mcc, including in rules you saved earlier.
 
 ## [2.3.0] - 2026-09-10
 

--- a/visualization/CHANGELOG.md
+++ b/visualization/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - **Flattened buildings stay flat**: a flattened building always has the lowest building height, whatever the height metric and whether height is inverted.
 - **Flattening keeps the map in place**: flattening or unflattening buildings changes only their height and colour, and every building stays where it was.
-- **No loading flash on quick changes**: the loading overlay only appears when a change takes a moment, so adding or removing a rule no longer makes the map blink.
+- **No loading flash on quick changes**: the loading overlay only appears when a change takes a moment, so adding or removing a rule, or flattening or excluding a single building or file extension, no longer makes the map blink.
 
 ## [2.3.0] - 2026-09-10
 

--- a/visualization/app/codeCharta/features/codeMap/effects/setLoadingIndicator/setLoadingIndicator.effect.spec.ts
+++ b/visualization/app/codeCharta/features/codeMap/effects/setLoadingIndicator/setLoadingIndicator.effect.spec.ts
@@ -117,8 +117,8 @@ describe("LoadingIndicatorEffect", () => {
         expect(viewReadinessStore.isStale("domain")).toBe(false)
     })
 
-    it("should mark every view stale when a node is excluded, so the hidden view rebuilds on switch", () => {
-        // Arrange
+    it("should not mark views stale when a path entry changes", () => {
+        // Arrange — only the metrics view can change path entries, and the domain view does not read them
         viewReadinessStore.markReady("metrics")
         viewReadinessStore.markReady("domain")
 
@@ -126,8 +126,8 @@ describe("LoadingIndicatorEffect", () => {
         actions$.next(addBlacklistItem({ item: { path: "/root/foo", type: "exclude" } }))
 
         // Assert
-        expect(viewReadinessStore.isStale("metrics")).toBe(true)
-        expect(viewReadinessStore.isStale("domain")).toBe(true)
+        expect(viewReadinessStore.isStale("metrics")).toBe(false)
+        expect(viewReadinessStore.isStale("domain")).toBe(false)
     })
 
     it("should mark the metrics view ready only after the render burst settles", async () => {

--- a/visualization/app/codeCharta/features/codeMap/effects/setLoadingIndicator/setLoadingIndicator.effect.ts
+++ b/visualization/app/codeCharta/features/codeMap/effects/setLoadingIndicator/setLoadingIndicator.effect.ts
@@ -5,12 +5,6 @@ import { debounceTime, filter, map, merge, skip, tap } from "rxjs"
 import { CcState } from "../../../../model/codeCharta.model"
 import { ViewReadinessStore } from "../../../../routing/viewReadiness.store"
 import { filesLoaded, setIsLoadingFile, visibleFileStatesSelector } from "../../../../stores/fileStore/fileStore.facade"
-import {
-    addBlacklistItem,
-    addBlacklistItems,
-    removeBlacklistItem,
-    removeBlacklistItems
-} from "../../../../stores/sharedView/sharedView.write.facade"
 import { RenderCodeMapEffect } from "../renderCodeMapEffect/renderCodeMap.effect"
 
 export const RENDER_QUIET_PERIOD_MS = 350
@@ -33,11 +27,7 @@ export class LoadingIndicatorEffect {
 
     markViewsStaleOnDataChange$ = createEffect(
         () =>
-            merge(
-                this.store.select(visibleFileStatesSelector).pipe(skip(1)),
-                this.actions$.pipe(ofType(filesLoaded)),
-                this.actions$.pipe(ofType(addBlacklistItem, addBlacklistItems, removeBlacklistItem, removeBlacklistItems))
-            ).pipe(
+            merge(this.store.select(visibleFileStatesSelector).pipe(skip(1)), this.actions$.pipe(ofType(filesLoaded))).pipe(
                 tap(() => {
                     this.viewReadinessStore.markAllStale()
                 })

--- a/visualization/app/codeCharta/features/scenarios/model/scenarioSettings.registry.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/model/scenarioSettings.registry.spec.ts
@@ -100,7 +100,7 @@ describe("scenario settings registry", () => {
         it("should patch the metric rules as a whole list", () => {
             // Arrange
             const metricRules: ScenarioSettings["metricRules"] = [
-                { id: "rule-1", metric: "mcc", operator: ">", value: 10, type: "flatten" }
+                { id: "rule-1", metric: "mcc", operator: "gt", value: 10, type: "flatten" }
             ]
 
             // Act

--- a/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.spec.ts
+++ b/visualization/app/codeCharta/features/scenarios/services/scenarioApplier.service.spec.ts
@@ -34,7 +34,7 @@ const testSettings: ScenarioSettings = {
     groupLabelCollisions: true,
     camera: { position: { x: 100, y: 200, z: 300 }, target: { x: 10, y: 0, z: 20 } },
     blacklist: [{ path: "/root/file.ts", type: "exclude" }],
-    metricRules: [{ id: "rule-1", metric: "mcc", operator: ">", value: 10, type: "flatten" }],
+    metricRules: [{ id: "rule-1", metric: "mcc", operator: "gt", value: 10, type: "flatten" }],
     focusedNodePath: ["/root/src"]
 }
 

--- a/visualization/app/codeCharta/features/shared/components/loadingFileProgressSpinner/loadingFileProgressSpinner.component.html
+++ b/visualization/app/codeCharta/features/shared/components/loadingFileProgressSpinner/loadingFileProgressSpinner.component.html
@@ -1,7 +1,9 @@
+@let isLoading = isLoadingStream() | async;
 <div
     id="loading-gif-file"
     class="fixed inset-x-0 bottom-0 top-[var(--cc-bars-height,49px)] z-[1000] bg-white/80 text-center"
-    [style.visibility]="(isLoadingStream() | async) ? 'visible' : 'hidden'"
+    [class.animate-fade-in-delayed]="isLoading"
+    [style.visibility]="isLoading ? 'visible' : 'hidden'"
 >
     <div class="mt-[22%] inline-block h-24 w-24 animate-spin rounded-full border-4 border-base-300 [border-top-color:var(--color-primary)]"></div>
 </div>

--- a/visualization/app/codeCharta/features/shared/components/loadingFileProgressSpinner/loadingFileProgressSpinner.component.spec.ts
+++ b/visualization/app/codeCharta/features/shared/components/loadingFileProgressSpinner/loadingFileProgressSpinner.component.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from "@angular/core/testing"
+import { render } from "@testing-library/angular"
+import { BehaviorSubject } from "rxjs"
+import { LoadingFileProgressSpinnerService } from "../../services/loadingFileProgressSpinner.service"
+import { LoadingFileProgressSpinnerComponent } from "./loadingFileProgressSpinner.component"
+
+const FADE_IN_CLASS = "animate-fade-in-delayed"
+
+describe("LoadingFileProgressSpinnerComponent", () => {
+    let isLoading$: BehaviorSubject<boolean>
+
+    beforeEach(() => {
+        isLoading$ = new BehaviorSubject(false)
+        TestBed.configureTestingModule({
+            providers: [{ provide: LoadingFileProgressSpinnerService, useValue: { isLoading$: () => isLoading$ } }]
+        })
+    })
+
+    async function renderOverlay() {
+        const { container } = await render(LoadingFileProgressSpinnerComponent, { componentInputs: { view: "metrics" } })
+        return container.querySelector<HTMLElement>("#loading-gif-file")
+    }
+
+    it("should fade the overlay in when loading", async () => {
+        // Arrange
+        isLoading$.next(true)
+
+        // Act
+        const overlay = await renderOverlay()
+
+        // Assert
+        expect(overlay.style.visibility).toBe("visible")
+        expect(overlay.classList).toContain(FADE_IN_CLASS)
+    })
+
+    it("should hide the overlay without a fade when not loading", async () => {
+        // Arrange
+        isLoading$.next(false)
+
+        // Act
+        const overlay = await renderOverlay()
+
+        // Assert
+        expect(overlay.style.visibility).toBe("hidden")
+        expect(overlay.classList).not.toContain(FADE_IN_CLASS)
+    })
+})

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/streetLayout/streetViewHelper.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/streetLayout/streetViewHelper.spec.ts
@@ -1,5 +1,14 @@
-import { CodeMapNode, NodeType } from "../../../../model/codeCharta.model"
+import { Vector2 } from "three"
+import { STATE } from "../../../../mocks/dataMocks"
+import { CcState, CodeMapNode, NodeType } from "../../../../model/codeCharta.model"
+import Rectangle from "../../../../model/rectangle"
+import { clone } from "../../../../util/clone"
+import { TreeMapHelper } from "../treeMapLayout/treeMapHelper"
 import { StreetViewHelper } from "./streetViewHelper"
+
+jest.mock("../../../renderModel/accumulatedData/metricData/selectedColorMetricData.selector", () => ({
+    selectedColorMetricDataSelector: () => ({ minValue: 0, maxValue: 100 })
+}))
 
 describe("StreetViewHelper", () => {
     let leafNode: CodeMapNode
@@ -41,6 +50,43 @@ describe("StreetViewHelper", () => {
         it("should not merge directory names", () => {
             const node = StreetViewHelper.mergeDirectories(innerNode, "rloc")
             expect(node.name).toBe(innerNode.name)
+        })
+    })
+
+    describe("buildNodeFrom", () => {
+        const largeHeightScale = 10
+        const maxHeight = 2000
+        let state: CcState
+
+        beforeEach(() => {
+            state = clone(STATE)
+            state.mapState.heightMetric = "rloc"
+            state.sharedView.focusedNodePath = []
+            leafNode.isFlattened = true
+            leafNode.rect = new Rectangle(new Vector2(0, 0), 10, 10)
+            leafNode.zOffset = 1
+        })
+
+        it("should build a flattened building at the minimum height whatever its height metric value", () => {
+            // Arrange
+            state.mapState.invertHeight = false
+
+            // Act
+            const node = StreetViewHelper.buildNodeFrom(leafNode, largeHeightScale, maxHeight, state, false)
+
+            // Assert
+            expect(node.height).toBe(TreeMapHelper.MIN_BUILDING_HEIGHT)
+        })
+
+        it("should build a flattened building at the minimum height when the height is inverted", () => {
+            // Arrange
+            state.mapState.invertHeight = true
+
+            // Act
+            const node = StreetViewHelper.buildNodeFrom(leafNode, largeHeightScale, maxHeight, state, false)
+
+            // Assert
+            expect(node.height).toBe(TreeMapHelper.MIN_BUILDING_HEIGHT)
         })
     })
 })

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/streetLayout/streetViewHelper.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/streetLayout/streetViewHelper.ts
@@ -39,10 +39,10 @@ function mergeDirectories(node: CodeMapNode, metricName: string): CodeMapNode {
 function buildNodeFrom(layoutNode: CodeMapNode, heightScale: number, maxHeight: number, state: CcState, isDeltaState: boolean): Node {
     const isNodeLeaf = !(layoutNode.children && layoutNode.children.length > 0)
     const flattened: boolean = isNodeFlat(layoutNode, state)
-    const heightValue: number = TreeMapHelper.getHeightValue(state, layoutNode, maxHeight, flattened)
-    const height = Math.abs(
-        isNodeLeaf ? Math.max(heightScale * heightValue, TreeMapHelper.MIN_BUILDING_HEIGHT) : TreeMapHelper.FOLDER_HEIGHT
-    )
+    const leafHeight = flattened
+        ? TreeMapHelper.MIN_BUILDING_HEIGHT
+        : Math.max(heightScale * TreeMapHelper.getHeightValue(state, layoutNode, maxHeight), TreeMapHelper.MIN_BUILDING_HEIGHT)
+    const height = isNodeLeaf ? leafHeight : TreeMapHelper.FOLDER_HEIGHT
 
     const length = layoutNode.rect.height
     const x0 = layoutNode.rect.topLeft.x

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.spec.ts
@@ -17,7 +17,7 @@ import { NodeDecorator } from "../../../../util/nodeDecorator"
 import * as SquarifiedLayoutGenerator from "./treeMapGenerator"
 
 function flattenLeaves(node: CodeMapNode) {
-    if (!node.children?.length) {
+    if (!node.children || node.children.length === 0) {
         node.isFlattened = true
         return
     }

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.spec.ts
@@ -16,6 +16,20 @@ import { getCCFile } from "../../../../stores/fileStore/fileStore.facade"
 import { NodeDecorator } from "../../../../util/nodeDecorator"
 import * as SquarifiedLayoutGenerator from "./treeMapGenerator"
 
+function flattenLeaves(node: CodeMapNode) {
+    if (!node.children?.length) {
+        node.isFlattened = true
+        return
+    }
+    for (const child of node.children) {
+        flattenLeaves(child)
+    }
+}
+
+function footprintsOf(nodes: Node[]) {
+    return nodes.map(({ path, x0, y0, width, length }) => ({ path, x0, y0, width, length }))
+}
+
 describe("treeMapGenerator", () => {
     let map: CodeMapNode
     let state: CcState
@@ -136,6 +150,31 @@ describe("treeMapGenerator", () => {
                 expect(nodesWithFloorLabel.width).not.toEqual(nodes[index].width)
             }
             expect(nodes).toMatchSnapshot()
+        })
+
+        it("should keep every footprint in place when buildings are flattened", () => {
+            // Arrange
+            const unflattenedNodes = SquarifiedLayoutGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
+            flattenLeaves(map)
+
+            // Act
+            const flattenedNodes = SquarifiedLayoutGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
+
+            // Assert
+            expect(footprintsOf(flattenedNodes)).toEqual(footprintsOf(unflattenedNodes))
+        })
+
+        it("should keep every footprint in place when buildings in fixed folders are flattened", () => {
+            // Arrange
+            map = klona(FIXED_FOLDERS_NESTED_MIXED_WITH_DYNAMIC_ONES_MAP_FILE.map)
+            const unflattenedNodes = SquarifiedLayoutGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
+            flattenLeaves(map)
+
+            // Act
+            const flattenedNodes = SquarifiedLayoutGenerator.createTreemapNodes(map, state, metricData, isDeltaState)
+
+            // Assert
+            expect(footprintsOf(flattenedNodes)).toEqual(footprintsOf(unflattenedNodes))
         })
     })
 

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapGenerator.ts
@@ -212,15 +212,15 @@ function getSquarifiedTreeMap(map: CodeMapNode, state: CcState, mapSizeResolutio
 
 function getEstimatedNodesPerSide(hierarchyNode: HierarchyNode<CodeMapNode>) {
     let totalNodes = 0
-    let blacklistedNodes = 0
+    let excludedNodes = 0
     hierarchyNode.each(({ data }) => {
-        if (data.isExcluded || data.isFlattened) {
-            blacklistedNodes++
+        if (data.isExcluded) {
+            excludedNodes++
         }
         totalNodes++
     })
 
-    return 2 * Math.sqrt(totalNodes - blacklistedNodes)
+    return 2 * Math.sqrt(totalNodes - excludedNodes)
 }
 
 function isOnlyVisibleInComparisonMap(node: CodeMapNode, mapState: MapState) {

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapHelper.spec.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapHelper.spec.ts
@@ -104,6 +104,47 @@ describe("TreeMapHelper", () => {
             expect(buildNode().heightDelta).toBe(-33)
         })
 
+        describe("flattened building", () => {
+            const largeHeightScale = 10
+
+            beforeEach(() => {
+                codeMapNode.isFlattened = true
+            })
+
+            it("should build a flattened building at the minimum height whatever its height metric value", () => {
+                // Arrange
+                state.mapState.invertHeight = false
+
+                // Act
+                const node = TreeMapHelper.buildNodeFrom(squaredNode, largeHeightScale, maxHeight, state, isDeltaState)
+
+                // Assert
+                expect(node.height).toBe(TreeMapHelper.MIN_BUILDING_HEIGHT)
+            })
+
+            it("should build a flattened building at the minimum height when the height is inverted", () => {
+                // Arrange
+                state.mapState.invertHeight = true
+
+                // Act
+                const node = TreeMapHelper.buildNodeFrom(squaredNode, largeHeightScale, maxHeight, state, isDeltaState)
+
+                // Assert
+                expect(node.height).toBe(TreeMapHelper.MIN_BUILDING_HEIGHT)
+            })
+
+            it("should keep the height delta of a flattened building", () => {
+                // Arrange
+                codeMapNode.deltas = { theHeight: 33 }
+
+                // Act
+                const node = TreeMapHelper.buildNodeFrom(squaredNode, largeHeightScale, maxHeight, state, true)
+
+                // Assert
+                expect(node.heightDelta).toBe(33 * largeHeightScale)
+            })
+        })
+
         it("should set lowest possible height caused by other visible edge pairs", () => {
             ;(edgesSelector as unknown as jest.Mock).mockReturnValue([
                 {

--- a/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapHelper.ts
+++ b/visualization/app/codeCharta/renderer/threeViewer/algorithm/treeMapLayout/treeMapHelper.ts
@@ -78,9 +78,11 @@ function buildNodeFrom(
     const { x0, x1, y0, y1, data } = squaredNode
     const isNodeLeaf = isLeaf(squaredNode)
     const flattened = isNodeFlat(data, state)
-    const heightValue = getHeightValue(state, data, maxHeight, flattened)
     const depth = data.path.split("/").length - 2
-    const height = isNodeLeaf ? resolveHeightValue(heightValue, heightScale, data, state) * mapSizeResolutionScaling : FOLDER_HEIGHT
+    const leafHeight = flattened
+        ? MIN_BUILDING_HEIGHT
+        : resolveHeightValue(getHeightValue(state, data, maxHeight), heightScale, data, state)
+    const height = isNodeLeaf ? leafHeight * mapSizeResolutionScaling : FOLDER_HEIGHT
     const width = x1 - x0
     const length = y1 - y0
     const z0 = squaredNode.depth * FOLDER_HEIGHT
@@ -114,12 +116,8 @@ function buildNodeFrom(
     }
 }
 
-function getHeightValue(state: CcState, squaredNode: CodeMapNode, maxHeight: number, flattened: boolean) {
+function getHeightValue(state: CcState, squaredNode: CodeMapNode, maxHeight: number) {
     const mapSizeResolutionScaling = getMapResolutionScaleFactor(state.files)
-
-    if (flattened) {
-        return MIN_BUILDING_HEIGHT
-    }
 
     let heightValue = squaredNode.attributes[state.mapState.heightMetric] || HEIGHT_VALUE_WHEN_METRIC_NOT_FOUND
     heightValue *= mapSizeResolutionScaling

--- a/visualization/app/tailwind.css
+++ b/visualization/app/tailwind.css
@@ -36,6 +36,19 @@
     --color-warning-content: #382800;
     --color-error: #f87272;
     --color-error-content: #470000;
+
+    /* The loading overlay is shown before every heavy dispatch; the delay lets quick ones finish before it becomes
+       visible. Opacity only, so the compositor keeps animating it while a slow one blocks the main thread. */
+    --animate-fade-in-delayed: fade-in 150ms ease-out 200ms both;
+
+    @keyframes fade-in {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
 }
 
 /* Layout constants shared between features and legacy SCSS */


### PR DESCRIPTION
# {Meaningful title}

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/codecharta/blob/main/dev_docs/CONTRIBUTING.md) before opening a PR.**_

Closes: #

## Description

**Descriptive pull request text**, answering:
  - What problem/issue are you fixing?
  - What does this PR implement and how?

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
- [ ] Changes have been manually tested
- [ ] All TODOs related to this PR have been closed
- [ ] There are automated tests for newly written code and bug fixes
- [ ] All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
- [ ] Documentation (GH-pages, analysis/visualization READMEs, parser READMEs, --help, etc.) has been updated (almost always necessary except for bug fixes)
- [ ] CHANGELOG.md has been updated

## Screenshots or gifs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flattened buildings now remain at minimum height, regardless of metric scaling or height inversion.
  * Flattening buildings preserves their positions and layout footprint, including within fixed-folder structures.
  * Loading overlays now fade in after a short delay, preventing flashes during quick updates.
  * Flatten, unflatten, and exclude actions now maintain the loading indicator during rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->